### PR TITLE
54-Ignore-CSS-for-Github-language-classification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.css linguist-detectable=false


### PR DESCRIPTION
Resolves #54 (or should resolve, the other option is to add `true` also to all other languages used in the .gitattributes file. This also may not work, as there was a note that it may not work retroactively.