### PR TITLE
Experimental homepage design mockups

### DIFF
--- a/mockups/01-terminal.html
+++ b/mockups/01-terminal.html
@@ -1,0 +1,231 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Terminal</title>
+    <style>
+      :root {
+        --bg: #0b0f0a;
+        --fg: #9cf59c;
+        --dim: #4a7a4a;
+        --accent: #c4ff5e;
+        --warn: #ffb86b;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+      }
+      body {
+        color: var(--fg);
+        font-family: ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace;
+        font-size: 15px;
+        line-height: 1.6;
+        min-height: 100vh;
+        background-image:
+          radial-gradient(
+            ellipse at center,
+            rgba(40, 80, 40, 0.3) 0%,
+            transparent 70%
+          ),
+          repeating-linear-gradient(
+            0deg,
+            rgba(0, 0, 0, 0.15) 0 1px,
+            transparent 1px 3px
+          );
+      }
+      a {
+        color: var(--accent);
+      }
+      .wrap {
+        max-width: 920px;
+        margin: 0 auto;
+        padding: 32px 20px 80px;
+      }
+      nav {
+        display: flex;
+        gap: 20px;
+        flex-wrap: wrap;
+        padding-bottom: 20px;
+        border-bottom: 1px dashed var(--dim);
+      }
+      nav a {
+        text-decoration: none;
+      }
+      nav a:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .brand {
+        color: var(--accent);
+        font-weight: 700;
+      }
+      h1 {
+        font-size: 28px;
+        margin: 40px 0 8px;
+        color: var(--accent);
+      }
+      h1::before {
+        content: "> ";
+      }
+      h2 {
+        font-size: 18px;
+        color: var(--accent);
+        margin: 40px 0 12px;
+      }
+      h2::before {
+        content: "## ";
+        color: var(--dim);
+      }
+      .prompt {
+        color: var(--dim);
+      }
+      .cursor {
+        display: inline-block;
+        width: 9px;
+        height: 16px;
+        background: var(--accent);
+        vertical-align: -2px;
+        animation: blink 1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .ascii {
+        color: var(--dim);
+        white-space: pre;
+        font-size: 12px;
+        margin: 20px 0 30px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 10px 18px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+        text-decoration: none;
+        margin-top: 16px;
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .cols {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 24px;
+        margin-top: 24px;
+      }
+      .card {
+        border: 1px solid var(--dim);
+        padding: 16px;
+      }
+      .card h3 {
+        margin: 0 0 8px;
+        color: var(--warn);
+        font-size: 15px;
+      }
+      .card h3::before {
+        content: "[*] ";
+      }
+      ul {
+        padding-left: 20px;
+      }
+      ul li::marker {
+        content: "» ";
+      }
+      code.tag {
+        color: var(--warn);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <nav>
+        <span class="brand">codeselfstudy:~$</span>
+        <a href="#">home</a><a href="#">events</a><a href="#">learn</a
+        ><a href="#">forum</a><a href="#">jobs</a><a href="#">puzzles</a
+        ><a href="#">tools</a><a href="#">about</a>
+      </nav>
+      <pre class="ascii">
+   ____          _        ____       _  __   ____  _             _
+  / ___|___   __| | ___  / ___|  ___| |/ _| / ___|| |_ _   _  __| |_   _
+ | |   / _ \ / _` |/ _ \ \___ \ / _ \ | |_  \___ \| __| | | |/ _` | | | |
+ | |__| (_) | (_| |  __/  ___) |  __/ |  _|  ___) | |_| |_| | (_| | |_| |
+  \____\___/ \__,_|\___| |____/ \___|_|_|   |____/ \__|\__,_|\__,_|\__, |
+                                                                   |___/
+</pre
+      >
+      <p class="prompt">
+        // a programming community in the san francisco bay area &mdash; est.
+        2014
+      </p>
+      <h1>hello, world.</h1>
+      <p>
+        Self-study computer programming in a community of like-minded people.
+        5,000+ programmers in Berkeley and the Bay Area. All languages, all
+        levels.<span class="cursor"></span>
+      </p>
+      <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+        >$ join --community</a
+      >
+
+      <h2>features</h2>
+      <div class="cols">
+        <div class="card">
+          <h3>community</h3>
+          <p>
+            Attend meetups. Get out of your room. Meet like-minded programmers.
+          </p>
+        </div>
+        <div class="card">
+          <h3>get help</h3>
+          <p>
+            Experienced members help beginners. Bring questions. Ask for study
+            plans.
+          </p>
+        </div>
+        <div class="card">
+          <h3>networking</h3>
+          <p>
+            Know people in the industry. Members have found jobs through
+            introductions here.
+          </p>
+        </div>
+      </div>
+
+      <h2>what we do</h2>
+      <ul>
+        <li>
+          Build a local community of friendly, highly-motivated programmers.
+        </li>
+        <li>Open to all languages, all levels, all types of programming.</li>
+        <li>Self study with mentorship from experienced members.</li>
+      </ul>
+      <p class="prompt">$ echo $LANGUAGES</p>
+      <p>
+        <code class="tag">python</code> <code class="tag">javascript</code>
+        <code class="tag">typescript</code> <code class="tag">go</code>
+        <code class="tag">rust</code> <code class="tag">haskell</code>
+        <code class="tag">clojure</code> <code class="tag">elixir</code>
+        <code class="tag">racket</code> <code class="tag">ruby</code>
+        <code class="tag">c++</code> <code class="tag">scala</code>
+        <code class="tag">sql</code> <code class="tag">...</code>
+      </p>
+
+      <h2>bootcamp supplement</h2>
+      <p>
+        Attend our meetings as a self-directed bootcamp supplement or
+        alternative. Experienced programmers offer mentorship on project-based
+        learning.
+      </p>
+      <p class="prompt">&mdash; end of transmission &mdash;</p>
+    </div>
+  </body>
+</html>

--- a/mockups/02-editorial.html
+++ b/mockups/02-editorial.html
@@ -1,0 +1,280 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Editorial</title>
+    <style>
+      :root {
+        --bg: #fbf8f1;
+        --ink: #1a1a1a;
+        --muted: #6b6358;
+        --rule: #d9d2c2;
+        --accent: #9a2a2a;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+        line-height: 1.55;
+      }
+      .masthead {
+        border-top: 6px double var(--ink);
+        border-bottom: 1px solid var(--ink);
+        padding: 10px 0;
+        text-align: center;
+        font-variant: small-caps;
+        letter-spacing: 0.08em;
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .wrap {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 0 32px;
+      }
+      .title {
+        text-align: center;
+        padding: 24px 0 16px;
+        border-bottom: 1px solid var(--ink);
+      }
+      .title .vol {
+        font-size: 12px;
+        letter-spacing: 0.2em;
+        color: var(--muted);
+        text-transform: uppercase;
+      }
+      h1.paper {
+        font-family: "Didot", "Bodoni 72", "Playfair Display", Georgia, serif;
+        font-size: clamp(48px, 7vw, 88px);
+        letter-spacing: -0.02em;
+        margin: 4px 0 4px;
+        font-weight: 900;
+      }
+      .tagline {
+        font-style: italic;
+        color: var(--muted);
+      }
+      nav {
+        display: flex;
+        justify-content: center;
+        gap: 28px;
+        padding: 12px 0;
+        border-bottom: 1px solid var(--ink);
+        flex-wrap: wrap;
+        font-variant: small-caps;
+        letter-spacing: 0.06em;
+        font-size: 14px;
+      }
+      nav a {
+        color: var(--ink);
+        text-decoration: none;
+      }
+      nav a:hover {
+        color: var(--accent);
+      }
+      .lede {
+        padding: 40px 0 24px;
+        display: grid;
+        grid-template-columns: 1.6fr 1fr;
+        gap: 40px;
+        border-bottom: 1px solid var(--rule);
+      }
+      .lede h2 {
+        font-family: "Didot", "Bodoni 72", "Playfair Display", Georgia, serif;
+        font-size: clamp(32px, 4vw, 52px);
+        line-height: 1.1;
+        margin: 0 0 12px;
+        letter-spacing: -0.01em;
+      }
+      .lede .kicker {
+        color: var(--accent);
+        font-variant: small-caps;
+        letter-spacing: 0.2em;
+        font-size: 13px;
+        margin-bottom: 8px;
+      }
+      .lede p {
+        font-size: 18px;
+      }
+      .lede p::first-letter {
+        font-family: "Didot", "Bodoni 72", Georgia, serif;
+        font-size: 62px;
+        float: left;
+        line-height: 0.9;
+        padding: 6px 8px 0 0;
+        color: var(--accent);
+      }
+      .aside {
+        border-left: 1px solid var(--rule);
+        padding-left: 24px;
+      }
+      .aside h3 {
+        margin: 0 0 6px;
+        font-variant: small-caps;
+        letter-spacing: 0.12em;
+        font-size: 13px;
+        color: var(--muted);
+      }
+      .aside p {
+        margin: 0 0 14px;
+      }
+      .cta {
+        display: inline-block;
+        margin-top: 8px;
+        border-bottom: 2px solid var(--accent);
+        color: var(--accent);
+        text-decoration: none;
+        padding: 2px 0;
+        font-variant: small-caps;
+        letter-spacing: 0.15em;
+      }
+      .cols {
+        padding: 40px 0;
+        column-count: 3;
+        column-gap: 32px;
+        column-rule: 1px solid var(--rule);
+      }
+      .cols h3 {
+        font-family: inherit;
+        margin: 0 0 8px;
+        font-size: 20px;
+        letter-spacing: -0.01em;
+      }
+      .cols p {
+        margin: 0 0 12px;
+      }
+      section.deep {
+        border-top: 1px solid var(--ink);
+        padding: 32px 0 64px;
+      }
+      section.deep h2 {
+        font-family: "Didot", "Bodoni 72", Georgia, serif;
+        font-size: 36px;
+        margin: 0 0 12px;
+      }
+      @media (max-width: 760px) {
+        .lede {
+          grid-template-columns: 1fr;
+        }
+        .cols {
+          column-count: 1;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="masthead">
+      Bay Area · Self-Directed Programmers · Since 2014
+    </div>
+    <div class="wrap">
+      <div class="title">
+        <div class="vol">
+          Vol. XII &middot; No. 7 &middot; Saturdays in Berkeley
+        </div>
+        <h1 class="paper">The Code Self Study</h1>
+        <div class="tagline">
+          &ldquo;Study together &mdash; build what you wish you knew.&rdquo;
+        </div>
+      </div>
+      <nav>
+        <a href="#">Home</a><a href="#">Events</a><a href="#">Learn</a
+        ><a href="#">Forum</a><a href="#">Jobs</a><a href="#">Puzzles</a
+        ><a href="#">Tools</a><a href="#">About</a>
+      </nav>
+
+      <article class="lede">
+        <div>
+          <div class="kicker">The Lead</div>
+          <h2>A friendly programming community, 5,000 strong.</h2>
+          <p>
+            We are a self-study computer-programming group based in Berkeley and
+            the San Francisco Bay Area. All languages and all levels of
+            experience are welcome. Bring a laptop, bring a question, and bring
+            yourself &mdash; the rest takes care of itself.
+          </p>
+          <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community &rarr;</a
+          >
+        </div>
+        <aside class="aside">
+          <h3>In This Issue</h3>
+          <p>
+            <strong>Events</strong> &mdash; upcoming meetups, both in-person and
+            online.
+          </p>
+          <p>
+            <strong>Puzzles</strong> &mdash; weekly programming challenges to
+            stretch your thinking.
+          </p>
+          <p>
+            <strong>Jobs</strong> &mdash; openings submitted by community
+            members.
+          </p>
+          <p>
+            <strong>Forum</strong> &mdash; ongoing study threads, reading
+            groups, projects.
+          </p>
+        </aside>
+      </article>
+
+      <div class="cols">
+        <div>
+          <h3>Community</h3>
+          <p>
+            Attend our meetups and get out of your room to meet like-minded
+            programmers. Conversations here outlast any single session.
+          </p>
+        </div>
+        <div>
+          <h3>Mentorship</h3>
+          <p>
+            Experienced members help beginners. Bring your programming
+            questions. Ask for help designing a study plan &mdash; the model is
+            self-study with guidance.
+          </p>
+        </div>
+        <div>
+          <h3>Networking</h3>
+          <p>
+            Knowing people in the industry makes finding work easier. Many
+            members have landed jobs through introductions made at the group.
+          </p>
+        </div>
+      </div>
+
+      <section class="deep">
+        <h2>What We Do</h2>
+        <p>
+          Dozens of meetups teach people to code. We approach it differently. We
+          are building a local community of friendly, creative, highly-motivated
+          programmers. We're open to every language, every level, and every
+          style of computer programming &mdash; from web work and systems to
+          languages people invent for fun.
+        </p>
+        <p>
+          Recent languages in the group include Python, JavaScript, TypeScript,
+          Go, Rust, WebAssembly, Java, Scheme, Racket, Haskell, Clojure, Common
+          Lisp, C, C++, C#, F#, Lua, Elixir, Erlang, Elm, PureScript, Ruby,
+          Scala, PHP, R, Julia, HTML/CSS, Octave, and SQL. If it's on a
+          computer, it's fair game.
+        </p>
+        <h2 style="margin-top: 28px">As a Bootcamp Supplement</h2>
+        <p>
+          Come as a self-directed bootcamp supplement or alternative.
+          Experienced programmers can offer mentorship on a project-based
+          approach. Ask in the forum, the chatroom, or at a meetup.
+        </p>
+      </section>
+    </div>
+  </body>
+</html>

--- a/mockups/03-brutalist.html
+++ b/mockups/03-brutalist.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Neo-brutalist</title>
+    <style>
+      :root {
+        --bg: #fef6e4;
+        --ink: #0a0a0a;
+        --pink: #ff6ab0;
+        --blue: #3a86ff;
+        --yellow: #ffd166;
+        --green: #06d6a0;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 600;
+        line-height: 1.45;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 24px;
+        border-bottom: 4px solid var(--ink);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 900;
+        font-size: 20px;
+        background: var(--ink);
+        color: var(--bg);
+        padding: 6px 10px;
+        border: 4px solid var(--ink);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 16px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        color: var(--ink);
+        padding: 4px 10px;
+        border: 3px solid var(--ink);
+        background: var(--bg);
+        transition: transform 0.1s;
+      }
+      nav a:hover {
+        background: var(--yellow);
+        transform: translate(-2px, -2px);
+        box-shadow: 4px 4px 0 var(--ink);
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 40px 24px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 24px;
+        align-items: stretch;
+      }
+      .hero > div {
+        border: 5px solid var(--ink);
+        box-shadow: 10px 10px 0 var(--ink);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--pink);
+      }
+      .hero .main h1 {
+        font-size: clamp(40px, 6vw, 88px);
+        line-height: 0.95;
+        margin: 0 0 16px;
+        font-weight: 900;
+        letter-spacing: -0.03em;
+      }
+      .hero .main p {
+        font-size: 18px;
+        margin: 0 0 20px;
+        max-width: 30ch;
+      }
+      .btn {
+        display: inline-block;
+        background: var(--ink);
+        color: var(--yellow);
+        padding: 14px 22px;
+        text-decoration: none;
+        font-weight: 900;
+        font-size: 18px;
+        border: 4px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--yellow);
+      }
+      .btn:hover {
+        transform: translate(-2px, -2px);
+        box-shadow: 10px 10px 0 var(--yellow);
+      }
+      .side {
+        background: var(--yellow);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .side h2 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        font-weight: 900;
+      }
+      .stat {
+        font-size: 72px;
+        font-weight: 900;
+        line-height: 1;
+        margin: 10px 0;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 48px;
+      }
+      .features > div {
+        border: 5px solid var(--ink);
+        padding: 24px;
+        box-shadow: 8px 8px 0 var(--ink);
+      }
+      .features > div:nth-child(1) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      .features > div:nth-child(2) {
+        background: var(--green);
+      }
+      .features > div:nth-child(3) {
+        background: var(--yellow);
+      }
+      .features h3 {
+        margin: 0 0 8px;
+        font-size: 28px;
+        font-weight: 900;
+      }
+      .features .num {
+        font-size: 64px;
+        font-weight: 900;
+        line-height: 1;
+        margin-bottom: 4px;
+      }
+      .big {
+        margin-top: 48px;
+        border: 5px solid var(--ink);
+        box-shadow: 12px 12px 0 var(--ink);
+        background: var(--bg);
+        padding: 32px;
+      }
+      .big h2 {
+        font-size: clamp(32px, 4vw, 56px);
+        margin: 0 0 12px;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+      .tag {
+        border: 3px solid var(--ink);
+        padding: 4px 10px;
+        background: var(--yellow);
+      }
+      .tag:nth-child(3n) {
+        background: var(--pink);
+      }
+      .tag:nth-child(3n + 1) {
+        background: var(--green);
+      }
+      .tag:nth-child(5n) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      footer {
+        padding: 32px 24px;
+        border-top: 5px solid var(--ink);
+        text-align: center;
+        font-weight: 900;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">CODE / SELF / STUDY</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the Community &rarr;</a
+          >
+        </div>
+        <div class="side">
+          <h2>Since 2014</h2>
+          <div class="stat">5,000+</div>
+          <p>programmers, all levels, all languages.</p>
+        </div>
+      </section>
+
+      <section class="features">
+        <div>
+          <div class="num">01</div>
+          <h3>Community</h3>
+          <p>
+            Get out of your room. Meet like-minded programmers who actually show
+            up.
+          </p>
+        </div>
+        <div>
+          <div class="num">02</div>
+          <h3>Get Help</h3>
+          <p>
+            Experienced members mentor beginners. Ask questions. Ask for a study
+            plan.
+          </p>
+        </div>
+        <div>
+          <div class="num">03</div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions and tips from the
+            group.
+          </p>
+        </div>
+      </section>
+
+      <section class="big">
+        <h2>All languages. All levels.</h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag">Python</span><span class="tag">JavaScript</span
+          ><span class="tag">TypeScript</span><span class="tag">Go</span
+          ><span class="tag">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag">SQL</span
+          ><span class="tag">&amp; more</span>
+        </div>
+      </section>
+    </div>
+    <footer>© Code Self Study &middot; Bay Area</footer>
+  </body>
+</html>

--- a/mockups/04-minimal.html
+++ b/mockups/04-minimal.html
@@ -1,0 +1,270 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Minimal</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --ink: #111111;
+        --muted: #6b6b6b;
+        --rule: #ececec;
+        --accent: #2b6cb0;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          "Inter",
+          -apple-system,
+          ui-sans-serif,
+          system-ui,
+          Segoe UI,
+          sans-serif;
+        line-height: 1.6;
+        font-size: 17px;
+        -webkit-font-smoothing: antialiased;
+      }
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 28px 40px;
+        border-bottom: 1px solid var(--rule);
+      }
+      nav .brand {
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      nav ul {
+        display: flex;
+        gap: 28px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      nav a {
+        color: var(--muted);
+        text-decoration: none;
+        font-size: 15px;
+      }
+      nav a:hover {
+        color: var(--ink);
+      }
+      .wrap {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 120px 32px 80px;
+      }
+      .eyebrow {
+        color: var(--accent);
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        margin-bottom: 20px;
+      }
+      h1 {
+        font-size: clamp(40px, 6vw, 64px);
+        line-height: 1.05;
+        letter-spacing: -0.03em;
+        margin: 0 0 24px;
+        font-weight: 600;
+      }
+      .lede {
+        color: var(--muted);
+        font-size: 20px;
+        max-width: 60ch;
+        margin: 0 0 40px;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background: var(--ink);
+        color: #fff;
+        padding: 14px 22px;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 500;
+        font-size: 15px;
+        transition: opacity 0.15s;
+      }
+      .cta:hover {
+        opacity: 0.85;
+      }
+      .cta .arrow {
+        transition: transform 0.2s;
+      }
+      .cta:hover .arrow {
+        transform: translateX(4px);
+      }
+      section {
+        padding: 72px 32px;
+        max-width: 960px;
+        margin: 0 auto;
+        border-top: 1px solid var(--rule);
+      }
+      section h2 {
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--muted);
+        font-weight: 500;
+        margin: 0 0 32px;
+      }
+      .three {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 48px;
+      }
+      .three h3 {
+        font-size: 20px;
+        letter-spacing: -0.01em;
+        margin: 0 0 8px;
+        font-weight: 600;
+      }
+      .three p {
+        color: var(--muted);
+        margin: 0;
+        font-size: 16px;
+      }
+      .prose {
+        max-width: 640px;
+      }
+      .prose h2 {
+        color: var(--ink);
+        text-transform: none;
+        letter-spacing: -0.02em;
+        font-size: 28px;
+        font-weight: 600;
+        margin: 0 0 16px;
+      }
+      .prose p {
+        color: var(--muted);
+      }
+      .lang {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px 14px;
+        font-size: 15px;
+        color: var(--muted);
+        margin-top: 16px;
+      }
+      .lang span {
+        position: relative;
+      }
+      .lang span + span::before {
+        content: "·";
+        margin-right: 14px;
+        color: var(--rule);
+      }
+      footer {
+        padding: 48px 40px;
+        border-top: 1px solid var(--rule);
+        color: var(--muted);
+        font-size: 14px;
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      @media (max-width: 720px) {
+        .three {
+          grid-template-columns: 1fr;
+          gap: 32px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="brand">Code Self Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+
+    <main class="wrap">
+      <div class="eyebrow">A Bay Area programming community</div>
+      <h1>Study programming, together.</h1>
+      <p class="lede">
+        We're 5,000 programmers in Berkeley and the San Francisco Bay Area
+        learning in public. All languages, all levels of experience, no
+        curriculum &mdash; just self-study with mentorship.
+      </p>
+      <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+        >Join the community <span class="arrow">→</span></a
+      >
+    </main>
+
+    <section>
+      <h2>Why people come</h2>
+      <div class="three">
+        <div>
+          <h3>Community</h3>
+          <p>
+            Show up, meet people who care about what you're working on, leave
+            less alone.
+          </p>
+        </div>
+        <div>
+          <h3>Mentorship</h3>
+          <p>
+            Experienced members help beginners. Bring a question, ask for a
+            study plan.
+          </p>
+        </div>
+        <div>
+          <h3>Networking</h3>
+          <p>
+            Many members have found jobs through introductions and tips from the
+            group.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="prose">
+      <h2>What we do</h2>
+      <p>
+        Dozens of groups teach people to code. We instead build a local
+        community of friendly, creative, highly-motivated programmers. We're
+        open to every language and every level. The format is self-study with
+        guidance from more experienced members.
+      </p>
+      <div class="lang">
+        <span>Python</span><span>JavaScript</span><span>TypeScript</span
+        ><span>Go</span><span>Rust</span><span>Haskell</span><span>Clojure</span
+        ><span>Elixir</span><span>Racket</span><span>Scala</span
+        ><span>Ruby</span><span>C++</span><span>SQL</span>
+      </div>
+    </section>
+
+    <section class="prose">
+      <h2>Bootcamp supplement</h2>
+      <p>
+        Come as a self-directed bootcamp supplement or alternative. Experienced
+        programmers can offer project-based mentorship &mdash; ask in the forum,
+        the chat, or at a meetup.
+      </p>
+    </section>
+
+    <footer>
+      <div>© Code Self Study</div>
+      <div>Berkeley, CA &middot; Since 2014</div>
+    </footer>
+  </body>
+</html>

--- a/mockups/05-dark-neon.html
+++ b/mockups/05-dark-neon.html
@@ -1,0 +1,352 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Dark Neon</title>
+    <style>
+      :root {
+        --bg: #07080d;
+        --fg: #e6ebf5;
+        --muted: #8892a6;
+        --border: rgba(255, 255, 255, 0.08);
+        --cyan: #22d3ee;
+        --pink: #f472b6;
+        --violet: #a78bfa;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "Inter",
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          sans-serif;
+        line-height: 1.55;
+        overflow-x: hidden;
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: -40vmax;
+        background:
+          radial-gradient(
+            circle at 20% 10%,
+            rgba(34, 211, 238, 0.18),
+            transparent 40%
+          ),
+          radial-gradient(
+            circle at 85% 15%,
+            rgba(244, 114, 182, 0.18),
+            transparent 40%
+          ),
+          radial-gradient(
+            circle at 50% 80%,
+            rgba(167, 139, 250, 0.18),
+            transparent 45%
+          );
+        z-index: -1;
+      }
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 22px 40px;
+        backdrop-filter: blur(10px);
+        background: rgba(7, 8, 13, 0.6);
+        border-bottom: 1px solid var(--border);
+        position: sticky;
+        top: 0;
+        z-index: 10;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+      .brand .dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--cyan);
+        box-shadow: 0 0 12px var(--cyan);
+      }
+      nav ul {
+        display: flex;
+        gap: 24px;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      nav a {
+        color: var(--muted);
+        text-decoration: none;
+        font-size: 14px;
+      }
+      nav a:hover {
+        color: var(--fg);
+      }
+      .hero {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 96px 32px 64px;
+        text-align: center;
+      }
+      .pill {
+        display: inline-block;
+        padding: 6px 14px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        font-size: 12px;
+        color: var(--muted);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        background: rgba(255, 255, 255, 0.02);
+      }
+      .pill span {
+        color: var(--cyan);
+      }
+      h1 {
+        font-size: clamp(44px, 7vw, 92px);
+        line-height: 1;
+        letter-spacing: -0.03em;
+        margin: 28px 0 20px;
+        font-weight: 800;
+        background: linear-gradient(
+          90deg,
+          #fff 0%,
+          var(--cyan) 50%,
+          var(--pink) 100%
+        );
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+      }
+      .lede {
+        color: var(--muted);
+        font-size: 19px;
+        max-width: 64ch;
+        margin: 0 auto 36px;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        padding: 14px 26px;
+        background: linear-gradient(90deg, var(--cyan), var(--violet));
+        color: #07080d;
+        font-weight: 700;
+        border-radius: 999px;
+        text-decoration: none;
+        box-shadow: 0 10px 40px -10px rgba(34, 211, 238, 0.6);
+      }
+      .cta:hover {
+        transform: translateY(-1px);
+      }
+      .cta-ghost {
+        margin-left: 8px;
+        color: var(--fg);
+        text-decoration: none;
+        padding: 14px 20px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        font-size: 14px;
+      }
+      .cards {
+        max-width: 1100px;
+        margin: 48px auto;
+        padding: 0 32px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+      }
+      .card {
+        background: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.04),
+          rgba(255, 255, 255, 0.02)
+        );
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 28px;
+        position: relative;
+        overflow: hidden;
+      }
+      .card::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(
+          circle at 0% 0%,
+          rgba(34, 211, 238, 0.12),
+          transparent 60%
+        );
+        pointer-events: none;
+      }
+      .card:nth-child(2)::before {
+        background: radial-gradient(
+          circle at 100% 0%,
+          rgba(244, 114, 182, 0.12),
+          transparent 60%
+        );
+      }
+      .card:nth-child(3)::before {
+        background: radial-gradient(
+          circle at 50% 100%,
+          rgba(167, 139, 250, 0.14),
+          transparent 60%
+        );
+      }
+      .card h3 {
+        margin: 10px 0 6px;
+        font-size: 22px;
+        letter-spacing: -0.01em;
+      }
+      .card p {
+        color: var(--muted);
+        margin: 0;
+      }
+      .glyph {
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+        background: rgba(34, 211, 238, 0.15);
+        display: grid;
+        place-items: center;
+        color: var(--cyan);
+        font-weight: 800;
+      }
+      .card:nth-child(2) .glyph {
+        background: rgba(244, 114, 182, 0.15);
+        color: var(--pink);
+      }
+      .card:nth-child(3) .glyph {
+        background: rgba(167, 139, 250, 0.15);
+        color: var(--violet);
+      }
+      section.long {
+        max-width: 760px;
+        margin: 64px auto;
+        padding: 0 32px;
+      }
+      section.long h2 {
+        font-size: 32px;
+        letter-spacing: -0.02em;
+        margin: 0 0 12px;
+      }
+      section.long p {
+        color: var(--muted);
+      }
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 16px;
+      }
+      .chip {
+        padding: 4px 10px;
+        font-size: 13px;
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.03);
+      }
+      footer {
+        border-top: 1px solid var(--border);
+        padding: 32px;
+        color: var(--muted);
+        text-align: center;
+        font-size: 14px;
+      }
+      @media (max-width: 820px) {
+        .cards {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="brand"><span class="dot"></span> Code Self Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+      </ul>
+    </nav>
+
+    <section class="hero">
+      <span class="pill"><span>●</span> 5,000+ Bay Area programmers</span>
+      <h1>Learn to code.<br />In the open.</h1>
+      <p class="lede">
+        A friendly programming community in Berkeley and the San Francisco Bay
+        Area. Self-study, with mentorship, in every language imaginable.
+      </p>
+      <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+        >Join the community →</a
+      >
+      <a class="cta-ghost" href="#">Browse events</a>
+    </section>
+
+    <section class="cards">
+      <div class="card">
+        <div class="glyph">◎</div>
+        <h3>Community</h3>
+        <p>
+          Get out of your room. Meet like-minded programmers who keep showing
+          up.
+        </p>
+      </div>
+      <div class="card">
+        <div class="glyph">✺</div>
+        <h3>Mentorship</h3>
+        <p>
+          Experienced members help beginners with questions, study plans, and
+          project reviews.
+        </p>
+      </div>
+      <div class="card">
+        <div class="glyph">⟁</div>
+        <h3>Networking</h3>
+        <p>
+          Members have found jobs through introductions and tips shared inside
+          the group.
+        </p>
+      </div>
+    </section>
+
+    <section class="long">
+      <h2>All languages, all levels.</h2>
+      <p>
+        Dozens of meetups teach you to code. We instead build a local community
+        of friendly, motivated programmers. We're open to every language and
+        every level. The format is self-study with mentorship.
+      </p>
+      <div class="chips">
+        <span class="chip">Python</span><span class="chip">TypeScript</span
+        ><span class="chip">Go</span><span class="chip">Rust</span
+        ><span class="chip">Haskell</span><span class="chip">Clojure</span
+        ><span class="chip">Elixir</span><span class="chip">Racket</span
+        ><span class="chip">Scala</span><span class="chip">Ruby</span
+        ><span class="chip">C++</span><span class="chip">SQL</span
+        ><span class="chip">+ more</span>
+      </div>
+    </section>
+
+    <footer>© Code Self Study &middot; Built by the community</footer>
+  </body>
+</html>

--- a/mockups/06-warm-community.html
+++ b/mockups/06-warm-community.html
@@ -1,0 +1,385 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Warm Community</title>
+    <style>
+      :root {
+        --bg: #fff8ef;
+        --cream: #fff1dc;
+        --ink: #2b2118;
+        --muted: #7a6a58;
+        --brand: #e0652a;
+        --brand-dark: #b84e1c;
+        --green: #3d7c47;
+        --blue: #2f6fb3;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "DM Sans", "Inter", ui-sans-serif, system-ui, sans-serif;
+        line-height: 1.6;
+      }
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 20px 32px;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .brand .mark {
+        width: 34px;
+        height: 34px;
+        border-radius: 10px;
+        background: var(--brand);
+        color: white;
+        display: grid;
+        place-items: center;
+        font-weight: 900;
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 24px;
+        margin: 0;
+        padding: 0;
+      }
+      nav a {
+        color: var(--ink);
+        text-decoration: none;
+        font-weight: 500;
+        font-size: 15px;
+      }
+      nav a:hover {
+        color: var(--brand);
+      }
+      .hero {
+        padding: 40px 32px 60px;
+        max-width: 1200px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: 40px;
+        align-items: center;
+      }
+      .hero h1 {
+        font-size: clamp(40px, 6vw, 72px);
+        line-height: 1.05;
+        letter-spacing: -0.025em;
+        margin: 12px 0 20px;
+        font-weight: 800;
+      }
+      .hero h1 em {
+        color: var(--brand);
+        font-style: normal;
+      }
+      .hero p {
+        color: var(--muted);
+        font-size: 19px;
+        max-width: 52ch;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        background: var(--brand);
+        color: white;
+        padding: 14px 24px;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 700;
+        margin-top: 20px;
+        transition: background 0.15s;
+      }
+      .cta:hover {
+        background: var(--brand-dark);
+      }
+      .ghost {
+        color: var(--ink);
+        margin-left: 6px;
+        text-decoration: none;
+        padding: 14px 18px;
+        font-weight: 600;
+      }
+      .ghost:hover {
+        text-decoration: underline;
+        text-decoration-color: var(--brand);
+        text-decoration-thickness: 2px;
+      }
+      .illo {
+        aspect-ratio: 1 / 1;
+        border-radius: 28px;
+        background: var(--cream);
+        position: relative;
+        overflow: hidden;
+        padding: 24px;
+      }
+      .blob {
+        position: absolute;
+        border-radius: 50%;
+        filter: blur(0);
+      }
+      .b1 {
+        width: 60%;
+        height: 60%;
+        background: var(--brand);
+        opacity: 0.9;
+        top: -10%;
+        left: -10%;
+      }
+      .b2 {
+        width: 45%;
+        height: 45%;
+        background: var(--green);
+        bottom: -8%;
+        right: 10%;
+      }
+      .b3 {
+        width: 30%;
+        height: 30%;
+        background: var(--blue);
+        top: 40%;
+        left: 45%;
+      }
+      .illo .face {
+        position: absolute;
+        width: 80px;
+        height: 80px;
+        border-radius: 50%;
+        border: 4px solid var(--ink);
+        background: var(--cream);
+      }
+      .f1 {
+        top: 18%;
+        left: 22%;
+      }
+      .f2 {
+        top: 55%;
+        right: 18%;
+      }
+      .f3 {
+        bottom: 18%;
+        left: 35%;
+      }
+      .face::before,
+      .face::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        background: var(--ink);
+        border-radius: 50%;
+        top: 28px;
+      }
+      .face::before {
+        left: 18px;
+      }
+      .face::after {
+        right: 18px;
+      }
+      .face .smile {
+        position: absolute;
+        bottom: 18px;
+        left: 22px;
+        width: 32px;
+        height: 14px;
+        border: 3px solid var(--ink);
+        border-top: none;
+        border-radius: 0 0 30px 30px;
+      }
+      section.feat {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 40px 32px 72px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+      }
+      .tile {
+        background: white;
+        border-radius: 20px;
+        padding: 28px;
+        border: 2px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--ink);
+      }
+      .tile:nth-child(2) {
+        background: var(--cream);
+      }
+      .tile h3 {
+        margin: 8px 0 8px;
+        font-size: 22px;
+        letter-spacing: -0.01em;
+      }
+      .tile p {
+        color: var(--muted);
+        margin: 0;
+      }
+      .emoji {
+        font-size: 36px;
+        width: 56px;
+        height: 56px;
+        border-radius: 16px;
+        display: grid;
+        place-items: center;
+        background: var(--bg);
+        border: 2px solid var(--ink);
+      }
+      .t1 .emoji {
+        background: #ffe2c7;
+      }
+      .t2 .emoji {
+        background: #e1f0d7;
+      }
+      .t3 .emoji {
+        background: #d9e8f5;
+      }
+      .wide {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 40px 32px 80px;
+      }
+      .wide h2 {
+        font-size: 40px;
+        letter-spacing: -0.02em;
+        margin: 0 0 12px;
+      }
+      .wide p {
+        color: var(--muted);
+        font-size: 18px;
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 18px;
+      }
+      .l {
+        padding: 6px 14px;
+        background: white;
+        border: 2px solid var(--ink);
+        border-radius: 999px;
+        font-weight: 600;
+        font-size: 14px;
+      }
+      footer {
+        padding: 40px 32px;
+        text-align: center;
+        color: var(--muted);
+        border-top: 2px dashed var(--ink);
+      }
+      @media (max-width: 820px) {
+        .hero,
+        section.feat {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="brand"><span class="mark">☼</span> Code Self Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+
+    <section class="hero">
+      <div>
+        <span
+          style="
+            color: var(--brand);
+            font-weight: 700;
+            letter-spacing: 0.1em;
+            font-size: 13px;
+            text-transform: uppercase;
+          "
+          >Bay Area · Since 2014</span
+        >
+        <h1>A friendly place to <em>study code</em> together.</h1>
+        <p>
+          5,000 programmers in Berkeley and the San Francisco Bay Area. Bring
+          your laptop, your language of choice, and your curiosity. Leave with
+          new friends.
+        </p>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >Join the community →</a
+        >
+        <a class="ghost" href="#">See upcoming events</a>
+      </div>
+      <div class="illo" aria-hidden="true">
+        <div class="blob b1"></div>
+        <div class="blob b2"></div>
+        <div class="blob b3"></div>
+        <div class="face f1"><div class="smile"></div></div>
+        <div class="face f2"><div class="smile"></div></div>
+        <div class="face f3"><div class="smile"></div></div>
+      </div>
+    </section>
+
+    <section class="feat">
+      <div class="tile t1">
+        <div class="emoji">☕</div>
+        <h3>Community</h3>
+        <p>
+          Get out of your room. Meet people who actually show up week after
+          week.
+        </p>
+      </div>
+      <div class="tile t2">
+        <div class="emoji">✦</div>
+        <h3>Mentorship</h3>
+        <p>
+          Experienced members help beginners &mdash; questions, study plans,
+          project reviews.
+        </p>
+      </div>
+      <div class="tile t3">
+        <div class="emoji">✈</div>
+        <h3>Networking</h3>
+        <p>
+          Friends → introductions → jobs. It's how a lot of the group ends up
+          hired.
+        </p>
+      </div>
+    </section>
+
+    <section class="wide">
+      <h2>Every language, every level.</h2>
+      <p>
+        Dozens of meetups teach people to code. We're instead building a local
+        community of friendly, motivated programmers. The format is self-study
+        with mentorship &mdash; no curriculum, no gatekeeping.
+      </p>
+      <div class="langs">
+        <span class="l">Python</span><span class="l">JavaScript</span
+        ><span class="l">TypeScript</span><span class="l">Go</span
+        ><span class="l">Rust</span><span class="l">Haskell</span
+        ><span class="l">Clojure</span><span class="l">Elixir</span
+        ><span class="l">Racket</span><span class="l">Ruby</span
+        ><span class="l">Scala</span><span class="l">C++</span
+        ><span class="l">SQL</span><span class="l">+ more</span>
+      </div>
+    </section>
+
+    <footer>Made with care in Berkeley, CA ☼ Code Self Study</footer>
+  </body>
+</html>

--- a/mockups/07-zine.html
+++ b/mockups/07-zine.html
@@ -1,0 +1,371 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Zine</title>
+    <style>
+      :root {
+        --paper: #f3ead3;
+        --paper-dark: #e8dcb8;
+        --ink: #1a1a1a;
+        --red: #c8361a;
+        --blue: #2742a8;
+        --yellow: #f4c430;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: "Courier New", ui-monospace, Menlo, monospace;
+        line-height: 1.55;
+        min-height: 100vh;
+        background-image:
+          radial-gradient(
+            circle at 20% 30%,
+            rgba(0, 0, 0, 0.04) 0 1px,
+            transparent 1px
+          ),
+          radial-gradient(
+            circle at 70% 60%,
+            rgba(0, 0, 0, 0.04) 0 1px,
+            transparent 1px
+          ),
+          radial-gradient(
+            circle at 40% 80%,
+            rgba(0, 0, 0, 0.03) 0 1px,
+            transparent 1px
+          );
+        background-size:
+          8px 8px,
+          12px 12px,
+          10px 10px;
+      }
+      .page {
+        max-width: 960px;
+        margin: 30px auto;
+        background: var(--paper);
+        padding: 30px;
+        border: 2px solid var(--ink);
+        box-shadow:
+          12px 12px 0 rgba(0, 0, 0, 0.15),
+          inset 0 0 0 6px var(--paper),
+          inset 0 0 0 8px var(--ink);
+      }
+      header {
+        text-align: center;
+        border-bottom: 3px double var(--ink);
+        padding-bottom: 16px;
+        margin-bottom: 20px;
+      }
+      .zine-label {
+        display: inline-block;
+        background: var(--red);
+        color: var(--paper);
+        padding: 3px 10px;
+        transform: rotate(-2deg);
+        font-weight: 700;
+        letter-spacing: 0.2em;
+        font-size: 12px;
+      }
+      h1.title {
+        font-family: "Impact", "Oswald", "Arial Black", sans-serif;
+        font-size: clamp(56px, 10vw, 110px);
+        margin: 10px 0 6px;
+        letter-spacing: -0.02em;
+        line-height: 0.9;
+        text-transform: uppercase;
+      }
+      h1.title span {
+        display: inline-block;
+      }
+      h1.title .b {
+        background: var(--ink);
+        color: var(--paper);
+        padding: 0 8px;
+        transform: rotate(-1deg);
+      }
+      h1.title .r {
+        color: var(--red);
+        transform: rotate(1deg);
+      }
+      .subtitle {
+        font-style: italic;
+        font-size: 18px;
+      }
+      nav {
+        display: flex;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 14px;
+      }
+      nav a {
+        color: var(--ink);
+        text-decoration: none;
+        padding: 4px 10px;
+        border: 2px solid var(--ink);
+        background: var(--paper-dark);
+        font-weight: 700;
+        font-size: 13px;
+      }
+      nav a:nth-child(odd) {
+        background: var(--yellow);
+      }
+      nav a:nth-child(3n) {
+        background: var(--red);
+        color: var(--paper);
+      }
+      nav a:hover {
+        transform: rotate(-2deg);
+      }
+      .layout {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 24px;
+        margin-top: 20px;
+      }
+      .lead {
+        border: 2px solid var(--ink);
+        padding: 20px;
+        background: var(--paper);
+        position: relative;
+      }
+      .lead::before {
+        content: "MANIFESTO";
+        position: absolute;
+        top: -14px;
+        left: 16px;
+        background: var(--paper);
+        padding: 0 8px;
+        font-weight: 800;
+        letter-spacing: 0.2em;
+        font-size: 12px;
+      }
+      .lead h2 {
+        font-family: "Impact", "Oswald", "Arial Black", sans-serif;
+        font-size: 36px;
+        margin: 0 0 10px;
+        line-height: 1;
+        letter-spacing: -0.01em;
+        text-transform: uppercase;
+      }
+      .lead p {
+        margin: 10px 0;
+      }
+      .lead p::first-letter {
+        font-family: "Impact", sans-serif;
+        font-size: 56px;
+        float: left;
+        line-height: 0.9;
+        padding-right: 8px;
+        padding-top: 4px;
+        color: var(--red);
+      }
+      .btn {
+        display: inline-block;
+        margin-top: 10px;
+        padding: 10px 16px;
+        background: var(--blue);
+        color: var(--yellow);
+        text-decoration: none;
+        font-weight: 800;
+        letter-spacing: 0.1em;
+        border: 2px solid var(--ink);
+        box-shadow: 4px 4px 0 var(--ink);
+        transform: rotate(-1deg);
+      }
+      .btn:hover {
+        transform: rotate(1deg);
+      }
+      .sticky {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+      }
+      .note {
+        background: var(--yellow);
+        padding: 14px;
+        border: 2px solid var(--ink);
+        transform: rotate(-2deg);
+        font-size: 15px;
+      }
+      .note:nth-child(2) {
+        background: #ffb3a7;
+        transform: rotate(1.5deg);
+      }
+      .note:nth-child(3) {
+        background: #b7d9b1;
+        transform: rotate(-1deg);
+      }
+      .note h3 {
+        margin: 0 0 4px;
+        font-family: "Impact", sans-serif;
+        font-size: 22px;
+        letter-spacing: 0.02em;
+      }
+      .note p {
+        margin: 0;
+      }
+      .divider {
+        display: flex;
+        justify-content: center;
+        gap: 10px;
+        margin: 30px 0 20px;
+        font-size: 20px;
+      }
+      .long {
+        border-top: 2px solid var(--ink);
+        padding-top: 20px;
+        columns: 2;
+        column-gap: 24px;
+        column-rule: 1px solid var(--ink);
+      }
+      .long h2 {
+        font-family: "Impact", sans-serif;
+        font-size: 28px;
+        letter-spacing: 0.01em;
+        margin: 0 0 10px;
+        text-transform: uppercase;
+      }
+      .stickers {
+        margin-top: 26px;
+        padding: 14px;
+        border: 2px dashed var(--ink);
+        background: var(--paper-dark);
+      }
+      .stickers h3 {
+        font-family: "Impact", sans-serif;
+        margin: 0 0 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 18px;
+      }
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      .chip {
+        padding: 3px 10px;
+        border: 2px solid var(--ink);
+        font-weight: 700;
+        font-size: 13px;
+        background: var(--paper);
+        transform: rotate(-1deg);
+      }
+      .chip:nth-child(3n) {
+        background: var(--yellow);
+        transform: rotate(2deg);
+      }
+      .chip:nth-child(4n) {
+        background: var(--red);
+        color: var(--paper);
+        transform: rotate(-2deg);
+      }
+      @media (max-width: 820px) {
+        .layout,
+        .long {
+          grid-template-columns: 1fr;
+          columns: 1;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <header>
+        <span class="zine-label">Issue No. 103 &middot; Free</span>
+        <h1 class="title">
+          <span class="b">CODE</span> <span>SELF</span>
+          <span class="r">STUDY</span>
+        </h1>
+        <div class="subtitle">
+          ✂ A scrappy Bay Area programming community since 2014 ✂
+        </div>
+        <nav>
+          <a href="#">HOME</a><a href="#">EVENTS</a><a href="#">FORUM</a
+          ><a href="#">LEARN</a><a href="#">JOBS</a><a href="#">PUZZLES</a
+          ><a href="#">TOOLS</a><a href="#">ABOUT</a>
+        </nav>
+      </header>
+
+      <div class="layout">
+        <article class="lead">
+          <h2>Study together. In person. For real.</h2>
+          <p>
+            We are a friendly community of over 5,000 programmers in Berkeley
+            and the SF Bay Area. All languages, all levels, all welcome. Show
+            up, bring something you're stuck on, make friends, go home less
+            confused than you came.
+          </p>
+          <p>
+            No curriculum. No gatekeeping. No bootcamp pitch. Just people who
+            like writing code and would rather do it next to other humans than
+            alone.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >→ JOIN US ←</a
+          >
+        </article>
+        <aside class="sticky">
+          <div class="note">
+            <h3>★ Community</h3>
+            <p>Get out of your room. Meet people who show up.</p>
+          </div>
+          <div class="note">
+            <h3>✎ Mentorship</h3>
+            <p>Experienced members help beginners. Ask for a study plan.</p>
+          </div>
+          <div class="note">
+            <h3>♞ Networking</h3>
+            <p>Jobs, intros, tips. Members find work through the group.</p>
+          </div>
+        </aside>
+      </div>
+
+      <div class="divider">✂ ✦ ✂ ✦ ✂ ✦ ✂</div>
+
+      <section class="long">
+        <h2>what we do</h2>
+        <p>
+          Dozens of meetups teach people to code. We are doing something a
+          little different &mdash; building a local community of friendly,
+          creative, highly-motivated programmers. We're open to every language,
+          every level, every kind of project.
+        </p>
+        <p>
+          The format is self-study with advice and mentorship from the more
+          experienced members. We can help you with study plans and guidance
+          &mdash; just ask at a meetup or in the forum.
+        </p>
+        <h2>bootcamp supplement</h2>
+        <p>
+          Attend as a self-directed bootcamp supplement or alternative.
+          Experienced programmers can offer mentorship on project-based
+          learning.
+        </p>
+      </section>
+
+      <div class="stickers">
+        <h3>✩ languages in the wild ✩</h3>
+        <div class="chips">
+          <span class="chip">Python</span><span class="chip">JS</span
+          ><span class="chip">TypeScript</span><span class="chip">Go</span
+          ><span class="chip">Rust</span><span class="chip">Haskell</span
+          ><span class="chip">Clojure</span><span class="chip">Elixir</span
+          ><span class="chip">Racket</span><span class="chip">Scala</span
+          ><span class="chip">Ruby</span><span class="chip">C++</span
+          ><span class="chip">SQL</span>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/mockups/08-glass.html
+++ b/mockups/08-glass.html
@@ -1,0 +1,324 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Glass</title>
+    <style>
+      :root {
+        --ink: #0b0a1a;
+        --fg: #1a1830;
+        --muted: #5a5871;
+        --accent: #5b5cff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        color: var(--fg);
+        font-family:
+          "Inter",
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          sans-serif;
+        line-height: 1.55;
+        min-height: 100vh;
+        background: linear-gradient(
+          135deg,
+          #ffd3a5 0%,
+          #fd9cc8 35%,
+          #a98cff 70%,
+          #6ed0ff 100%
+        );
+        background-attachment: fixed;
+        overflow-x: hidden;
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        background:
+          radial-gradient(
+            600px 400px at 10% 10%,
+            rgba(255, 255, 255, 0.5),
+            transparent
+          ),
+          radial-gradient(
+            500px 400px at 90% 80%,
+            rgba(255, 255, 255, 0.35),
+            transparent
+          ),
+          radial-gradient(
+            400px 300px at 50% 50%,
+            rgba(255, 255, 255, 0.3),
+            transparent
+          );
+        pointer-events: none;
+      }
+      nav {
+        position: sticky;
+        top: 16px;
+        z-index: 20;
+        max-width: 1100px;
+        margin: 16px auto 0;
+        padding: 12px 20px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: rgba(255, 255, 255, 0.45);
+        border: 1px solid rgba(255, 255, 255, 0.6);
+        backdrop-filter: blur(14px) saturate(140%);
+        -webkit-backdrop-filter: blur(14px) saturate(140%);
+        border-radius: 999px;
+        box-shadow: 0 8px 32px rgba(20, 10, 60, 0.12);
+      }
+      .brand {
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .brand .mark {
+        width: 28px;
+        height: 28px;
+        border-radius: 8px;
+        background: linear-gradient(135deg, #fff, #c9c5ff);
+        border: 1px solid rgba(255, 255, 255, 0.8);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 20px;
+        margin: 0;
+        padding: 0;
+      }
+      nav a {
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      nav a:hover {
+        color: var(--accent);
+      }
+      .hero {
+        max-width: 1100px;
+        margin: 48px auto;
+        padding: 56px 40px 56px;
+        text-align: center;
+        background: rgba(255, 255, 255, 0.35);
+        border: 1px solid rgba(255, 255, 255, 0.65);
+        border-radius: 32px;
+        backdrop-filter: blur(20px) saturate(140%);
+        -webkit-backdrop-filter: blur(20px) saturate(140%);
+        box-shadow: 0 20px 60px -20px rgba(20, 10, 60, 0.2);
+      }
+      .pill {
+        display: inline-flex;
+        gap: 8px;
+        align-items: center;
+        padding: 6px 14px;
+        background: rgba(255, 255, 255, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.8);
+        border-radius: 999px;
+        font-size: 13px;
+        font-weight: 500;
+      }
+      .pill .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #22c55e;
+      }
+      h1 {
+        font-size: clamp(44px, 6vw, 80px);
+        letter-spacing: -0.03em;
+        line-height: 1.02;
+        margin: 20px 0 16px;
+        font-weight: 800;
+        color: var(--ink);
+      }
+      .lede {
+        font-size: 19px;
+        color: var(--fg);
+        opacity: 0.8;
+        max-width: 60ch;
+        margin: 0 auto 28px;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 14px 24px;
+        border-radius: 999px;
+        background: var(--ink);
+        color: white;
+        text-decoration: none;
+        font-weight: 600;
+        box-shadow: 0 12px 30px -10px rgba(10, 10, 60, 0.5);
+      }
+      .cta:hover {
+        transform: translateY(-1px);
+      }
+      .cards {
+        max-width: 1100px;
+        margin: 32px auto;
+        padding: 0 32px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+      }
+      .card {
+        padding: 28px;
+        background: rgba(255, 255, 255, 0.4);
+        border: 1px solid rgba(255, 255, 255, 0.7);
+        border-radius: 24px;
+        backdrop-filter: blur(16px) saturate(140%);
+        -webkit-backdrop-filter: blur(16px) saturate(140%);
+        box-shadow: 0 10px 30px -10px rgba(20, 10, 60, 0.12);
+      }
+      .card .glyph {
+        width: 44px;
+        height: 44px;
+        border-radius: 12px;
+        display: grid;
+        place-items: center;
+        font-size: 20px;
+        background: linear-gradient(
+          135deg,
+          rgba(255, 255, 255, 0.9),
+          rgba(255, 255, 255, 0.4)
+        );
+        border: 1px solid rgba(255, 255, 255, 0.8);
+      }
+      .card h3 {
+        margin: 14px 0 6px;
+        font-size: 20px;
+        color: var(--ink);
+        letter-spacing: -0.01em;
+      }
+      .card p {
+        margin: 0;
+        color: var(--fg);
+        opacity: 0.75;
+      }
+      .prose {
+        max-width: 880px;
+        margin: 40px auto;
+        padding: 40px;
+        background: rgba(255, 255, 255, 0.45);
+        border: 1px solid rgba(255, 255, 255, 0.7);
+        border-radius: 24px;
+        backdrop-filter: blur(18px) saturate(140%);
+        -webkit-backdrop-filter: blur(18px) saturate(140%);
+      }
+      .prose h2 {
+        margin: 0 0 10px;
+        font-size: 28px;
+        letter-spacing: -0.02em;
+        color: var(--ink);
+      }
+      .prose p {
+        color: var(--fg);
+        opacity: 0.8;
+      }
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 14px;
+      }
+      .chip {
+        padding: 4px 12px;
+        background: rgba(255, 255, 255, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.8);
+        border-radius: 999px;
+        font-size: 13px;
+      }
+      footer {
+        text-align: center;
+        color: rgba(20, 10, 60, 0.55);
+        padding: 40px;
+        font-size: 14px;
+      }
+      @media (max-width: 820px) {
+        .cards {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="brand"><span class="mark"></span> Code Self Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+      </ul>
+    </nav>
+
+    <section class="hero">
+      <span class="pill"
+        ><span class="dot"></span> 5,000+ Bay Area programmers</span
+      >
+      <h1>Study code together, in the open.</h1>
+      <p class="lede">
+        A friendly programming community in Berkeley and the San Francisco Bay
+        Area. Self-study, mentorship, and every language welcome.
+      </p>
+      <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+        >Join the community →</a
+      >
+    </section>
+
+    <section class="cards">
+      <div class="card">
+        <div class="glyph">◎</div>
+        <h3>Community</h3>
+        <p>Show up, meet people, leave less alone than you came.</p>
+      </div>
+      <div class="card">
+        <div class="glyph">✦</div>
+        <h3>Mentorship</h3>
+        <p>
+          Experienced members help with questions, study plans, and project
+          reviews.
+        </p>
+      </div>
+      <div class="card">
+        <div class="glyph">⟁</div>
+        <h3>Networking</h3>
+        <p>Members have found jobs through introductions made in the group.</p>
+      </div>
+    </section>
+
+    <section class="prose">
+      <h2>All languages, all levels.</h2>
+      <p>
+        Dozens of meetups teach you to code. We're instead building a local
+        community of friendly, motivated programmers &mdash; open to every
+        language and every level.
+      </p>
+      <div class="chips">
+        <span class="chip">Python</span><span class="chip">TypeScript</span
+        ><span class="chip">Go</span><span class="chip">Rust</span
+        ><span class="chip">Haskell</span><span class="chip">Clojure</span
+        ><span class="chip">Elixir</span><span class="chip">Racket</span
+        ><span class="chip">Ruby</span><span class="chip">C++</span
+        ><span class="chip">SQL</span><span class="chip">+ more</span>
+      </div>
+    </section>
+
+    <footer>© Code Self Study · Berkeley, CA</footer>
+  </body>
+</html>

--- a/mockups/09-bauhaus.html
+++ b/mockups/09-bauhaus.html
@@ -1,0 +1,398 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Bauhaus</title>
+    <style>
+      :root {
+        --bg: #f2ece1;
+        --ink: #121212;
+        --red: #d8352a;
+        --yellow: #f4c80b;
+        --blue: #1f4fd6;
+        --muted: #5a5347;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          "Futura", "Avenir Next", "Futura PT", "Inter", ui-sans-serif,
+          system-ui, sans-serif;
+        line-height: 1.5;
+      }
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 20px 40px;
+        border-bottom: 3px solid var(--ink);
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-weight: 800;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+      .brand .shapes {
+        display: flex;
+        gap: 3px;
+      }
+      .brand .shapes .sq {
+        width: 14px;
+        height: 14px;
+        background: var(--red);
+      }
+      .brand .shapes .ci {
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        background: var(--blue);
+      }
+      .brand .shapes .tr {
+        width: 0;
+        height: 0;
+        border-left: 7px solid transparent;
+        border-right: 7px solid transparent;
+        border-bottom: 14px solid var(--yellow);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 22px;
+        margin: 0;
+        padding: 0;
+      }
+      nav a {
+        color: var(--ink);
+        text-decoration: none;
+        font-size: 14px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      nav a:hover {
+        color: var(--red);
+      }
+      .hero {
+        position: relative;
+        padding: 60px 40px 80px;
+        max-width: 1200px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 40px;
+        align-items: center;
+        overflow: hidden;
+      }
+      .hero h1 {
+        font-size: clamp(48px, 8vw, 112px);
+        font-weight: 900;
+        letter-spacing: -0.04em;
+        line-height: 0.9;
+        margin: 0 0 20px;
+        text-transform: uppercase;
+      }
+      .hero h1 .red {
+        color: var(--red);
+      }
+      .hero h1 .blue {
+        color: var(--blue);
+      }
+      .hero .lede {
+        font-size: 19px;
+        max-width: 44ch;
+        color: var(--muted);
+        margin: 0 0 24px;
+      }
+      .cta {
+        display: inline-block;
+        background: var(--ink);
+        color: var(--yellow);
+        padding: 16px 28px;
+        font-weight: 800;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        text-decoration: none;
+      }
+      .cta:hover {
+        background: var(--red);
+      }
+      .composition {
+        position: relative;
+        aspect-ratio: 1 / 1;
+        border: 3px solid var(--ink);
+      }
+      .composition .big-circle {
+        position: absolute;
+        width: 70%;
+        height: 70%;
+        border-radius: 50%;
+        background: var(--red);
+        top: -10%;
+        right: -10%;
+      }
+      .composition .yellow-sq {
+        position: absolute;
+        width: 35%;
+        height: 35%;
+        background: var(--yellow);
+        left: 0;
+        top: 30%;
+        border-right: 3px solid var(--ink);
+        border-bottom: 3px solid var(--ink);
+      }
+      .composition .blue-tri {
+        position: absolute;
+        width: 0;
+        height: 0;
+        border-left: 80px solid transparent;
+        border-right: 80px solid transparent;
+        border-bottom: 140px solid var(--blue);
+        bottom: 0;
+        right: 10%;
+      }
+      .composition .line {
+        position: absolute;
+        background: var(--ink);
+      }
+      .composition .h {
+        height: 3px;
+        width: 100%;
+        top: 60%;
+      }
+      .composition .v {
+        width: 3px;
+        height: 100%;
+        left: 35%;
+      }
+      section.grid3 {
+        border-top: 3px solid var(--ink);
+        border-bottom: 3px solid var(--ink);
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+      }
+      section.grid3 > div {
+        padding: 48px 32px;
+        border-right: 3px solid var(--ink);
+        position: relative;
+        min-height: 260px;
+      }
+      section.grid3 > div:last-child {
+        border-right: none;
+      }
+      section.grid3 .num {
+        font-size: 80px;
+        font-weight: 900;
+        line-height: 1;
+        letter-spacing: -0.04em;
+      }
+      section.grid3 > div:nth-child(1) .num {
+        color: var(--red);
+      }
+      section.grid3 > div:nth-child(2) .num {
+        color: var(--blue);
+      }
+      section.grid3 > div:nth-child(3) .num {
+        color: var(--yellow);
+        -webkit-text-stroke: 2px var(--ink);
+      }
+      section.grid3 h3 {
+        margin: 16px 0 8px;
+        font-size: 26px;
+        text-transform: uppercase;
+        letter-spacing: -0.01em;
+      }
+      section.grid3 p {
+        color: var(--muted);
+        margin: 0;
+      }
+      .ornament-r {
+        position: absolute;
+        top: 20px;
+        right: 20px;
+        width: 30px;
+        height: 30px;
+      }
+      .ornament-r.circle {
+        border-radius: 50%;
+        background: var(--red);
+      }
+      .ornament-r.square {
+        background: var(--blue);
+      }
+      .ornament-r.triangle {
+        width: 0;
+        height: 0;
+        border-left: 15px solid transparent;
+        border-right: 15px solid transparent;
+        border-bottom: 26px solid var(--yellow);
+        background: transparent;
+      }
+      section.long {
+        max-width: 1000px;
+        margin: 0 auto;
+        padding: 64px 40px;
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 40px;
+      }
+      section.long h2 {
+        font-size: 44px;
+        font-weight: 900;
+        letter-spacing: -0.03em;
+        line-height: 1;
+        text-transform: uppercase;
+        margin: 0;
+      }
+      section.long p {
+        margin: 0 0 14px;
+        color: var(--muted);
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 16px;
+      }
+      .lang {
+        padding: 4px 12px;
+        border: 2px solid var(--ink);
+        font-weight: 700;
+        font-size: 13px;
+        text-transform: uppercase;
+      }
+      .lang:nth-child(3n) {
+        background: var(--yellow);
+      }
+      .lang:nth-child(4n) {
+        background: var(--red);
+        color: var(--bg);
+      }
+      .lang:nth-child(5n) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      footer {
+        padding: 30px 40px;
+        text-align: center;
+        border-top: 3px solid var(--ink);
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        font-size: 13px;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        section.grid3,
+        section.long {
+          grid-template-columns: 1fr;
+        }
+        section.grid3 > div {
+          border-right: none;
+          border-bottom: 3px solid var(--ink);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="brand">
+        <div class="shapes">
+          <div class="sq"></div>
+          <div class="ci"></div>
+          <div class="tr"></div>
+        </div>
+        Code Self Study
+      </div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+
+    <section class="hero">
+      <div>
+        <h1>
+          Study <span class="red">Code</span>.<br />
+          Build <span class="blue">Things</span>.
+        </h1>
+        <p class="lede">
+          A programming community in Berkeley and the San Francisco Bay Area.
+          Over 5,000 members. All languages, all levels, self-directed.
+        </p>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >Join the Community</a
+        >
+      </div>
+      <div class="composition" aria-hidden="true">
+        <div class="line v"></div>
+        <div class="line h"></div>
+        <div class="big-circle"></div>
+        <div class="yellow-sq"></div>
+        <div class="blue-tri"></div>
+      </div>
+    </section>
+
+    <section class="grid3">
+      <div>
+        <span class="ornament-r circle"></span>
+        <div class="num">01</div>
+        <h3>Community</h3>
+        <p>Get out of your room. Meet people who keep showing up.</p>
+      </div>
+      <div>
+        <span class="ornament-r square"></span>
+        <div class="num">02</div>
+        <h3>Mentorship</h3>
+        <p>
+          Experienced members help beginners. Questions, study plans, projects.
+        </p>
+      </div>
+      <div>
+        <span class="ornament-r triangle"></span>
+        <div class="num">03</div>
+        <h3>Networking</h3>
+        <p>Members have found jobs through introductions made at the group.</p>
+      </div>
+    </section>
+
+    <section class="long">
+      <h2>What We Do</h2>
+      <div>
+        <p>
+          Dozens of meetups teach people to code. We're instead building a local
+          community of friendly, creative, motivated programmers. Open to every
+          language, every level. The format is self-study with mentorship.
+        </p>
+        <p>
+          Come as a self-directed bootcamp supplement or alternative.
+          Experienced programmers offer project-based mentorship.
+        </p>
+        <div class="langs">
+          <span class="lang">Python</span><span class="lang">JS</span
+          ><span class="lang">TS</span><span class="lang">Go</span
+          ><span class="lang">Rust</span><span class="lang">Haskell</span
+          ><span class="lang">Clojure</span><span class="lang">Elixir</span
+          ><span class="lang">Racket</span><span class="lang">Ruby</span
+          ><span class="lang">C++</span><span class="lang">SQL</span>
+        </div>
+      </div>
+    </section>
+
+    <footer>Code Self Study &middot; Berkeley &middot; Est. 2014</footer>
+  </body>
+</html>

--- a/mockups/10-swiss.html
+++ b/mockups/10-swiss.html
@@ -1,0 +1,363 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Swiss</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --ink: #0a0a0a;
+        --muted: #555;
+        --rule: #111;
+        --accent: #e4002b;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          "Helvetica Neue", "Helvetica", "Arial", "Inter", ui-sans-serif,
+          system-ui, sans-serif;
+        line-height: 1.45;
+        font-size: 15px;
+      }
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 0 32px;
+      }
+      header {
+        border-bottom: 1px solid var(--rule);
+        padding: 14px 0;
+      }
+      header .row {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+      }
+      .brand {
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        font-size: 20px;
+      }
+      .brand .dot {
+        color: var(--accent);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 24px;
+        margin: 0;
+        padding: 0;
+      }
+      nav a {
+        color: var(--ink);
+        text-decoration: none;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+      }
+      nav a:hover {
+        color: var(--accent);
+      }
+      .meta {
+        font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+        font-size: 12px;
+        color: var(--muted);
+        padding: 10px 0;
+        border-bottom: 1px solid var(--rule);
+        display: flex;
+        justify-content: space-between;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1fr 11fr;
+        gap: 0;
+        border-bottom: 1px solid var(--rule);
+      }
+      .hero .num {
+        padding: 40px 16px 40px 0;
+        font-size: 14px;
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        color: var(--muted);
+        border-right: 1px solid var(--rule);
+      }
+      .hero .content {
+        padding: 40px 0 40px 32px;
+        display: grid;
+        grid-template-columns: 3fr 2fr;
+        gap: 32px;
+      }
+      h1 {
+        font-size: clamp(52px, 9vw, 140px);
+        line-height: 0.9;
+        letter-spacing: -0.045em;
+        margin: 0;
+        font-weight: 700;
+      }
+      h1 .accent {
+        color: var(--accent);
+      }
+      .hero aside {
+        align-self: end;
+      }
+      .hero aside p {
+        font-size: 18px;
+        max-width: 38ch;
+        margin: 0 0 16px;
+      }
+      .hero aside .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        background: var(--ink);
+        color: var(--bg);
+        padding: 12px 20px;
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+      }
+      .hero aside .cta:hover {
+        background: var(--accent);
+      }
+      .specs {
+        display: grid;
+        grid-template-columns: 1fr 3fr 3fr 3fr;
+        border-bottom: 1px solid var(--rule);
+      }
+      .specs > div {
+        padding: 32px 16px 32px 0;
+        border-right: 1px solid var(--rule);
+      }
+      .specs > div:last-child {
+        border-right: none;
+      }
+      .specs > div:first-child {
+        padding-right: 0;
+      }
+      .specs .label {
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        font-size: 12px;
+        color: var(--muted);
+        padding: 32px 16px;
+      }
+      .specs h3 {
+        margin: 0 0 12px;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .specs .big {
+        font-size: 32px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        margin: 0 0 8px;
+        line-height: 1;
+      }
+      .specs p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      section.article {
+        display: grid;
+        grid-template-columns: 1fr 11fr;
+        border-bottom: 1px solid var(--rule);
+      }
+      section.article .label {
+        padding: 40px 16px 40px 0;
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        font-size: 12px;
+        color: var(--muted);
+        border-right: 1px solid var(--rule);
+      }
+      section.article .body {
+        padding: 40px 0 40px 32px;
+        display: grid;
+        grid-template-columns: 2fr 3fr;
+        gap: 32px;
+      }
+      section.article h2 {
+        font-size: 36px;
+        letter-spacing: -0.02em;
+        margin: 0;
+        line-height: 1.05;
+      }
+      section.article .copy p {
+        margin: 0 0 12px;
+      }
+      .index {
+        display: grid;
+        grid-template-columns: repeat(6, 1fr);
+        gap: 8px 16px;
+        margin-top: 16px;
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        font-size: 13px;
+      }
+      .index span {
+        border-top: 1px solid var(--rule);
+        padding-top: 6px;
+      }
+      footer {
+        padding: 24px 0;
+        border-top: 1px solid var(--rule);
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        font-size: 12px;
+        color: var(--muted);
+        display: flex;
+        justify-content: space-between;
+      }
+      .bar {
+        height: 6px;
+        background: var(--accent);
+        margin: 0;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        section.article,
+        .specs {
+          grid-template-columns: 1fr;
+        }
+        .hero .content,
+        section.article .body {
+          grid-template-columns: 1fr;
+          padding-left: 0;
+        }
+        .specs > div,
+        .hero .num,
+        section.article .label {
+          border-right: none;
+          border-bottom: 1px solid var(--rule);
+          padding: 16px 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="bar"></div>
+    <div class="container">
+      <header>
+        <div class="row">
+          <div class="brand">Code Self Study<span class="dot">.</span></div>
+          <nav>
+            <ul>
+              <li><a href="#">Events</a></li>
+              <li><a href="#">Learn</a></li>
+              <li><a href="#">Forum</a></li>
+              <li><a href="#">Jobs</a></li>
+              <li><a href="#">Puzzles</a></li>
+              <li><a href="#">About</a></li>
+            </ul>
+          </nav>
+        </div>
+      </header>
+      <div class="meta">
+        <span>Berkeley, CA &middot; 37.87°N 122.27°W</span>
+        <span>Vol. 12 &middot; Est. 2014 &middot; 5,000+ members</span>
+      </div>
+
+      <section class="hero">
+        <div class="num">§01</div>
+        <div class="content">
+          <h1>
+            Study<br />
+            the <span class="accent">code.</span><br />
+            Together.
+          </h1>
+          <aside>
+            <p>
+              A friendly, self-directed programming community in Berkeley and
+              the San Francisco Bay Area. Every language, every level. No
+              curriculum &mdash; just mentorship and people who show up.
+            </p>
+            <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+              >Join →</a
+            >
+          </aside>
+        </div>
+      </section>
+
+      <section class="specs">
+        <div class="label">§02<br />Why</div>
+        <div>
+          <h3>Community</h3>
+          <p class="big">01</p>
+          <p>
+            Get out of your room. Meet programmers who actually keep showing up.
+          </p>
+        </div>
+        <div>
+          <h3>Mentorship</h3>
+          <p class="big">02</p>
+          <p>
+            Experienced members help beginners &mdash; questions, study plans,
+            code reviews.
+          </p>
+        </div>
+        <div>
+          <h3>Networking</h3>
+          <p class="big">03</p>
+          <p>
+            Members have found jobs through introductions made inside the group.
+          </p>
+        </div>
+      </section>
+
+      <section class="article">
+        <div class="label">§03<br />What</div>
+        <div class="body">
+          <h2>A local community of motivated programmers.</h2>
+          <div class="copy">
+            <p>
+              Dozens of meetups teach people how to code. We instead build a
+              local community of friendly, creative, motivated programmers.
+              We're open to every language, every level, and every type of
+              computer programming.
+            </p>
+            <p>
+              The format is self-study with advice and mentorship from the more
+              experienced members. Ask in the forum or at a meetup &mdash; we
+              can help you shape a study plan.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="article">
+        <div class="label">§04<br />Langs</div>
+        <div class="body" style="grid-template-columns: 2fr 3fr">
+          <h2>Every language<br />in rotation.</h2>
+          <div>
+            <div class="index">
+              <span>Python</span><span>JavaScript</span><span>TypeScript</span
+              ><span>Go</span><span>Rust</span><span>WASM</span><span>Java</span
+              ><span>Scheme</span><span>Racket</span><span>Haskell</span
+              ><span>Clojure</span><span>Lisp</span><span>C</span
+              ><span>C++</span><span>C#</span><span>F#</span><span>Lua</span
+              ><span>Elixir</span><span>Erlang</span><span>Elm</span
+              ><span>PureScript</span><span>Ruby</span><span>Scala</span
+              ><span>PHP</span><span>R</span><span>Julia</span><span>SQL</span
+              ><span>More</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <footer>
+        <span>© Code Self Study</span>
+        <span>⇣ Scroll for more</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/mockups/11-bbs.html
+++ b/mockups/11-bbs.html
@@ -1,0 +1,336 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — BBS</title>
+    <style>
+      :root {
+        --bg: #1a0f00;
+        --amber: #ffb000;
+        --amber-dim: #8a5a00;
+        --cyan: #00d4ff;
+        --red: #ff4444;
+        --green: #7cff7c;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--amber);
+        font-family:
+          "VT323", "Perfect DOS VGA 437", "Courier New", ui-monospace, monospace;
+        font-size: 18px;
+        line-height: 1.4;
+        min-height: 100vh;
+        background-image:
+          linear-gradient(
+            to bottom,
+            transparent 0,
+            transparent 2px,
+            rgba(0, 0, 0, 0.25) 2px,
+            rgba(0, 0, 0, 0.25) 3px
+          ),
+          radial-gradient(
+            ellipse at center,
+            rgba(255, 176, 0, 0.06) 0%,
+            transparent 70%
+          );
+        background-size:
+          100% 3px,
+          100% 100%;
+        text-shadow: 0 0 4px rgba(255, 176, 0, 0.5);
+      }
+      a {
+        color: var(--cyan);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--cyan);
+        color: var(--bg);
+      }
+      .screen {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .header {
+        border: 2px solid var(--amber);
+        padding: 10px;
+        margin-bottom: 16px;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 20px;
+        align-items: center;
+      }
+      .logo {
+        white-space: pre;
+        font-size: 12px;
+        line-height: 1.1;
+        color: var(--amber);
+      }
+      .stats {
+        text-align: right;
+        font-size: 14px;
+        color: var(--amber-dim);
+      }
+      .stats strong {
+        color: var(--green);
+      }
+      .menubar {
+        border: 2px solid var(--amber);
+        background: var(--amber);
+        color: var(--bg);
+        padding: 4px 10px;
+        margin-bottom: 16px;
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        text-shadow: none;
+      }
+      .menubar span {
+        font-weight: 700;
+      }
+      .menubar .k {
+        color: var(--red);
+      }
+      .welcome {
+        border: 2px solid var(--amber);
+        padding: 18px;
+        margin-bottom: 16px;
+      }
+      h1 {
+        font-family: inherit;
+        font-size: 48px;
+        letter-spacing: 4px;
+        margin: 4px 0 12px;
+        color: var(--green);
+        text-shadow: 0 0 8px rgba(124, 255, 124, 0.6);
+      }
+      .blink {
+        animation: blink 1s steps(1) infinite;
+        color: var(--cyan);
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cta {
+        display: inline-block;
+        border: 2px solid var(--cyan);
+        color: var(--cyan);
+        padding: 6px 14px;
+        margin-top: 12px;
+        text-shadow: 0 0 4px rgba(0, 212, 255, 0.5);
+      }
+      .cta:hover {
+        background: var(--cyan);
+        color: var(--bg);
+      }
+      .sep {
+        color: var(--amber-dim);
+        letter-spacing: -1px;
+      }
+      .cols {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        margin-bottom: 16px;
+      }
+      .box {
+        border: 2px solid var(--amber);
+        padding: 12px;
+      }
+      .box .tag {
+        display: inline-block;
+        background: var(--amber);
+        color: var(--bg);
+        padding: 0 6px;
+        margin-bottom: 6px;
+        text-shadow: none;
+        letter-spacing: 2px;
+      }
+      .box h3 {
+        margin: 0 0 6px;
+        color: var(--green);
+        font-size: 22px;
+      }
+      .box p {
+        margin: 0;
+        color: var(--amber);
+      }
+      .log {
+        border: 2px solid var(--amber);
+        padding: 14px;
+        margin-bottom: 16px;
+      }
+      .log h2 {
+        color: var(--cyan);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .log ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .log li {
+        padding: 2px 0;
+      }
+      .log li::before {
+        content: "> ";
+        color: var(--green);
+      }
+      .langs {
+        border: 2px solid var(--amber);
+        padding: 14px;
+      }
+      .langs h2 {
+        color: var(--cyan);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .lang-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 2px 14px;
+      }
+      .status {
+        margin-top: 12px;
+        color: var(--amber-dim);
+        font-size: 14px;
+        border-top: 1px solid var(--amber-dim);
+        padding-top: 6px;
+      }
+      @media (max-width: 700px) {
+        .cols {
+          grid-template-columns: 1fr;
+        }
+        .header {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="screen">
+      <div class="header">
+        <pre class="logo">
+ ██████╗███████╗███████╗    ██████╗ ██████╗ ███████╗
+██╔════╝██╔════╝██╔════╝    ██╔══██╗██╔══██╗██╔════╝
+██║     ███████╗███████╗    ██████╔╝██████╔╝███████╗
+██║     ╚════██║╚════██║    ██╔══██╗██╔══██╗╚════██║
+╚██████╗███████║███████║    ██████╔╝██████╔╝███████║
+ ╚═════╝╚══════╝╚══════╝    ╚═════╝ ╚═════╝ ╚══════╝</pre
+        >
+        <div class="stats">
+          NODE: 01<br />
+          USERS ONLINE: <strong>37</strong><br />
+          TOTAL MEMBERS: <strong>5,247</strong><br />
+          UPTIME: 4,127 DAYS
+        </div>
+      </div>
+
+      <div class="menubar">
+        <span><span class="k">[H]</span>OME</span>
+        <span><span class="k">[E]</span>VENTS</span>
+        <span><span class="k">[L]</span>EARN</span>
+        <span><span class="k">[F]</span>ORUM</span>
+        <span><span class="k">[J]</span>OBS</span>
+        <span><span class="k">[P]</span>UZZLES</span>
+        <span><span class="k">[T]</span>OOLS</span>
+        <span><span class="k">[A]</span>BOUT</span>
+      </div>
+
+      <div class="welcome">
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <h1>WELCOME, USER</h1>
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <p>
+          YOU HAVE CONNECTED TO
+          <strong style="color: var(--green)">CODE SELF STUDY</strong> &mdash; A
+          FRIENDLY PROGRAMMING COMMUNITY OF 5,000+ MEMBERS IN BERKELEY AND THE
+          SAN FRANCISCO BAY AREA.
+        </p>
+        <p>
+          ALL LANGUAGES, ALL LEVELS, ALL WELCOME.
+          <span class="blink">█</span>
+        </p>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >[ PRESS RETURN TO JOIN ]</a
+        >
+      </div>
+
+      <div class="cols">
+        <div class="box">
+          <span class="tag">◆ NODE 01</span>
+          <h3>COMMUNITY</h3>
+          <p>
+            Connect to the meetup &mdash; meet 5,000+ programmers who actually
+            keep showing up.
+          </p>
+        </div>
+        <div class="box">
+          <span class="tag">◆ NODE 02</span>
+          <h3>MENTORSHIP</h3>
+          <p>
+            SYSOP-approved mentorship. Ask for a study plan. Beginners welcome.
+          </p>
+        </div>
+        <div class="box">
+          <span class="tag">◆ NODE 03</span>
+          <h3>NETWORKING</h3>
+          <p>
+            Members have landed jobs via intros in the forum and at meetups.
+          </p>
+        </div>
+      </div>
+
+      <div class="log">
+        <h2>▓▓▓ BULLETIN ▓▓▓</h2>
+        <ul>
+          <li>
+            DOZENS OF MEETUPS TEACH YOU TO CODE. WE BUILD A LOCAL COMMUNITY.
+          </li>
+          <li>OPEN TO EVERY LANGUAGE. EVERY LEVEL. EVERY KIND OF PROJECT.</li>
+          <li>
+            FORMAT IS SELF-STUDY WITH ADVICE FROM MORE EXPERIENCED MEMBERS.
+          </li>
+          <li>
+            COMES AS A BOOTCAMP SUPPLEMENT OR ALTERNATIVE &mdash; ASK IN FORUM.
+          </li>
+        </ul>
+      </div>
+
+      <div class="langs">
+        <h2>▓▓▓ SUPPORTED DIALECTS ▓▓▓</h2>
+        <div class="lang-grid">
+          <span>» PYTHON</span><span>» JS</span><span>» TYPESCRIPT</span
+          ><span>» GO</span><span>» RUST</span><span>» HASKELL</span
+          ><span>» CLOJURE</span><span>» ELIXIR</span><span>» RACKET</span
+          ><span>» SCHEME</span><span>» C</span><span>» C++</span
+          ><span>» RUBY</span><span>» SCALA</span><span>» ERLANG</span
+          ><span>» ELM</span><span>» LUA</span><span>» SQL</span
+          ><span>» JULIA</span><span>» R</span><span>» +MORE</span>
+        </div>
+        <div class="status">
+          <span class="sep">───</span> CARRIER: 2400 BAUD · ANSI ON · LOCAL ECHO
+          ON · PRESS ? FOR HELP <span class="sep">───</span>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/mockups/12-riso.html
+++ b/mockups/12-riso.html
@@ -1,0 +1,457 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Risograph</title>
+    <style>
+      :root {
+        --paper: #f7f1e1;
+        --ink: #1f1a14;
+        --fed-blue: #3d5af1;
+        --flu-pink: #ff48a0;
+        --sun-yel: #ffd400;
+        --mint: #9ad9c0;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: "Work Sans", "Inter", ui-sans-serif, system-ui, sans-serif;
+        line-height: 1.5;
+        font-size: 16px;
+        min-height: 100vh;
+        background-image:
+          radial-gradient(rgba(0, 0, 0, 0.05) 1px, transparent 1px),
+          radial-gradient(rgba(0, 0, 0, 0.05) 1px, transparent 1px);
+        background-size:
+          3px 3px,
+          5px 5px;
+        background-position:
+          0 0,
+          1px 1px;
+      }
+      .page {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 24px;
+        position: relative;
+      }
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding-bottom: 18px;
+        margin-bottom: 18px;
+        border-bottom: 3px solid var(--ink);
+      }
+      .brand {
+        font-weight: 900;
+        font-size: 20px;
+        letter-spacing: 0.02em;
+      }
+      .brand .dot {
+        display: inline-block;
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        background: var(--flu-pink);
+        mix-blend-mode: multiply;
+        margin-right: 6px;
+        vertical-align: middle;
+      }
+      nav ul {
+        display: flex;
+        list-style: none;
+        gap: 18px;
+        margin: 0;
+        padding: 0;
+      }
+      nav a {
+        color: var(--ink);
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 14px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      nav a:hover {
+        color: var(--fed-blue);
+      }
+      .hero {
+        position: relative;
+        padding: 40px 0 60px;
+        display: grid;
+        grid-template-columns: 3fr 2fr;
+        gap: 32px;
+        align-items: center;
+        overflow: hidden;
+      }
+      .ink-blob {
+        position: absolute;
+        mix-blend-mode: multiply;
+        filter: contrast(1.05) saturate(1.1);
+        pointer-events: none;
+      }
+      .b-pink {
+        top: -60px;
+        left: -40px;
+        width: 320px;
+        height: 320px;
+        border-radius: 50%;
+        background: radial-gradient(
+          circle at 30% 30%,
+          var(--flu-pink) 0%,
+          var(--flu-pink) 55%,
+          transparent 70%
+        );
+        opacity: 0.85;
+      }
+      .b-blue {
+        top: 40px;
+        right: -40px;
+        width: 260px;
+        height: 260px;
+        background: var(--fed-blue);
+        clip-path: polygon(0 20%, 80% 0, 100% 60%, 65% 100%, 0 95%);
+        opacity: 0.8;
+      }
+      .b-yellow {
+        bottom: -40px;
+        left: 20%;
+        width: 200px;
+        height: 200px;
+        background: var(--sun-yel);
+        border-radius: 50%;
+        opacity: 0.85;
+      }
+      .overprint-label {
+        display: inline-block;
+        background: var(--sun-yel);
+        color: var(--ink);
+        padding: 4px 12px;
+        font-weight: 700;
+        letter-spacing: 0.2em;
+        font-size: 12px;
+        mix-blend-mode: multiply;
+        margin-bottom: 14px;
+        transform: translateX(2px) translateY(1px);
+        box-shadow: -2px -1px 0 var(--flu-pink);
+      }
+      h1 {
+        font-size: clamp(48px, 8vw, 104px);
+        font-weight: 900;
+        letter-spacing: -0.04em;
+        line-height: 0.9;
+        margin: 0 0 18px;
+        position: relative;
+      }
+      h1 .shadow {
+        position: absolute;
+        top: 4px;
+        left: 4px;
+        color: var(--flu-pink);
+        z-index: -1;
+        mix-blend-mode: multiply;
+      }
+      h1 .front {
+        position: relative;
+        color: var(--ink);
+      }
+      .hero p {
+        font-size: 19px;
+        max-width: 48ch;
+        position: relative;
+      }
+      .cta {
+        display: inline-block;
+        padding: 14px 22px;
+        background: var(--fed-blue);
+        color: var(--paper);
+        text-decoration: none;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        margin-top: 10px;
+        box-shadow: 5px 5px 0 var(--flu-pink);
+        mix-blend-mode: multiply;
+      }
+      .cta:hover {
+        box-shadow: 2px 2px 0 var(--flu-pink);
+        transform: translate(3px, 3px);
+      }
+      .print-info {
+        position: relative;
+        font-family: ui-monospace, Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        padding: 10px 0;
+        border-top: 1.5px solid var(--ink);
+        border-bottom: 1.5px solid var(--ink);
+        display: flex;
+        justify-content: space-between;
+        text-transform: uppercase;
+        margin-bottom: 40px;
+      }
+      .feat {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin-bottom: 40px;
+      }
+      .tile {
+        border: 2px solid var(--ink);
+        padding: 22px;
+        background: var(--paper);
+        position: relative;
+        overflow: hidden;
+      }
+      .tile::before {
+        content: "";
+        position: absolute;
+        width: 160px;
+        height: 160px;
+        border-radius: 50%;
+        top: -60px;
+        right: -60px;
+        mix-blend-mode: multiply;
+        opacity: 0.85;
+      }
+      .tile:nth-child(1)::before {
+        background: var(--flu-pink);
+      }
+      .tile:nth-child(2)::before {
+        background: var(--fed-blue);
+      }
+      .tile:nth-child(3)::before {
+        background: var(--sun-yel);
+      }
+      .tile .num {
+        font-family: ui-monospace, Menlo, monospace;
+        font-size: 12px;
+        letter-spacing: 0.2em;
+        color: var(--ink);
+      }
+      .tile h3 {
+        font-size: 30px;
+        margin: 6px 0 8px;
+        letter-spacing: -0.02em;
+        line-height: 1;
+      }
+      .tile p {
+        margin: 0;
+        font-size: 15px;
+      }
+      .prose {
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 32px;
+        padding: 32px 0;
+        border-top: 3px solid var(--ink);
+        border-bottom: 3px solid var(--ink);
+        margin-bottom: 40px;
+      }
+      .prose h2 {
+        font-size: 44px;
+        line-height: 0.95;
+        margin: 0;
+        letter-spacing: -0.03em;
+      }
+      .prose h2 em {
+        font-style: normal;
+        color: var(--fed-blue);
+        mix-blend-mode: multiply;
+      }
+      .prose p {
+        margin: 0 0 12px;
+      }
+      .chips {
+        margin-top: 14px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      .chip {
+        padding: 3px 10px;
+        border: 1.5px solid var(--ink);
+        font-weight: 600;
+        font-size: 13px;
+        background: var(--paper);
+      }
+      .chip:nth-child(3n) {
+        background: var(--flu-pink);
+        mix-blend-mode: multiply;
+      }
+      .chip:nth-child(4n) {
+        background: var(--sun-yel);
+        mix-blend-mode: multiply;
+      }
+      .chip:nth-child(5n) {
+        background: var(--fed-blue);
+        color: var(--paper);
+        mix-blend-mode: multiply;
+      }
+      .reg-marks {
+        position: absolute;
+        width: 22px;
+        height: 22px;
+        border: 1.5px solid var(--ink);
+        border-radius: 50%;
+      }
+      .reg-marks::before,
+      .reg-marks::after {
+        content: "";
+        position: absolute;
+        background: var(--ink);
+      }
+      .reg-marks::before {
+        left: 50%;
+        top: -6px;
+        bottom: -6px;
+        width: 1.5px;
+        transform: translateX(-50%);
+      }
+      .reg-marks::after {
+        top: 50%;
+        left: -6px;
+        right: -6px;
+        height: 1.5px;
+        transform: translateY(-50%);
+      }
+      .rm-tl {
+        top: 10px;
+        left: 10px;
+      }
+      .rm-tr {
+        top: 10px;
+        right: 10px;
+      }
+      .rm-bl {
+        bottom: 10px;
+        left: 10px;
+      }
+      .rm-br {
+        bottom: 10px;
+        right: 10px;
+      }
+      footer {
+        font-family: ui-monospace, Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        text-align: center;
+        color: var(--ink);
+        padding: 12px 0 40px;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .feat,
+        .prose {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <span class="reg-marks rm-tl"></span>
+      <span class="reg-marks rm-tr"></span>
+      <span class="reg-marks rm-bl"></span>
+      <span class="reg-marks rm-br"></span>
+      <nav>
+        <div class="brand"><span class="dot"></span>Code Self Study</div>
+        <ul>
+          <li><a href="#">Events</a></li>
+          <li><a href="#">Learn</a></li>
+          <li><a href="#">Forum</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">About</a></li>
+        </ul>
+      </nav>
+
+      <section class="hero">
+        <div class="ink-blob b-pink"></div>
+        <div class="ink-blob b-blue"></div>
+        <div class="ink-blob b-yellow"></div>
+        <div style="position: relative">
+          <span class="overprint-label">Issue No. 12 / Bay Area</span>
+          <h1>
+            <span class="shadow">STUDY CODE</span>
+            <span class="front">STUDY CODE</span>
+          </h1>
+          <p>
+            A friendly programming community of 5,000+ members in Berkeley and
+            the San Francisco Bay Area. Every language, every level. Self-study
+            with mentorship, since 2014.
+          </p>
+          <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+            >Join the Community →</a
+          >
+        </div>
+        <div></div>
+      </section>
+
+      <div class="print-info">
+        <span>2-color riso · pink + blue · 128gsm</span>
+        <span>printed in berkeley · run of 5247</span>
+      </div>
+
+      <section class="feat">
+        <div class="tile">
+          <div class="num">№ 01</div>
+          <h3>Community</h3>
+          <p>
+            Show up, meet programmers who keep showing up, leave less alone.
+          </p>
+        </div>
+        <div class="tile">
+          <div class="num">№ 02</div>
+          <h3>Mentorship</h3>
+          <p>
+            Experienced members help beginners &mdash; questions, plans, code
+            reviews.
+          </p>
+        </div>
+        <div class="tile">
+          <div class="num">№ 03</div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions inside the group.
+          </p>
+        </div>
+      </section>
+
+      <section class="prose">
+        <h2>Every <em>language.</em><br />Every level.</h2>
+        <div>
+          <p>
+            Dozens of groups teach people to code. We instead build a local
+            community of friendly, motivated programmers. The format is
+            self-study with mentorship &mdash; no curriculum, no gatekeeping.
+          </p>
+          <p>
+            Come as a self-directed bootcamp supplement or alternative.
+            Experienced programmers offer project-based mentorship.
+          </p>
+          <div class="chips">
+            <span class="chip">Python</span><span class="chip">JavaScript</span
+            ><span class="chip">TypeScript</span><span class="chip">Go</span
+            ><span class="chip">Rust</span><span class="chip">Haskell</span
+            ><span class="chip">Clojure</span><span class="chip">Elixir</span
+            ><span class="chip">Racket</span><span class="chip">Scala</span
+            ><span class="chip">Ruby</span><span class="chip">C++</span
+            ><span class="chip">SQL</span>
+          </div>
+        </div>
+      </section>
+      <footer>© CODE SELF STUDY · PRINTED WITH SOY-BASED INK · BERKELEY</footer>
+    </div>
+  </body>
+</html>

--- a/mockups/13-arcade.html
+++ b/mockups/13-arcade.html
@@ -1,0 +1,412 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Arcade</title>
+    <style>
+      :root {
+        --bg: #0a0320;
+        --bg-2: #1a0840;
+        --fg: #fef6ff;
+        --yellow: #fde047;
+        --pink: #ff3ea5;
+        --cyan: #22f0ff;
+        --green: #3cff7a;
+        --purple: #9945ff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: "Press Start 2P", "VT323", ui-monospace, Menlo, monospace;
+        line-height: 1.6;
+        font-size: 14px;
+        min-height: 100vh;
+        background-image:
+          linear-gradient(
+            to bottom,
+            var(--bg) 0%,
+            var(--bg-2) 50%,
+            #2e0a5f 100%
+          ),
+          repeating-linear-gradient(
+            0deg,
+            rgba(0, 0, 0, 0.25) 0 2px,
+            transparent 2px 4px
+          );
+        background-blend-mode: normal, overlay;
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        background: radial-gradient(
+          ellipse at 50% 100%,
+          rgba(153, 69, 255, 0.35),
+          transparent 60%
+        );
+      }
+      .cabinet {
+        max-width: 960px;
+        margin: 20px auto;
+        padding: 24px;
+      }
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 10px 0;
+        border-bottom: 4px solid var(--yellow);
+        margin-bottom: 30px;
+      }
+      .brand {
+        color: var(--yellow);
+        font-weight: 700;
+        letter-spacing: 2px;
+        font-size: 16px;
+        text-shadow: 3px 3px 0 var(--pink);
+      }
+      nav ul {
+        display: flex;
+        list-style: none;
+        gap: 16px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        color: var(--cyan);
+        text-decoration: none;
+        font-size: 10px;
+        letter-spacing: 2px;
+      }
+      nav a:hover {
+        color: var(--yellow);
+      }
+      .title {
+        text-align: center;
+        margin: 20px 0 40px;
+      }
+      .high-score {
+        color: var(--cyan);
+        font-size: 10px;
+        letter-spacing: 4px;
+        margin-bottom: 12px;
+      }
+      h1 {
+        font-size: clamp(28px, 5vw, 48px);
+        letter-spacing: 4px;
+        line-height: 1.3;
+        color: var(--yellow);
+        text-shadow:
+          0 0 8px var(--yellow),
+          4px 4px 0 var(--pink),
+          8px 8px 0 var(--purple);
+        margin: 0;
+      }
+      .subtitle {
+        color: var(--green);
+        font-size: 11px;
+        letter-spacing: 3px;
+        margin-top: 20px;
+      }
+      .blink {
+        animation: blink 0.8s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          visibility: hidden;
+        }
+      }
+      .sprites {
+        display: flex;
+        gap: 12px;
+        justify-content: center;
+        margin: 30px 0;
+      }
+      .sprite {
+        width: 48px;
+        height: 48px;
+      }
+      .sprite > div {
+        width: 100%;
+        height: 100%;
+      }
+      .ghost {
+        width: 48px;
+        height: 48px;
+        background:
+          radial-gradient(circle at 12px 14px, #fff 0 5px, transparent 6px),
+          radial-gradient(circle at 32px 14px, #fff 0 5px, transparent 6px),
+          radial-gradient(circle at 14px 16px, #000 0 2px, transparent 3px),
+          radial-gradient(circle at 34px 16px, #000 0 2px, transparent 3px);
+        background-color: var(--pink);
+        clip-path: polygon(
+          0% 30%,
+          50% 0%,
+          100% 30%,
+          100% 100%,
+          85% 85%,
+          70% 100%,
+          50% 85%,
+          30% 100%,
+          15% 85%,
+          0% 100%
+        );
+      }
+      .ghost.g2 {
+        background-color: var(--cyan);
+      }
+      .ghost.g3 {
+        background-color: var(--green);
+      }
+      .ghost.g4 {
+        background-color: var(--yellow);
+      }
+      .pac {
+        width: 48px;
+        height: 48px;
+        background: var(--yellow);
+        border-radius: 50%;
+        clip-path: polygon(100% 0, 50% 50%, 100% 100%, 0 100%, 0 0);
+      }
+      .cta {
+        display: inline-block;
+        background: var(--yellow);
+        color: var(--bg);
+        padding: 16px 28px;
+        text-decoration: none;
+        font-weight: 700;
+        letter-spacing: 3px;
+        font-size: 14px;
+        margin-top: 20px;
+        border: 4px solid var(--fg);
+        box-shadow:
+          6px 6px 0 var(--pink),
+          6px 6px 0 6px var(--fg);
+      }
+      .cta:hover {
+        transform: translate(3px, 3px);
+        box-shadow:
+          3px 3px 0 var(--pink),
+          3px 3px 0 3px var(--fg);
+      }
+      .stats-bar {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 14px;
+        margin: 50px 0 30px;
+      }
+      .stat {
+        border: 3px solid var(--cyan);
+        background: rgba(34, 240, 255, 0.08);
+        padding: 16px;
+        text-align: center;
+      }
+      .stat .label {
+        color: var(--cyan);
+        font-size: 9px;
+        letter-spacing: 2px;
+        margin-bottom: 8px;
+      }
+      .stat .value {
+        color: var(--yellow);
+        font-size: 24px;
+        letter-spacing: 2px;
+        text-shadow: 2px 2px 0 var(--pink);
+      }
+      .levels {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 14px;
+        margin: 30px 0;
+      }
+      .level {
+        border: 3px solid var(--fg);
+        padding: 18px;
+        background: rgba(255, 255, 255, 0.04);
+        position: relative;
+      }
+      .level .lv {
+        position: absolute;
+        top: -14px;
+        left: 12px;
+        background: var(--bg);
+        color: var(--green);
+        padding: 0 6px;
+        font-size: 10px;
+        letter-spacing: 2px;
+      }
+      .level h3 {
+        color: var(--yellow);
+        font-size: 14px;
+        letter-spacing: 2px;
+        margin: 6px 0 10px;
+      }
+      .level p {
+        color: var(--fg);
+        font-size: 11px;
+        line-height: 1.7;
+        letter-spacing: 1px;
+        margin: 0;
+      }
+      .big-box {
+        border: 4px solid var(--pink);
+        padding: 28px;
+        margin-top: 30px;
+        box-shadow: 0 0 30px rgba(255, 62, 165, 0.4);
+      }
+      .big-box h2 {
+        color: var(--pink);
+        font-size: 20px;
+        letter-spacing: 3px;
+        margin: 0 0 14px;
+        text-shadow: 2px 2px 0 var(--cyan);
+      }
+      .big-box p {
+        font-size: 12px;
+        line-height: 1.9;
+        letter-spacing: 1px;
+      }
+      .powerups {
+        margin-top: 16px;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 6px;
+      }
+      .pu {
+        border: 2px dashed var(--green);
+        padding: 6px 8px;
+        font-size: 10px;
+        letter-spacing: 1px;
+        color: var(--green);
+        text-align: center;
+      }
+      .pu:nth-child(3n) {
+        border-color: var(--yellow);
+        color: var(--yellow);
+      }
+      .pu:nth-child(4n) {
+        border-color: var(--pink);
+        color: var(--pink);
+      }
+      footer {
+        margin-top: 40px;
+        padding: 16px 0;
+        text-align: center;
+        color: var(--cyan);
+        font-size: 10px;
+        letter-spacing: 2px;
+        border-top: 3px dashed var(--cyan);
+      }
+      @media (max-width: 700px) {
+        .stats-bar,
+        .levels {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="cabinet">
+      <nav>
+        <div class="brand">★ CSS ARCADE</div>
+        <ul>
+          <li><a href="#">EVENTS</a></li>
+          <li><a href="#">LEARN</a></li>
+          <li><a href="#">FORUM</a></li>
+          <li><a href="#">JOBS</a></li>
+          <li><a href="#">PUZZLES</a></li>
+        </ul>
+      </nav>
+
+      <div class="title">
+        <div class="high-score">
+          HIGH · SCORE · 5,247 · MEMBERS · EST · 2014
+        </div>
+        <h1>CODE<br />SELF<br />STUDY</h1>
+        <div class="sprites">
+          <div class="sprite"><div class="pac"></div></div>
+          <div class="sprite"><div class="ghost"></div></div>
+          <div class="sprite"><div class="ghost g2"></div></div>
+          <div class="sprite"><div class="ghost g3"></div></div>
+          <div class="sprite"><div class="ghost g4"></div></div>
+        </div>
+        <div class="subtitle">
+          <span class="blink">▶</span> INSERT COIN TO JOIN BAY AREA PROGRAMMERS
+          <span class="blink">◀</span>
+        </div>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >PRESS START</a
+        >
+      </div>
+
+      <div class="stats-bar">
+        <div class="stat">
+          <div class="label">PLAYERS</div>
+          <div class="value">5000+</div>
+        </div>
+        <div class="stat">
+          <div class="label">LANGUAGES</div>
+          <div class="value">30+</div>
+        </div>
+        <div class="stat">
+          <div class="label">YEARS UP</div>
+          <div class="value">11</div>
+        </div>
+      </div>
+
+      <div class="levels">
+        <div class="level">
+          <span class="lv">LEVEL 01</span>
+          <h3>COMMUNITY</h3>
+          <p>Get out of your room. Meet players who keep showing up.</p>
+        </div>
+        <div class="level">
+          <span class="lv">LEVEL 02</span>
+          <h3>MENTORSHIP</h3>
+          <p>Experienced members help beginners. Ask for a study plan.</p>
+        </div>
+        <div class="level">
+          <span class="lv">LEVEL 03</span>
+          <h3>NETWORKING</h3>
+          <p>Members have landed jobs via intros inside the group.</p>
+        </div>
+      </div>
+
+      <div class="big-box">
+        <h2>▶ WHAT WE DO</h2>
+        <p>
+          Dozens of meetups teach you to code. We instead build a local
+          community of friendly, motivated programmers. Self-study with
+          mentorship. Every language welcome.
+        </p>
+        <div class="powerups">
+          <div class="pu">PY</div>
+          <div class="pu">JS</div>
+          <div class="pu">TS</div>
+          <div class="pu">GO</div>
+          <div class="pu">RUST</div>
+          <div class="pu">HASKELL</div>
+          <div class="pu">CLOJURE</div>
+          <div class="pu">ELIXIR</div>
+          <div class="pu">RACKET</div>
+          <div class="pu">RUBY</div>
+          <div class="pu">C++</div>
+          <div class="pu">SQL</div>
+        </div>
+      </div>
+
+      <footer>© 2014 CSS · 1 COIN · 1 PLAY · BERKELEY CA</footer>
+    </div>
+  </body>
+</html>

--- a/mockups/14-schematic.html
+++ b/mockups/14-schematic.html
@@ -1,0 +1,600 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Schematic</title>
+    <style>
+      :root {
+        --paper: #f4efe3;
+        --ink: #18201e;
+        --accent: #b23a2e;
+        --muted: #6d6a5d;
+        --rule: #2a2a24;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "IBM Plex Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+        font-size: 14px;
+        line-height: 1.55;
+        min-height: 100vh;
+        background-image:
+          linear-gradient(to right, rgba(0, 0, 0, 0.05) 1px, transparent 1px),
+          linear-gradient(to bottom, rgba(0, 0, 0, 0.05) 1px, transparent 1px);
+        background-size: 24px 24px;
+      }
+      .sheet {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .border {
+        border: 2px solid var(--ink);
+        padding: 20px;
+        position: relative;
+        background: transparent;
+      }
+      .border::before,
+      .border::after {
+        content: "";
+        position: absolute;
+        border: 1px solid var(--ink);
+      }
+      .border::before {
+        inset: 6px;
+      }
+      .title-block {
+        display: grid;
+        grid-template-columns: 3fr 1fr 1fr 1fr;
+        border: 2px solid var(--ink);
+        margin-bottom: 16px;
+      }
+      .title-block > div {
+        padding: 10px 14px;
+        border-right: 1px solid var(--ink);
+      }
+      .title-block > div:last-child {
+        border-right: none;
+      }
+      .title-block .label {
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin-bottom: 2px;
+      }
+      .title-block .value {
+        font-weight: 700;
+        font-size: 14px;
+      }
+      .title-block h1 {
+        font-family: "IBM Plex Sans", "Inter", ui-sans-serif, sans-serif;
+        font-size: 32px;
+        margin: 0;
+        letter-spacing: -0.01em;
+      }
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+        font-size: 12px;
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 18px;
+        margin: 0;
+        padding: 0;
+      }
+      nav a {
+        color: var(--ink);
+        text-decoration: none;
+      }
+      nav a::before {
+        content: "[ ";
+        color: var(--accent);
+      }
+      nav a::after {
+        content: " ]";
+        color: var(--accent);
+      }
+      nav a:hover {
+        color: var(--accent);
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 14px;
+      }
+      .panel {
+        border: 2px solid var(--ink);
+        padding: 18px;
+        position: relative;
+      }
+      .panel .tag {
+        position: absolute;
+        top: -11px;
+        left: 12px;
+        background: var(--paper);
+        padding: 0 8px;
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--accent);
+      }
+      .hero-svg {
+        width: 100%;
+        height: 240px;
+      }
+      .hero-content {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+        align-items: center;
+      }
+      .hero-content h2 {
+        font-family: "IBM Plex Sans", "Inter", sans-serif;
+        font-size: 40px;
+        letter-spacing: -0.02em;
+        line-height: 1.05;
+        margin: 0 0 10px;
+      }
+      .hero-content p {
+        margin: 0 0 14px;
+      }
+      .cta {
+        display: inline-block;
+        border: 2px solid var(--ink);
+        padding: 8px 16px;
+        text-decoration: none;
+        color: var(--ink);
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        position: relative;
+        background: var(--paper);
+      }
+      .cta::after {
+        content: "";
+        position: absolute;
+        inset: 3px;
+        border: 1px solid var(--ink);
+        pointer-events: none;
+      }
+      .cta:hover {
+        background: var(--accent);
+        color: var(--paper);
+      }
+      .specs {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 14px;
+        margin-top: 14px;
+      }
+      .spec {
+        border: 2px solid var(--ink);
+        padding: 14px;
+        position: relative;
+      }
+      .spec .ref {
+        font-size: 10px;
+        color: var(--accent);
+        letter-spacing: 0.2em;
+      }
+      .spec h3 {
+        font-family: "IBM Plex Sans", "Inter", sans-serif;
+        font-size: 20px;
+        margin: 6px 0 8px;
+      }
+      .spec .dims {
+        font-size: 11px;
+        color: var(--muted);
+        border-top: 1px dashed var(--ink);
+        padding-top: 6px;
+        margin-top: 10px;
+        display: flex;
+        justify-content: space-between;
+      }
+      .bom {
+        margin-top: 14px;
+        border: 2px solid var(--ink);
+        padding: 14px;
+      }
+      .bom h3 {
+        margin: 0 0 10px;
+        font-family: "IBM Plex Sans", sans-serif;
+        font-size: 16px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 5px 10px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      th {
+        background: var(--ink);
+        color: var(--paper);
+        font-size: 11px;
+        letter-spacing: 0.15em;
+        text-transform: uppercase;
+      }
+      td.n {
+        color: var(--accent);
+        font-weight: 700;
+      }
+      .side {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+      }
+      .note {
+        border: 2px solid var(--ink);
+        padding: 14px;
+      }
+      .note h4 {
+        font-family: "IBM Plex Sans", sans-serif;
+        font-size: 14px;
+        margin: 0 0 8px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--accent);
+      }
+      .note p {
+        margin: 0 0 8px;
+        font-size: 13px;
+      }
+      .dim {
+        color: var(--muted);
+      }
+      footer {
+        margin-top: 20px;
+        border-top: 2px solid var(--ink);
+        padding-top: 10px;
+        display: flex;
+        justify-content: space-between;
+        font-size: 11px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+      @media (max-width: 820px) {
+        .grid,
+        .hero-content,
+        .specs,
+        .title-block {
+          grid-template-columns: 1fr;
+        }
+        .title-block > div {
+          border-right: none;
+          border-bottom: 1px solid var(--ink);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="sheet">
+      <nav>
+        <div><strong>CSS-DOC</strong> · Sheet 01 of 04</div>
+        <ul>
+          <li><a href="#">home</a></li>
+          <li><a href="#">events</a></li>
+          <li><a href="#">learn</a></li>
+          <li><a href="#">forum</a></li>
+          <li><a href="#">jobs</a></li>
+          <li><a href="#">about</a></li>
+        </ul>
+      </nav>
+
+      <div class="title-block">
+        <div>
+          <div class="label">System</div>
+          <h1>Code Self Study</h1>
+        </div>
+        <div>
+          <div class="label">Rev.</div>
+          <div class="value">v12.0</div>
+        </div>
+        <div>
+          <div class="label">Drawn</div>
+          <div class="value">BRK · 2014</div>
+        </div>
+        <div>
+          <div class="label">Scale</div>
+          <div class="value">1:1</div>
+        </div>
+      </div>
+
+      <div class="grid">
+        <div>
+          <div class="panel">
+            <span class="tag">Fig. 1 — Overview</span>
+            <div class="hero-content">
+              <div>
+                <h2>A Bay Area programming community.</h2>
+                <p>
+                  5,000+ programmers in Berkeley and the SF Bay Area. All
+                  languages, all levels, self-study with mentorship.
+                </p>
+                <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+                  >Join ∙ Enlist ∙ Commit</a
+                >
+              </div>
+              <div>
+                <svg class="hero-svg" viewBox="0 0 300 240">
+                  <g
+                    stroke="#18201e"
+                    stroke-width="1.5"
+                    fill="none"
+                    stroke-linecap="round"
+                  >
+                    <!-- nodes -->
+                    <circle cx="60" cy="60" r="16" />
+                    <circle cx="150" cy="30" r="16" />
+                    <circle cx="240" cy="60" r="16" />
+                    <circle cx="150" cy="120" r="22" fill="#b23a2e" />
+                    <circle cx="60" cy="190" r="16" />
+                    <circle cx="150" cy="210" r="16" />
+                    <circle cx="240" cy="190" r="16" />
+                    <!-- edges -->
+                    <line x1="60" y1="60" x2="150" y2="120" />
+                    <line x1="150" y1="30" x2="150" y2="120" />
+                    <line x1="240" y1="60" x2="150" y2="120" />
+                    <line x1="60" y1="190" x2="150" y2="120" />
+                    <line x1="150" y1="210" x2="150" y2="120" />
+                    <line x1="240" y1="190" x2="150" y2="120" />
+                    <!-- labels -->
+                    <text
+                      x="60"
+                      y="64"
+                      text-anchor="middle"
+                      font-size="10"
+                      font-family="IBM Plex Mono, monospace"
+                      fill="#18201e"
+                    >
+                      PY
+                    </text>
+                    <text
+                      x="150"
+                      y="34"
+                      text-anchor="middle"
+                      font-size="10"
+                      font-family="IBM Plex Mono, monospace"
+                      fill="#18201e"
+                    >
+                      JS
+                    </text>
+                    <text
+                      x="240"
+                      y="64"
+                      text-anchor="middle"
+                      font-size="10"
+                      font-family="IBM Plex Mono, monospace"
+                      fill="#18201e"
+                    >
+                      GO
+                    </text>
+                    <text
+                      x="150"
+                      y="125"
+                      text-anchor="middle"
+                      font-size="11"
+                      font-family="IBM Plex Mono, monospace"
+                      fill="#f4efe3"
+                      font-weight="bold"
+                    >
+                      CSS
+                    </text>
+                    <text
+                      x="60"
+                      y="194"
+                      text-anchor="middle"
+                      font-size="10"
+                      font-family="IBM Plex Mono, monospace"
+                      fill="#18201e"
+                    >
+                      RS
+                    </text>
+                    <text
+                      x="150"
+                      y="214"
+                      text-anchor="middle"
+                      font-size="10"
+                      font-family="IBM Plex Mono, monospace"
+                      fill="#18201e"
+                    >
+                      HS
+                    </text>
+                    <text
+                      x="240"
+                      y="194"
+                      text-anchor="middle"
+                      font-size="10"
+                      font-family="IBM Plex Mono, monospace"
+                      fill="#18201e"
+                    >
+                      CLJ
+                    </text>
+                    <!-- dims -->
+                    <line
+                      x1="10"
+                      y1="10"
+                      x2="10"
+                      y2="230"
+                      stroke-dasharray="2 3"
+                    />
+                    <line
+                      x1="10"
+                      y1="10"
+                      x2="290"
+                      y2="10"
+                      stroke-dasharray="2 3"
+                    />
+                    <text
+                      x="4"
+                      y="125"
+                      font-size="9"
+                      font-family="IBM Plex Mono, monospace"
+                      fill="#6d6a5d"
+                      transform="rotate(-90 4 125)"
+                    >
+                      BAY AREA
+                    </text>
+                  </g>
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          <div class="specs">
+            <div class="spec">
+              <span class="ref">REF A1 — Ø community</span>
+              <h3>Community</h3>
+              <p>
+                Get out of your room. Meet programmers who keep showing up week
+                after week.
+              </p>
+              <div class="dims">
+                <span>tol: ±0.0</span>
+                <span>weekly</span>
+              </div>
+            </div>
+            <div class="spec">
+              <span class="ref">REF A2 — Ø mentorship</span>
+              <h3>Mentorship</h3>
+              <p>
+                Experienced members help beginners. Ask for a study plan or
+                project review.
+              </p>
+              <div class="dims">
+                <span>tol: friendly</span>
+                <span>on-site</span>
+              </div>
+            </div>
+            <div class="spec">
+              <span class="ref">REF A3 — Ø networking</span>
+              <h3>Networking</h3>
+              <p>
+                Members have landed jobs through introductions and tips inside
+                the group.
+              </p>
+              <div class="dims">
+                <span>finish: human</span>
+                <span>ongoing</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="bom">
+            <h3>Bill of Materials &mdash; languages in circulation</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Language</th>
+                  <th>Paradigm</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="n">01</td>
+                  <td>Python</td>
+                  <td>Multi-paradigm</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td class="n">02</td>
+                  <td>TypeScript</td>
+                  <td>Structural</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td class="n">03</td>
+                  <td>Rust</td>
+                  <td>Systems</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td class="n">04</td>
+                  <td>Go</td>
+                  <td>Imperative</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td class="n">05</td>
+                  <td>Haskell</td>
+                  <td>Functional</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td class="n">06</td>
+                  <td>Clojure</td>
+                  <td>Lisp</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td class="n">…</td>
+                  <td>+ 25 more</td>
+                  <td>see forum</td>
+                  <td>Rotating</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <aside class="side">
+          <div class="note">
+            <h4>Notes</h4>
+            <p>1. Format is self-study with advice from experienced members.</p>
+            <p>2. No curriculum. No gatekeeping.</p>
+            <p>3. Suitable as bootcamp supplement or standalone.</p>
+            <p class="dim">Revised: quarterly</p>
+          </div>
+          <div class="note">
+            <h4>Dimensions</h4>
+            <p>
+              <strong>Members:</strong> 5,247 <span class="dim">(±50)</span
+              ><br />
+              <strong>Founded:</strong> 2014<br />
+              <strong>Location:</strong> Berkeley, CA<br />
+              <strong>Languages:</strong> 30+<br />
+              <strong>Cadence:</strong> Weekly
+            </p>
+          </div>
+          <div class="note">
+            <h4>Warning</h4>
+            <p class="dim">
+              Some members may form lasting friendships and receive unsolicited
+              job offers. Handle with enthusiasm.
+            </p>
+          </div>
+        </aside>
+      </div>
+
+      <footer>
+        <span>Drawing No. CSS-0001</span>
+        <span>Unless noted, all tolerances in friendship units</span>
+        <span>Sheet 1/4</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/mockups/15-newspaper.html
+++ b/mockups/15-newspaper.html
@@ -1,0 +1,464 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Newspaper</title>
+    <style>
+      :root {
+        --paper: #eae2d0;
+        --ink: #1a1814;
+        --muted: #4a463d;
+        --rule: #1a1814;
+        --accent: #8a1313;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: "Times New Roman", "Times", Georgia, serif;
+        line-height: 1.35;
+        font-size: 14px;
+        min-height: 100vh;
+        background-image: radial-gradient(
+          rgba(0, 0, 0, 0.08) 1px,
+          transparent 1px
+        );
+        background-size: 2px 2px;
+      }
+      .edition {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 18px 28px;
+      }
+      .masthead {
+        border-top: 3px solid var(--ink);
+        border-bottom: 5px double var(--ink);
+        padding: 16px 0 10px;
+        text-align: center;
+      }
+      .masthead .meta-row {
+        font-size: 11px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--ink);
+        margin-bottom: 8px;
+      }
+      h1.paper-name {
+        font-family:
+          "UnifrakturMaguntia", "Old English Text MT", "Blackletter",
+          "Times New Roman", serif;
+        font-size: clamp(56px, 10vw, 130px);
+        margin: 0;
+        letter-spacing: 0.02em;
+        font-weight: 400;
+        line-height: 1;
+      }
+      .motto {
+        font-style: italic;
+        font-size: 14px;
+        margin-top: 6px;
+        color: var(--muted);
+      }
+      .sub-meta {
+        display: flex;
+        justify-content: space-between;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        border-top: 1px solid var(--ink);
+        padding-top: 8px;
+        margin-top: 8px;
+      }
+      nav {
+        border-bottom: 3px double var(--ink);
+        padding: 6px 0;
+        display: flex;
+        justify-content: center;
+        gap: 22px;
+        flex-wrap: wrap;
+        font-size: 12px;
+        font-variant: small-caps;
+        letter-spacing: 0.2em;
+      }
+      nav a {
+        color: var(--ink);
+        text-decoration: none;
+      }
+      nav a:hover {
+        color: var(--accent);
+      }
+      .front {
+        display: grid;
+        grid-template-columns: 1fr 2.2fr 1fr;
+        gap: 20px;
+        padding: 20px 0;
+        border-bottom: 3px double var(--ink);
+      }
+      .col {
+        border-right: 1px solid var(--ink);
+        padding-right: 20px;
+      }
+      .col:last-child {
+        border-right: none;
+        padding-right: 0;
+      }
+      .col-left h3,
+      .col-right h3 {
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.15em;
+        border-bottom: 1px solid var(--ink);
+        padding-bottom: 4px;
+        margin: 14px 0 6px;
+      }
+      .col-left h3:first-child,
+      .col-right h3:first-child {
+        margin-top: 0;
+      }
+      .col p {
+        margin: 0 0 10px;
+        font-size: 13px;
+        line-height: 1.5;
+      }
+      .kicker {
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--accent);
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .lead h2 {
+        font-family: "Playfair Display", "Didot", "Times New Roman", serif;
+        font-size: clamp(40px, 5vw, 68px);
+        line-height: 1;
+        margin: 4px 0 10px;
+        letter-spacing: -0.01em;
+        font-weight: 900;
+      }
+      .byline {
+        font-size: 12px;
+        border-top: 1px solid var(--ink);
+        border-bottom: 1px solid var(--ink);
+        padding: 4px 0;
+        margin-bottom: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+      }
+      .lead-body {
+        columns: 2;
+        column-gap: 16px;
+        column-rule: 1px solid var(--ink);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lead-body p:first-child::first-letter {
+        font-family: "Playfair Display", "Didot", serif;
+        font-size: 56px;
+        float: left;
+        line-height: 0.9;
+        padding: 6px 8px 0 0;
+      }
+      .pullquote {
+        font-family: "Playfair Display", "Didot", serif;
+        font-style: italic;
+        font-size: 20px;
+        line-height: 1.25;
+        border-top: 3px solid var(--ink);
+        border-bottom: 3px solid var(--ink);
+        padding: 10px 0;
+        margin: 12px 0;
+        text-align: center;
+      }
+      .stats {
+        text-align: center;
+        padding: 8px 0;
+        border: 1px solid var(--ink);
+        margin-top: 12px;
+      }
+      .stats .big {
+        font-family: "Playfair Display", serif;
+        font-size: 44px;
+        font-weight: 900;
+        line-height: 1;
+      }
+      .stats .lbl {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.15em;
+      }
+      .ad {
+        border: 3px double var(--ink);
+        padding: 10px;
+        margin-bottom: 14px;
+        text-align: center;
+      }
+      .ad h4 {
+        font-family: "Playfair Display", serif;
+        font-size: 20px;
+        margin: 4px 0;
+      }
+      .ad .cta-link {
+        display: inline-block;
+        border: 2px solid var(--ink);
+        padding: 5px 10px;
+        margin-top: 6px;
+        color: var(--ink);
+        text-decoration: none;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.15em;
+        font-weight: 700;
+      }
+      .ad .cta-link:hover {
+        background: var(--ink);
+        color: var(--paper);
+      }
+      .halftone {
+        width: 100%;
+        height: 120px;
+        background:
+          radial-gradient(circle, var(--ink) 1.5px, transparent 1.6px) 0 0 / 6px
+            6px,
+          radial-gradient(circle, var(--ink) 1px, transparent 1.1px) 3px 3px /
+            6px 6px;
+        mix-blend-mode: multiply;
+        opacity: 0.85;
+        margin-bottom: 6px;
+        mask: linear-gradient(
+          135deg,
+          black 40%,
+          rgba(0, 0, 0, 0.3) 70%,
+          transparent
+        );
+      }
+      .classifieds {
+        padding: 18px 0;
+        border-bottom: 3px double var(--ink);
+      }
+      .classifieds h3 {
+        text-align: center;
+        font-family: "Playfair Display", serif;
+        font-size: 28px;
+        margin: 0 0 10px;
+        border-bottom: 1px solid var(--ink);
+        padding-bottom: 4px;
+      }
+      .classifieds-body {
+        columns: 4;
+        column-gap: 14px;
+        column-rule: 1px solid var(--ink);
+        font-size: 12px;
+        line-height: 1.5;
+      }
+      .classifieds-body p {
+        margin: 0 0 6px;
+        break-inside: avoid;
+      }
+      .classifieds-body strong {
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      footer {
+        padding: 10px 0;
+        text-align: center;
+        font-size: 11px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+      @media (max-width: 820px) {
+        .front {
+          grid-template-columns: 1fr;
+        }
+        .col {
+          border-right: none;
+          padding-right: 0;
+          border-bottom: 1px solid var(--ink);
+          padding-bottom: 14px;
+        }
+        .lead-body,
+        .classifieds-body {
+          columns: 1;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="edition">
+      <header class="masthead">
+        <div class="meta-row">
+          <span>Vol. XII · No. 247</span>
+          <span>Berkeley, California</span>
+          <span>Saturday Edition · 25¢</span>
+        </div>
+        <h1 class="paper-name">The Self Study Times</h1>
+        <div class="motto">
+          &ldquo;All the code that's fit to read&rdquo; &mdash; est. 2014
+        </div>
+        <div class="sub-meta">
+          <span>Fair · 68°F</span>
+          <span>Meetup: Saturdays, 9 am</span>
+          <span>Free to members</span>
+        </div>
+      </header>
+
+      <nav>
+        <a href="#">Home</a><a href="#">Events</a><a href="#">Forum</a
+        ><a href="#">Learn</a><a href="#">Jobs</a><a href="#">Puzzles</a
+        ><a href="#">Tools</a><a href="#">About</a>
+      </nav>
+
+      <section class="front">
+        <aside class="col col-left">
+          <h3>In This Issue</h3>
+          <p>
+            <strong>A1 —</strong> The community turns another year; membership
+            crosses 5,000.
+          </p>
+          <p><strong>B2 —</strong> Weekly puzzle: shortest path, revisited.</p>
+          <p><strong>C3 —</strong> New jobs posted by members: six openings.</p>
+          <p>
+            <strong>D4 —</strong> Reading group begins
+            <em>Crafting Interpreters</em>.
+          </p>
+          <div class="stats">
+            <div class="big">5,247</div>
+            <div class="lbl">members &amp; counting</div>
+          </div>
+          <div class="stats" style="margin-top: 10px">
+            <div class="big">30+</div>
+            <div class="lbl">languages in rotation</div>
+          </div>
+        </aside>
+
+        <article class="col lead">
+          <div class="kicker">Local &middot; Programming</div>
+          <h2>Bay Area Programmers Meet, Quietly, And Get On With It.</h2>
+          <div class="byline">
+            By the Editors &middot; Filed from Berkeley, CA &middot; April
+          </div>
+          <div class="lead-body">
+            <p>
+              Code Self Study is a friendly programming community of more than
+              five thousand members in Berkeley and the San Francisco Bay Area.
+              The format is straightforward: members attend meetups, bring their
+              own projects and questions, and get help from the more experienced
+              regulars. No curriculum, no gatekeeping, no bootcamp pitch.
+            </p>
+            <p>
+              Every programming language is welcome. On any given week, one
+              table is working through a Rust borrow checker puzzle, another is
+              reviewing a Clojure web app, and someone at the end is
+              painstakingly printing <em>Hello, world</em> in Haskell for the
+              first time. The experienced members help the beginners. That is,
+              in short, the whole trick.
+            </p>
+            <div class="pullquote">
+              &ldquo;Show up, bring a question, leave with a friend.&rdquo;
+            </div>
+            <p>
+              The group has run continuously since 2014. Many members have
+              landed jobs through introductions made here &mdash; often after
+              weeks or months of showing up and helping others with their code.
+              Networking, done the slow way.
+            </p>
+            <p>
+              Attend as a self-directed bootcamp supplement or alternative.
+              Experienced programmers offer mentorship on a project-based
+              approach to learning. Study plans available upon request.
+            </p>
+          </div>
+        </article>
+
+        <aside class="col col-right">
+          <div class="ad">
+            <div class="kicker">Enlist</div>
+            <h4>Join the Community</h4>
+            <div class="halftone"></div>
+            <p style="font-size: 12px; margin: 0 0 4px">
+              Meetup meets Saturdays in Berkeley. All languages. All levels. No
+              cover.
+            </p>
+            <a class="cta-link" href="https://www.meetup.com/codeselfstudy/"
+              >Join Now →</a
+            >
+          </div>
+          <h3>Editor's Picks</h3>
+          <p>
+            <strong>Forum —</strong> Ongoing reading groups for Haskell,
+            Clojure, and systems programming.
+          </p>
+          <p>
+            <strong>Puzzles —</strong> Weekly challenges, gently ranked, always
+            discussed afterward.
+          </p>
+          <p>
+            <strong>Tools —</strong> A curated index of editors, compilers, and
+            references.
+          </p>
+          <h3>Weather</h3>
+          <p>
+            Hacking index: <strong>High.</strong> Debugging forecast: cloudy
+            with scattered <code>undefined</code>.
+          </p>
+        </aside>
+      </section>
+
+      <section class="classifieds">
+        <h3>Classifieds &amp; Languages at Large</h3>
+        <div class="classifieds-body">
+          <p>
+            <strong>Python —</strong> Seeks patient reviewers for pandas-heavy
+            notebooks. Replies welcome.
+          </p>
+          <p>
+            <strong>TypeScript —</strong> New study group forming. Strict mode
+            preferred.
+          </p>
+          <p><strong>Go —</strong> Channels, goroutines. Bring lunch.</p>
+          <p>
+            <strong>Rust —</strong> Borrow checker lonely. Inquire at Saturday
+            meetup.
+          </p>
+          <p>
+            <strong>Haskell —</strong> Monads understood; will trade for cake.
+          </p>
+          <p>
+            <strong>Clojure —</strong> Paren-rich community seeks paren-poor
+            readers.
+          </p>
+          <p>
+            <strong>Elixir —</strong> OTP guild forming. Fault tolerance
+            included.
+          </p>
+          <p>
+            <strong>Racket —</strong> <em>Beautiful Racket</em> reading group
+            ongoing.
+          </p>
+          <p><strong>Ruby —</strong> Still DRY after all these years.</p>
+          <p><strong>Scala —</strong> Inquire for functional dog-walks.</p>
+          <p><strong>C++ —</strong> Move semantics explained, patiently.</p>
+          <p>
+            <strong>SQL —</strong> Query plans, not yours. Window functions a
+            specialty.
+          </p>
+        </div>
+      </section>
+
+      <footer>
+        © The Self Study Times · All reports filed with empathy · Berkeley
+      </footer>
+    </div>
+  </body>
+</html>

--- a/mockups/16-ledger.html
+++ b/mockups/16-ledger.html
@@ -1,0 +1,511 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Ledger &amp; Stamp</title>
+    <style>
+      :root {
+        --paper: #f0e4cc;
+        --paper-dark: #dfd0ad;
+        --ink: #231a10;
+        --faded: #6f5c3d;
+        --stamp: #7a1818;
+        --blue: #1e3a7c;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Cormorant Garamond", "Baskerville", "Book Antiqua", Georgia, serif;
+        font-size: 16px;
+        line-height: 1.5;
+        min-height: 100vh;
+        background-image:
+          radial-gradient(
+            circle at 20% 30%,
+            rgba(111, 92, 61, 0.15) 0,
+            transparent 6px
+          ),
+          radial-gradient(
+            circle at 80% 70%,
+            rgba(111, 92, 61, 0.15) 0,
+            transparent 8px
+          ),
+          radial-gradient(
+            circle at 50% 50%,
+            rgba(111, 92, 61, 0.12) 0,
+            transparent 10px
+          );
+        background-size:
+          120px 120px,
+          180px 180px,
+          240px 240px;
+      }
+      .book {
+        max-width: 960px;
+        margin: 24px auto;
+        background: var(--paper);
+        border: 1px solid var(--ink);
+        padding: 40px 48px;
+        box-shadow:
+          inset 0 0 60px rgba(60, 40, 10, 0.15),
+          8px 8px 0 rgba(0, 0, 0, 0.15);
+        position: relative;
+      }
+      .book::before {
+        content: "";
+        position: absolute;
+        inset: 6px;
+        border: 1px solid var(--ink);
+        pointer-events: none;
+      }
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding-bottom: 14px;
+        border-bottom: 1px solid var(--ink);
+        margin-bottom: 14px;
+        font-variant: small-caps;
+        letter-spacing: 0.12em;
+      }
+      .brand {
+        font-weight: 700;
+        font-size: 18px;
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 18px;
+        margin: 0;
+        padding: 0;
+        font-size: 14px;
+      }
+      nav a {
+        color: var(--ink);
+        text-decoration: none;
+      }
+      nav a:hover {
+        color: var(--stamp);
+      }
+      .header-row {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 24px;
+        align-items: start;
+        padding: 10px 0 20px;
+        border-bottom: 3px double var(--ink);
+      }
+      .slug {
+        font-variant: small-caps;
+        letter-spacing: 0.3em;
+        font-size: 12px;
+        color: var(--faded);
+      }
+      h1 {
+        font-family: inherit;
+        font-size: clamp(44px, 7vw, 84px);
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        line-height: 1;
+        margin: 6px 0;
+      }
+      h1 em {
+        font-family:
+          "Italianno", "Kaushan Script", "Snell Roundhand", "Brush Script MT",
+          cursive;
+        font-style: normal;
+        color: var(--stamp);
+        font-weight: 400;
+      }
+      .tagline {
+        font-style: italic;
+        color: var(--faded);
+        font-size: 17px;
+      }
+      .stamp {
+        border: 4px double var(--stamp);
+        color: var(--stamp);
+        padding: 12px 14px;
+        text-align: center;
+        transform: rotate(-6deg);
+        font-variant: small-caps;
+        letter-spacing: 0.2em;
+        font-weight: 700;
+        line-height: 1.2;
+        opacity: 0.85;
+        justify-self: end;
+        margin-top: 6px;
+        background:
+          radial-gradient(
+            circle at 20% 30%,
+            rgba(240, 228, 204, 0.5) 0 2px,
+            transparent 3px
+          ),
+          radial-gradient(
+            circle at 80% 70%,
+            rgba(240, 228, 204, 0.5) 0 2px,
+            transparent 3px
+          );
+      }
+      .stamp .big {
+        font-family: "Playfair Display", serif;
+        font-size: 22px;
+        letter-spacing: 0.15em;
+      }
+      .stamp .small {
+        font-size: 11px;
+        opacity: 0.8;
+      }
+      .intro {
+        display: grid;
+        grid-template-columns: 3fr 2fr;
+        gap: 32px;
+        padding: 24px 0;
+        border-bottom: 1px solid var(--ink);
+      }
+      .intro p {
+        font-size: 18px;
+        margin: 0 0 12px;
+      }
+      .intro p::first-letter {
+        font-family: "Italianno", "Brush Script MT", cursive;
+        font-size: 64px;
+        float: left;
+        line-height: 0.8;
+        padding: 10px 6px 0 0;
+        color: var(--stamp);
+      }
+      .cta {
+        display: inline-block;
+        border: 2px solid var(--ink);
+        padding: 10px 18px;
+        color: var(--ink);
+        text-decoration: none;
+        font-variant: small-caps;
+        letter-spacing: 0.25em;
+        font-weight: 700;
+        margin-top: 8px;
+        background: var(--paper);
+        position: relative;
+      }
+      .cta::after {
+        content: "";
+        position: absolute;
+        inset: 3px;
+        border: 1px solid var(--ink);
+      }
+      .cta:hover {
+        background: var(--ink);
+        color: var(--paper);
+      }
+      aside.receipt {
+        border: 1px solid var(--ink);
+        padding: 14px 16px;
+        background: var(--paper-dark);
+      }
+      aside.receipt h3 {
+        font-variant: small-caps;
+        letter-spacing: 0.2em;
+        font-size: 13px;
+        margin: 0 0 8px;
+        border-bottom: 1px solid var(--ink);
+        padding-bottom: 4px;
+      }
+      aside.receipt dl {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 4px 14px;
+        margin: 0;
+        font-size: 14px;
+      }
+      aside.receipt dt {
+        font-variant: small-caps;
+        letter-spacing: 0.15em;
+        color: var(--faded);
+      }
+      aside.receipt dd {
+        margin: 0;
+        text-align: right;
+      }
+      .ledger {
+        padding: 24px 0;
+        border-bottom: 3px double var(--ink);
+      }
+      .ledger h2 {
+        font-family: inherit;
+        font-size: 28px;
+        margin: 0 0 10px;
+        letter-spacing: -0.01em;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 15px;
+      }
+      thead th {
+        text-align: left;
+        font-variant: small-caps;
+        letter-spacing: 0.2em;
+        font-size: 12px;
+        border-bottom: 2px solid var(--ink);
+        padding: 6px 8px;
+      }
+      tbody td {
+        padding: 6px 8px;
+        border-bottom: 1px dotted var(--faded);
+      }
+      tbody tr:nth-child(even) {
+        background: rgba(111, 92, 61, 0.06);
+      }
+      tbody td.n {
+        font-variant: tabular-nums;
+        text-align: right;
+        color: var(--blue);
+        font-weight: 700;
+      }
+      tbody td.account {
+        font-style: italic;
+      }
+      .three {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin: 24px 0;
+      }
+      .entry {
+        border: 1px solid var(--ink);
+        padding: 16px;
+        position: relative;
+      }
+      .entry .dash {
+        font-family: "Italianno", cursive;
+        color: var(--stamp);
+        font-size: 28px;
+        line-height: 1;
+      }
+      .entry h3 {
+        margin: 4px 0 6px;
+        font-size: 22px;
+      }
+      .entry p {
+        margin: 0;
+        font-size: 15px;
+      }
+      .approved {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        border: 2px solid var(--stamp);
+        color: var(--stamp);
+        padding: 2px 6px;
+        font-variant: small-caps;
+        letter-spacing: 0.2em;
+        font-size: 10px;
+        transform: rotate(10deg);
+        opacity: 0.8;
+      }
+      .sign-off {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 20px;
+        padding: 14px 0 0;
+        font-size: 14px;
+      }
+      .sign-off .line {
+        border-top: 1px solid var(--ink);
+        padding-top: 4px;
+        font-variant: small-caps;
+        letter-spacing: 0.2em;
+        color: var(--faded);
+      }
+      .sig {
+        font-family: "Italianno", "Brush Script MT", cursive;
+        font-size: 36px;
+        color: var(--blue);
+        line-height: 1;
+      }
+      @media (max-width: 820px) {
+        .header-row,
+        .intro,
+        .three,
+        .sign-off {
+          grid-template-columns: 1fr;
+        }
+        .stamp {
+          justify-self: start;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="book">
+      <nav>
+        <div class="brand">Code Self Study &middot; Co.</div>
+        <ul>
+          <li><a href="#">Events</a></li>
+          <li><a href="#">Ledger</a></li>
+          <li><a href="#">Forum</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">About</a></li>
+        </ul>
+      </nav>
+
+      <header class="header-row">
+        <div>
+          <div class="slug">Established Anno 2014 &middot; Berkeley, Cal.</div>
+          <h1>Code<br />Self&nbsp;<em>Study</em></h1>
+          <div class="tagline">
+            A society for the mutual improvement of programmers.
+          </div>
+        </div>
+        <div class="stamp">
+          <div class="small">— approved —</div>
+          <div class="big">Chartered</div>
+          <div class="small">No. 5247</div>
+        </div>
+      </header>
+
+      <section class="intro">
+        <div>
+          <p>
+            A friendly programming community of more than five thousand members
+            in Berkeley and the San Francisco Bay Area. All languages, all
+            levels of experience; all welcome. The format is self-study with
+            mentorship &mdash; bring a laptop and a question, and take your seat
+            at the table.
+          </p>
+          <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+            >Sign the Register →</a
+          >
+        </div>
+        <aside class="receipt">
+          <h3>Particulars</h3>
+          <dl>
+            <dt>Members</dt>
+            <dd>5,247</dd>
+            <dt>Chartered</dt>
+            <dd>2014</dd>
+            <dt>Seat</dt>
+            <dd>Berkeley</dd>
+            <dt>Sessions</dt>
+            <dd>Weekly</dd>
+            <dt>Dues</dt>
+            <dd>None</dd>
+            <dt>Cover</dt>
+            <dd>Nil</dd>
+          </dl>
+        </aside>
+      </section>
+
+      <section class="three">
+        <div class="entry">
+          <span class="approved">Approved</span>
+          <div class="dash">~</div>
+          <h3>Community</h3>
+          <p>
+            Attend our sessions; meet programmers who keep showing up. Make
+            acquaintances of lasting utility.
+          </p>
+        </div>
+        <div class="entry">
+          <span class="approved">Approved</span>
+          <div class="dash">~</div>
+          <h3>Mentorship</h3>
+          <p>
+            Experienced members attend to beginners. Study plans and project
+            reviews furnished on request.
+          </p>
+        </div>
+        <div class="entry">
+          <span class="approved">Approved</span>
+          <div class="dash">~</div>
+          <h3>Networking</h3>
+          <p>
+            Many members have secured employment by way of introductions made at
+            this society.
+          </p>
+        </div>
+      </section>
+
+      <section class="ledger">
+        <h2>Ledger of Languages in Good Standing</h2>
+        <table>
+          <thead>
+            <tr>
+              <th style="width: 40px">№</th>
+              <th>Language</th>
+              <th>Family</th>
+              <th style="text-align: right">Sessions</th>
+              <th style="text-align: right">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>01</td>
+              <td>Python</td>
+              <td class="account">imperative, multi-paradigm</td>
+              <td class="n">212</td>
+              <td style="text-align: right">active</td>
+            </tr>
+            <tr>
+              <td>02</td>
+              <td>TypeScript</td>
+              <td class="account">structural</td>
+              <td class="n">189</td>
+              <td style="text-align: right">active</td>
+            </tr>
+            <tr>
+              <td>03</td>
+              <td>Rust</td>
+              <td class="account">systems</td>
+              <td class="n">134</td>
+              <td style="text-align: right">active</td>
+            </tr>
+            <tr>
+              <td>04</td>
+              <td>Haskell</td>
+              <td class="account">pure functional</td>
+              <td class="n">91</td>
+              <td style="text-align: right">active</td>
+            </tr>
+            <tr>
+              <td>05</td>
+              <td>Clojure</td>
+              <td class="account">lisp, JVM</td>
+              <td class="n">73</td>
+              <td style="text-align: right">active</td>
+            </tr>
+            <tr>
+              <td>&hellip;</td>
+              <td>and twenty-five more</td>
+              <td class="account">various</td>
+              <td class="n">—</td>
+              <td style="text-align: right">rotating</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <div class="sign-off">
+        <div>
+          <div class="line">Entered in the presence of &mdash;</div>
+          <div class="sig">The Membership</div>
+        </div>
+        <div>
+          <div class="line">Attested &mdash;</div>
+          <div class="sig">C. S. Study</div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/mockups/17-comic.html
+++ b/mockups/17-comic.html
@@ -1,0 +1,470 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Comic Book</title>
+    <style>
+      :root {
+        --bg: #fcf4d9;
+        --ink: #0e0e0e;
+        --red: #e8342f;
+        --yellow: #ffcd1b;
+        --blue: #1d4ed8;
+        --cyan: #06b6d4;
+        --pink: #ff6b9d;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "Bangers", "Anton", "Impact", "Arial Black", sans-serif;
+        letter-spacing: 0.03em;
+        min-height: 100vh;
+        background-image: radial-gradient(
+          circle,
+          rgba(0, 0, 0, 0.12) 1.2px,
+          transparent 1.4px
+        );
+        background-size: 6px 6px;
+      }
+      .book {
+        max-width: 1100px;
+        margin: 20px auto;
+        padding: 20px;
+        background: var(--bg);
+        border: 5px solid var(--ink);
+        box-shadow: 10px 10px 0 var(--ink);
+      }
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border-bottom: 4px solid var(--ink);
+        padding-bottom: 10px;
+        margin-bottom: 16px;
+      }
+      .logo {
+        background: var(--red);
+        color: var(--bg);
+        padding: 8px 18px;
+        border: 4px solid var(--ink);
+        box-shadow: 4px 4px 0 var(--ink);
+        font-size: 28px;
+        letter-spacing: 0.05em;
+        transform: rotate(-2deg);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 14px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        background: var(--yellow);
+        color: var(--ink);
+        text-decoration: none;
+        padding: 4px 10px;
+        border: 3px solid var(--ink);
+        font-size: 18px;
+        letter-spacing: 0.1em;
+        transform: rotate(-1deg);
+      }
+      nav a:hover {
+        background: var(--red);
+        color: var(--bg);
+        transform: rotate(1deg);
+      }
+      .title-card {
+        text-align: center;
+        margin: 20px 0;
+      }
+      .issue-meta {
+        display: inline-block;
+        background: var(--blue);
+        color: var(--yellow);
+        padding: 4px 12px;
+        font-size: 16px;
+        border: 3px solid var(--ink);
+        letter-spacing: 0.2em;
+      }
+      h1 {
+        font-family: inherit;
+        font-size: clamp(60px, 10vw, 130px);
+        line-height: 0.9;
+        margin: 12px 0 0;
+        color: var(--yellow);
+        -webkit-text-stroke: 4px var(--ink);
+        text-shadow:
+          6px 6px 0 var(--red),
+          12px 12px 0 var(--ink);
+        letter-spacing: 0.04em;
+      }
+      .subtitle {
+        font-family: "Comic Neue", "Comic Sans MS", "Chalkboard SE", cursive;
+        letter-spacing: normal;
+        font-size: 20px;
+        font-weight: 700;
+        margin-top: 14px;
+      }
+      .panels {
+        display: grid;
+        grid-template-columns: 1.3fr 1fr 1fr;
+        grid-template-rows: 200px 140px;
+        gap: 12px;
+        margin: 20px 0;
+      }
+      .panel {
+        border: 4px solid var(--ink);
+        position: relative;
+        overflow: hidden;
+        padding: 14px;
+        box-shadow: 4px 4px 0 var(--ink);
+        background: var(--bg);
+      }
+      .p1 {
+        grid-row: span 2;
+        background:
+          radial-gradient(
+            circle,
+            rgba(232, 52, 47, 0.9) 1.5px,
+            transparent 1.8px
+          ),
+          radial-gradient(
+            circle at 40% 60%,
+            var(--yellow) 0 30%,
+            transparent 30%
+          ),
+          var(--red);
+        background-size:
+          5px 5px,
+          100% 100%;
+        color: var(--bg);
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+      }
+      .p1::before {
+        content: "KAPOW!";
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        font-size: clamp(36px, 5vw, 64px);
+        color: var(--yellow);
+        -webkit-text-stroke: 3px var(--ink);
+        transform: rotate(-8deg);
+        line-height: 1;
+        letter-spacing: 0.02em;
+      }
+      .bubble {
+        background: var(--bg);
+        color: var(--ink);
+        border: 3px solid var(--ink);
+        border-radius: 28px;
+        padding: 10px 14px;
+        font-family: "Comic Neue", "Comic Sans MS", cursive;
+        font-weight: 700;
+        letter-spacing: normal;
+        font-size: 16px;
+        position: relative;
+        max-width: 80%;
+        box-shadow: 3px 3px 0 var(--ink);
+      }
+      .bubble::after {
+        content: "";
+        position: absolute;
+        width: 18px;
+        height: 18px;
+        background: var(--bg);
+        border-right: 3px solid var(--ink);
+        border-bottom: 3px solid var(--ink);
+        transform: rotate(45deg);
+        bottom: -11px;
+        left: 20px;
+      }
+      .p2 {
+        background: repeating-linear-gradient(
+          45deg,
+          var(--yellow) 0 14px,
+          #ffb800 14px 28px
+        );
+      }
+      .p2 h3 {
+        font-size: 30px;
+        margin: 0 0 4px;
+        letter-spacing: 0.05em;
+      }
+      .p2 .sub {
+        font-family: "Comic Neue", "Comic Sans MS", cursive;
+        font-size: 14px;
+        letter-spacing: normal;
+        font-weight: 700;
+      }
+      .p3 {
+        background: var(--cyan);
+      }
+      .p3 h3 {
+        font-size: 30px;
+        margin: 0 0 4px;
+        letter-spacing: 0.05em;
+      }
+      .p3 .sub {
+        font-family: "Comic Neue", cursive;
+        font-size: 14px;
+        letter-spacing: normal;
+        font-weight: 700;
+      }
+      .p4 {
+        background: var(--pink);
+        grid-column: 2;
+      }
+      .p4 h3 {
+        font-size: 30px;
+        margin: 0 0 4px;
+        letter-spacing: 0.05em;
+        color: var(--bg);
+      }
+      .p4 .sub {
+        font-family: "Comic Neue", cursive;
+        font-size: 14px;
+        letter-spacing: normal;
+        font-weight: 700;
+        color: var(--ink);
+      }
+      .p5 {
+        background: var(--blue);
+        color: var(--yellow);
+      }
+      .p5 h3 {
+        font-size: 30px;
+        margin: 0 0 4px;
+        letter-spacing: 0.05em;
+      }
+      .p5 .sub {
+        font-family: "Comic Neue", cursive;
+        font-size: 14px;
+        letter-spacing: normal;
+        font-weight: 700;
+        color: var(--bg);
+      }
+      .burst {
+        position: absolute;
+        width: 46px;
+        height: 46px;
+        top: -18px;
+        right: -14px;
+        background: var(--red);
+        color: var(--bg);
+        display: grid;
+        place-items: center;
+        font-size: 13px;
+        line-height: 1.1;
+        text-align: center;
+        clip-path: polygon(
+          50% 0%,
+          65% 20%,
+          85% 10%,
+          80% 30%,
+          100% 40%,
+          85% 55%,
+          95% 75%,
+          70% 75%,
+          70% 100%,
+          50% 85%,
+          30% 100%,
+          30% 75%,
+          5% 75%,
+          15% 55%,
+          0% 40%,
+          20% 30%,
+          15% 10%,
+          35% 20%
+        );
+        border: 0;
+        letter-spacing: 0.05em;
+      }
+      .big-panel {
+        border: 4px solid var(--ink);
+        padding: 26px;
+        background: var(--bg);
+        box-shadow: 6px 6px 0 var(--ink);
+        margin: 20px 0;
+        position: relative;
+      }
+      .big-panel h2 {
+        font-size: 52px;
+        margin: 0 0 10px;
+        letter-spacing: 0.04em;
+        color: var(--red);
+        -webkit-text-stroke: 2px var(--ink);
+      }
+      .big-panel p {
+        font-family: "Comic Neue", "Comic Sans MS", cursive;
+        letter-spacing: normal;
+        font-size: 17px;
+        font-weight: 700;
+        margin: 0 0 10px;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 8px;
+      }
+      .tag {
+        background: var(--yellow);
+        border: 3px solid var(--ink);
+        padding: 3px 10px;
+        font-size: 15px;
+        letter-spacing: 0.05em;
+      }
+      .tag:nth-child(3n) {
+        background: var(--cyan);
+      }
+      .tag:nth-child(4n) {
+        background: var(--pink);
+        color: var(--bg);
+      }
+      .tag:nth-child(5n) {
+        background: var(--red);
+        color: var(--bg);
+      }
+      .cta {
+        display: inline-block;
+        background: var(--red);
+        color: var(--yellow);
+        padding: 14px 24px;
+        text-decoration: none;
+        border: 4px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--ink);
+        font-size: 28px;
+        letter-spacing: 0.06em;
+        transform: rotate(-2deg);
+        margin-top: 14px;
+      }
+      .cta:hover {
+        transform: rotate(2deg);
+      }
+      footer {
+        text-align: center;
+        padding: 10px 0;
+        border-top: 4px dashed var(--ink);
+        margin-top: 20px;
+        font-family: "Comic Neue", cursive;
+        letter-spacing: normal;
+        font-weight: 700;
+      }
+      @media (max-width: 820px) {
+        .panels {
+          grid-template-columns: 1fr;
+          grid-template-rows: auto;
+        }
+        .p1 {
+          grid-row: auto;
+          min-height: 260px;
+        }
+        .p4 {
+          grid-column: auto;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="book">
+      <nav>
+        <div class="logo">CSS #12</div>
+        <ul>
+          <li><a href="#">Events</a></li>
+          <li><a href="#">Learn</a></li>
+          <li><a href="#">Forum</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Puzzles</a></li>
+          <li><a href="#">About</a></li>
+        </ul>
+      </nav>
+
+      <div class="title-card">
+        <span class="issue-meta">ISSUE №12 &middot; APR · 25¢</span>
+        <h1>CODE<br />SELF STUDY</h1>
+        <div class="subtitle">
+          &mdash; the greatest programming team the Bay Area has ever assembled!
+          &mdash;
+        </div>
+      </div>
+
+      <section class="panels">
+        <div class="panel p1">
+          <div class="bubble">
+            &ldquo;Five thousand programmers... meeting every week... and ALL
+            are welcome?!&rdquo;
+          </div>
+        </div>
+        <div class="panel p2">
+          <span class="burst">★ 01</span>
+          <h3>COMMUNITY!</h3>
+          <div class="sub">
+            Meet programmers who keep showing up &mdash; week after week.
+          </div>
+        </div>
+        <div class="panel p3">
+          <span class="burst">★ 02</span>
+          <h3>MENTORSHIP!</h3>
+          <div class="sub">
+            Experienced members help beginners with questions and study plans.
+          </div>
+        </div>
+        <div class="panel p4">
+          <span class="burst">★ 03</span>
+          <h3>NETWORKING!</h3>
+          <div class="sub">
+            Members have landed jobs through introductions at meetups.
+          </div>
+        </div>
+        <div class="panel p5">
+          <span class="burst">★ 04</span>
+          <h3>ALL LANGUAGES!</h3>
+          <div class="sub">
+            Python, Rust, Haskell, Clojure, TypeScript &mdash; all welcome.
+          </div>
+        </div>
+      </section>
+
+      <section class="big-panel">
+        <h2>MEANWHILE, IN BERKELEY...</h2>
+        <p>
+          Dozens of meetups teach you to code. Code Self Study is doing
+          something different &mdash; building a local community of friendly,
+          motivated programmers. The format is self-study with mentorship: no
+          curriculum, no gatekeeping, no bootcamp pitch. Bring a question. Take
+          a seat. Leave with a friend.
+        </p>
+        <div class="tags">
+          <span class="tag">Python</span><span class="tag">JS</span
+          ><span class="tag">TypeScript</span><span class="tag">Go</span
+          ><span class="tag">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Scala</span
+          ><span class="tag">Ruby</span><span class="tag">C++</span
+          ><span class="tag">SQL</span>
+        </div>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >JOIN THE TEAM! →</a
+        >
+      </section>
+
+      <footer>
+        Continued next Saturday, 9 am, Berkeley! &mdash; same code time, same
+        code channel.
+      </footer>
+    </div>
+  </body>
+</html>

--- a/mockups/18-transit.html
+++ b/mockups/18-transit.html
@@ -1,0 +1,579 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Transit</title>
+    <style>
+      :root {
+        --bg: #0b0c0f;
+        --fg: #ffffff;
+        --grey: #a9afb8;
+        --rule: #2a2d33;
+        --red: #e42313;
+        --yellow: #fdb913;
+        --green: #009a44;
+        --blue: #0072ce;
+        --orange: #ff6b00;
+        --purple: #8a2be2;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "Helvetica Neue", "Helvetica", "Arial", "Inter", ui-sans-serif,
+          system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.4;
+      }
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 0 24px;
+      }
+      header {
+        border-bottom: 2px solid var(--fg);
+        padding: 18px 0;
+      }
+      .head-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 20px;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        font-weight: 700;
+        font-size: 18px;
+        letter-spacing: 0.02em;
+      }
+      .roundel {
+        width: 46px;
+        height: 46px;
+        border-radius: 50%;
+        background: var(--red);
+        display: grid;
+        place-items: center;
+        color: var(--fg);
+        font-weight: 900;
+        font-size: 22px;
+        border: 3px solid var(--fg);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 8px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        padding: 6px 12px;
+        border: 1px solid var(--rule);
+        border-radius: 999px;
+      }
+      nav a:hover {
+        background: var(--fg);
+        color: var(--bg);
+        border-color: var(--fg);
+      }
+      .sign {
+        background: var(--fg);
+        color: var(--bg);
+        margin-top: 20px;
+        padding: 24px;
+        border-radius: 4px;
+      }
+      .sign .top {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border-bottom: 3px solid var(--bg);
+        padding-bottom: 10px;
+        margin-bottom: 14px;
+        font-size: 13px;
+        letter-spacing: 0.15em;
+        text-transform: uppercase;
+        font-weight: 700;
+      }
+      .line-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background: var(--bg);
+        color: var(--fg);
+        padding: 4px 12px;
+        border-radius: 999px;
+        font-size: 12px;
+      }
+      .line-chip .dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--yellow);
+      }
+      h1 {
+        font-family: inherit;
+        font-size: clamp(48px, 8vw, 104px);
+        font-weight: 700;
+        letter-spacing: -0.04em;
+        line-height: 0.95;
+        margin: 0 0 16px;
+      }
+      .sign p {
+        font-size: 20px;
+        max-width: 48ch;
+        margin: 0 0 18px;
+      }
+      .arrow-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: center;
+        margin-top: 10px;
+      }
+      .pill {
+        background: var(--bg);
+        color: var(--fg);
+        padding: 10px 16px;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        display: inline-flex;
+        gap: 10px;
+        align-items: center;
+        font-size: 15px;
+      }
+      .pill.primary {
+        background: var(--red);
+      }
+      .pill:hover {
+        opacity: 0.9;
+      }
+      .next-trains {
+        margin-top: 20px;
+        padding: 20px 0;
+        border-top: 1px solid var(--rule);
+        border-bottom: 1px solid var(--rule);
+      }
+      .board-head {
+        display: grid;
+        grid-template-columns: 60px 1fr 1fr 100px;
+        gap: 20px;
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--grey);
+        padding-bottom: 10px;
+        border-bottom: 1px solid var(--rule);
+      }
+      .board-row {
+        display: grid;
+        grid-template-columns: 60px 1fr 1fr 100px;
+        gap: 20px;
+        align-items: center;
+        padding: 14px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 17px;
+      }
+      .board-row:last-child {
+        border-bottom: none;
+      }
+      .line {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        color: var(--bg);
+        font-weight: 900;
+        font-size: 15px;
+      }
+      .l-red {
+        background: var(--red);
+        color: var(--fg);
+      }
+      .l-yellow {
+        background: var(--yellow);
+      }
+      .l-blue {
+        background: var(--blue);
+        color: var(--fg);
+      }
+      .l-green {
+        background: var(--green);
+        color: var(--fg);
+      }
+      .l-orange {
+        background: var(--orange);
+      }
+      .l-purple {
+        background: var(--purple);
+        color: var(--fg);
+      }
+      .eta {
+        text-align: right;
+        font-feature-settings: "tnum";
+        font-weight: 700;
+        color: var(--yellow);
+        font-size: 22px;
+        letter-spacing: 0.05em;
+      }
+      .dest {
+        color: var(--grey);
+        font-size: 14px;
+      }
+      .dest strong {
+        color: var(--fg);
+        display: block;
+        font-size: 17px;
+        margin-bottom: 2px;
+      }
+      .map {
+        margin-top: 30px;
+        padding: 24px;
+        background: #14171c;
+        border-radius: 10px;
+        overflow-x: auto;
+      }
+      .map h2 {
+        font-size: 13px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--grey);
+        margin: 0 0 20px;
+        font-weight: 500;
+      }
+      .route {
+        position: relative;
+        padding: 20px 0;
+        min-width: 720px;
+      }
+      .route::before {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 20px;
+        right: 20px;
+        height: 8px;
+        background: linear-gradient(
+          to right,
+          var(--red) 0% 33%,
+          var(--yellow) 33% 66%,
+          var(--blue) 66% 100%
+        );
+        border-radius: 4px;
+        transform: translateY(-50%);
+      }
+      .stops {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        position: relative;
+      }
+      .stop {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+        min-width: 90px;
+        text-align: center;
+      }
+      .stop .tick {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background: var(--bg);
+        border: 4px solid var(--fg);
+        z-index: 1;
+      }
+      .stop.big .tick {
+        width: 28px;
+        height: 28px;
+        border-width: 5px;
+        background: var(--red);
+      }
+      .stop .label {
+        font-size: 12px;
+        letter-spacing: 0.05em;
+        line-height: 1.2;
+      }
+      .stop .label strong {
+        display: block;
+        font-size: 14px;
+        margin-bottom: 2px;
+      }
+      .service-notices {
+        margin-top: 30px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 14px;
+      }
+      .notice {
+        padding: 18px;
+        border-radius: 8px;
+        border: 1px solid var(--rule);
+        background: #14171c;
+        position: relative;
+      }
+      .notice .badge {
+        display: inline-flex;
+        gap: 6px;
+        align-items: center;
+        font-size: 11px;
+        letter-spacing: 0.15em;
+        text-transform: uppercase;
+        color: var(--grey);
+        margin-bottom: 8px;
+      }
+      .notice .badge .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--green);
+      }
+      .notice h3 {
+        font-size: 22px;
+        margin: 0 0 6px;
+        letter-spacing: -0.01em;
+      }
+      .notice p {
+        color: var(--grey);
+        margin: 0;
+        font-size: 14px;
+      }
+      .info-strip {
+        margin-top: 28px;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 20px;
+        padding: 20px 0 30px;
+      }
+      .info-strip > div {
+        border-left: 3px solid var(--yellow);
+        padding-left: 14px;
+      }
+      .info-strip .k {
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--grey);
+      }
+      .info-strip .v {
+        font-size: 24px;
+        font-weight: 700;
+        margin-top: 2px;
+      }
+      footer {
+        border-top: 2px solid var(--fg);
+        padding: 14px 0;
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--grey);
+        display: flex;
+        justify-content: space-between;
+      }
+      @media (max-width: 820px) {
+        .board-head,
+        .board-row {
+          grid-template-columns: 50px 1fr 80px;
+        }
+        .board-row > .dest-system {
+          display: none;
+        }
+        .service-notices,
+        .info-strip {
+          grid-template-columns: 1fr;
+        }
+        h1 {
+          font-size: 48px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <div class="head-row">
+          <div class="brand">
+            <div class="roundel">CSS</div>
+            Code Self Study Transit Authority
+          </div>
+          <nav>
+            <ul>
+              <li><a href="#">Events</a></li>
+              <li><a href="#">Lines</a></li>
+              <li><a href="#">Forum</a></li>
+              <li><a href="#">Jobs</a></li>
+              <li><a href="#">About</a></li>
+            </ul>
+          </nav>
+        </div>
+      </header>
+
+      <section class="sign">
+        <div class="top">
+          <div class="line-chip"><span class="dot"></span> Now boarding</div>
+          <span>Berkeley · Bay Area · Since 2014</span>
+        </div>
+        <h1>Next train:<br />Curiosity.</h1>
+        <p>
+          A friendly programming community of 5,000+ members. All languages, all
+          levels, weekly in Berkeley. Self-study with mentorship &mdash; all
+          lines run on time.
+        </p>
+        <div class="arrow-row">
+          <a class="pill primary" href="https://www.meetup.com/codeselfstudy/"
+            >Join the Community →</a
+          >
+          <a class="pill" href="#">View schedule</a>
+        </div>
+      </section>
+
+      <section class="next-trains">
+        <div class="board-head">
+          <span>Line</span>
+          <span>Departs</span>
+          <span class="dest-system">Destination</span>
+          <span style="text-align: right">ETA</span>
+        </div>
+        <div class="board-row">
+          <div class="line l-red">C</div>
+          <div class="dest">
+            <strong>Community</strong>
+            Meet programmers who keep showing up
+          </div>
+          <div class="dest dest-system">→ Berkeley &middot; Sat 9:00</div>
+          <div class="eta">5 MIN</div>
+        </div>
+        <div class="board-row">
+          <div class="line l-yellow">M</div>
+          <div class="dest">
+            <strong>Mentorship</strong>
+            Ask for a study plan or project review
+          </div>
+          <div class="dest dest-system">→ Forum &middot; Anytime</div>
+          <div class="eta">8 MIN</div>
+        </div>
+        <div class="board-row">
+          <div class="line l-blue">N</div>
+          <div class="dest">
+            <strong>Networking</strong>
+            Intros that turn into interviews
+          </div>
+          <div class="dest dest-system">→ Jobs Board &middot; Weekly</div>
+          <div class="eta">12 MIN</div>
+        </div>
+        <div class="board-row">
+          <div class="line l-green">P</div>
+          <div class="dest">
+            <strong>Puzzles</strong>
+            Weekly programming challenges
+          </div>
+          <div class="dest dest-system">→ /puzzles &middot; Fri</div>
+          <div class="eta">18 MIN</div>
+        </div>
+        <div class="board-row">
+          <div class="line l-purple">L</div>
+          <div class="dest">
+            <strong>Learn</strong>
+            Study tracks, guides, and reading groups
+          </div>
+          <div class="dest dest-system">→ /learn &middot; Ongoing</div>
+          <div class="eta">22 MIN</div>
+        </div>
+      </section>
+
+      <section class="map">
+        <h2>→ The Self-Study Line &mdash; Stops from Idea to Shipped</h2>
+        <div class="route">
+          <div class="stops">
+            <div class="stop big">
+              <div class="tick"></div>
+              <div class="label"><strong>Show Up</strong>Saturday</div>
+            </div>
+            <div class="stop">
+              <div class="tick"></div>
+              <div class="label"><strong>Ask</strong>Questions</div>
+            </div>
+            <div class="stop">
+              <div class="tick"></div>
+              <div class="label"><strong>Build</strong>Projects</div>
+            </div>
+            <div class="stop">
+              <div class="tick"></div>
+              <div class="label"><strong>Review</strong>Feedback</div>
+            </div>
+            <div class="stop">
+              <div class="tick"></div>
+              <div class="label"><strong>Teach</strong>Someone else</div>
+            </div>
+            <div class="stop big">
+              <div class="tick"></div>
+              <div class="label"><strong>Ship</strong>It</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="service-notices">
+        <div class="notice">
+          <div class="badge"><span class="dot"></span> On time</div>
+          <h3>Saturday Meetup</h3>
+          <p>9:00 am &middot; Berkeley &middot; all lines running normally.</p>
+        </div>
+        <div class="notice">
+          <div class="badge"><span class="dot"></span> Open</div>
+          <h3>Forum &amp; Chat</h3>
+          <p>Ongoing threads in 30+ languages. Tickets checked by members.</p>
+        </div>
+        <div class="notice">
+          <div class="badge"><span class="dot"></span> Accepting</div>
+          <h3>Jobs Board</h3>
+          <p>Openings posted by members. No agencies, no recruiter spam.</p>
+        </div>
+      </section>
+
+      <section class="info-strip">
+        <div>
+          <div class="k">Riders</div>
+          <div class="v">5,247</div>
+        </div>
+        <div>
+          <div class="k">Since</div>
+          <div class="v">2014</div>
+        </div>
+        <div>
+          <div class="k">Lines</div>
+          <div class="v">30+</div>
+        </div>
+        <div>
+          <div class="k">Fare</div>
+          <div class="v">Free</div>
+        </div>
+      </section>
+
+      <footer>
+        <span>Code Self Study Transit Authority</span>
+        <span>Mind the compile errors · Berkeley, CA</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/mockups/19-punk.html
+++ b/mockups/19-punk.html
@@ -1,0 +1,438 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Punk Flyer</title>
+    <style>
+      :root {
+        --paper: #e7e2d6;
+        --ink: #0a0a0a;
+        --accent: #ff003c;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: "Courier New", "Courier", ui-monospace, Menlo, monospace;
+        line-height: 1.35;
+        font-size: 16px;
+        min-height: 100vh;
+        background-image:
+          repeating-linear-gradient(
+            0deg,
+            rgba(0, 0, 0, 0.08) 0 1px,
+            transparent 1px 2px
+          ),
+          radial-gradient(
+            circle at 50% 50%,
+            rgba(0, 0, 0, 0.03) 0 3px,
+            transparent 3px
+          );
+        background-size:
+          100% 3px,
+          6px 6px;
+        filter: contrast(1.05);
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        background: radial-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1.5px);
+        background-size: 3px 3px;
+        mix-blend-mode: multiply;
+      }
+      .flyer {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 22px;
+      }
+      .torn {
+        background: var(--ink);
+        color: var(--paper);
+        padding: 16px 20px 22px;
+        position: relative;
+        transform: rotate(-0.3deg);
+        box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.3);
+      }
+      .torn::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: -14px;
+        height: 16px;
+        background: var(--ink);
+        clip-path: polygon(
+          0 0,
+          100% 0,
+          100% 55%,
+          96% 100%,
+          92% 40%,
+          86% 85%,
+          80% 30%,
+          74% 90%,
+          68% 45%,
+          62% 80%,
+          56% 30%,
+          50% 95%,
+          44% 40%,
+          38% 80%,
+          32% 35%,
+          26% 90%,
+          20% 40%,
+          14% 80%,
+          8% 30%,
+          4% 85%,
+          0 40%
+        );
+      }
+      nav {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-bottom: 10px;
+      }
+      nav a {
+        color: var(--paper);
+        text-decoration: none;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        font-size: 13px;
+        border: 2px solid var(--paper);
+        padding: 2px 8px;
+        transform: rotate(-1deg);
+      }
+      nav a:hover {
+        background: var(--accent);
+        border-color: var(--accent);
+      }
+      .hero-head {
+        font-family: "Impact", "Anton", "Oswald", "Arial Black", sans-serif;
+        font-weight: 900;
+        line-height: 0.85;
+        letter-spacing: -0.03em;
+        text-transform: uppercase;
+      }
+      .hero-head .l1 {
+        font-size: clamp(56px, 12vw, 140px);
+        display: block;
+      }
+      .hero-head .l2 {
+        font-size: clamp(48px, 10vw, 110px);
+        color: var(--accent);
+        display: block;
+        transform: skewX(-6deg);
+      }
+      .hero-head .l3 {
+        font-size: clamp(48px, 10vw, 110px);
+        display: block;
+        outline: 2px dashed var(--paper);
+        outline-offset: -6px;
+        padding: 0 8px;
+      }
+      .scream {
+        background: var(--paper);
+        color: var(--ink);
+        padding: 6px 10px;
+        display: inline-block;
+        font-family: "Impact", sans-serif;
+        font-size: 28px;
+        transform: rotate(-3deg);
+        margin: 14px 0 10px;
+        letter-spacing: 0.04em;
+        border-top: 3px solid var(--accent);
+        border-bottom: 3px solid var(--accent);
+      }
+      .date-bar {
+        display: grid;
+        grid-template-columns: auto auto 1fr auto;
+        gap: 14px;
+        align-items: center;
+        background: var(--paper);
+        color: var(--ink);
+        padding: 8px 12px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        margin-top: 14px;
+        border: 3px solid var(--accent);
+      }
+      .date-bar .big {
+        font-family: "Impact", sans-serif;
+        font-size: 36px;
+        line-height: 1;
+      }
+      .date-bar .small {
+        font-size: 12px;
+        letter-spacing: 0.1em;
+      }
+      .cta {
+        display: inline-block;
+        background: var(--accent);
+        color: var(--ink);
+        padding: 12px 18px;
+        font-family: "Impact", sans-serif;
+        font-size: 28px;
+        letter-spacing: 0.05em;
+        text-decoration: none;
+        margin-top: 16px;
+        transform: rotate(-1.5deg);
+        box-shadow: 5px 5px 0 var(--paper);
+      }
+      .cta:hover {
+        transform: rotate(1.5deg);
+      }
+      .body-content {
+        background: var(--paper);
+        color: var(--ink);
+        padding: 24px;
+        margin-top: 20px;
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 24px;
+        transform: rotate(0.2deg);
+        border: 3px solid var(--ink);
+      }
+      .lineup h2 {
+        font-family: "Impact", "Anton", "Arial Black", sans-serif;
+        text-transform: uppercase;
+        font-size: 36px;
+        letter-spacing: 0.02em;
+        margin: 0 0 8px;
+        border-bottom: 4px solid var(--ink);
+        padding-bottom: 4px;
+      }
+      .lineup ul {
+        list-style: none;
+        padding: 0;
+        margin: 0 0 14px;
+      }
+      .lineup li {
+        padding: 4px 0;
+        border-bottom: 1px dashed var(--ink);
+        font-size: 18px;
+        display: flex;
+        gap: 10px;
+        align-items: baseline;
+      }
+      .lineup li .n {
+        font-family: "Impact", sans-serif;
+        font-size: 26px;
+        min-width: 46px;
+      }
+      .lineup li .n.headline {
+        color: var(--accent);
+      }
+      .lineup li strong {
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+      }
+      .lineup li .desc {
+        font-size: 13px;
+        opacity: 0.8;
+      }
+      aside {
+        font-size: 14px;
+      }
+      aside .mono {
+        font-family: "Courier New", monospace;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 8px;
+        font-size: 12px;
+        line-height: 1.5;
+        letter-spacing: 0.04em;
+        margin-bottom: 14px;
+        transform: rotate(-1deg);
+      }
+      aside .sticker {
+        background: var(--accent);
+        color: var(--ink);
+        padding: 10px 12px;
+        font-family: "Impact", sans-serif;
+        font-size: 18px;
+        text-transform: uppercase;
+        transform: rotate(4deg);
+        display: inline-block;
+        letter-spacing: 0.04em;
+        margin: 10px 0;
+      }
+      aside .xerox {
+        width: 100%;
+        aspect-ratio: 1 / 1;
+        background:
+          linear-gradient(135deg, var(--ink) 50%, transparent 50%) 0 0 / 10px
+            10px,
+          linear-gradient(135deg, transparent 50%, var(--ink) 50%) 5px 5px /
+            10px 10px,
+          var(--paper);
+        filter: contrast(2) grayscale(1);
+        mix-blend-mode: multiply;
+        margin: 14px 0;
+        mask: radial-gradient(
+          circle at 40% 40%,
+          black 0 30%,
+          rgba(0, 0, 0, 0.6) 40%,
+          rgba(0, 0, 0, 0.2) 60%,
+          transparent 70%
+        );
+      }
+      .smudge {
+        margin-top: 14px;
+        font-family: "Impact", sans-serif;
+        font-size: 28px;
+        color: var(--ink);
+        text-align: center;
+        text-transform: uppercase;
+      }
+      .smudge span {
+        display: inline-block;
+        padding: 4px 8px;
+        background: var(--paper);
+        border: 3px solid var(--ink);
+        margin: 4px;
+      }
+      .smudge span:nth-child(2) {
+        background: var(--ink);
+        color: var(--paper);
+        transform: rotate(2deg);
+      }
+      .smudge span:nth-child(3) {
+        background: var(--accent);
+        transform: rotate(-3deg);
+      }
+      .tearoff {
+        margin-top: 20px;
+        display: grid;
+        grid-template-columns: repeat(8, 1fr);
+        gap: 4px;
+        border-top: 2px dashed var(--ink);
+        padding-top: 14px;
+      }
+      .tearoff .tab {
+        font-family: "Courier New", monospace;
+        font-size: 11px;
+        text-align: center;
+        padding: 4px 0;
+        border: 1px solid var(--ink);
+        background: var(--paper);
+        transform: rotate(-90deg);
+        letter-spacing: 0.1em;
+      }
+      @media (max-width: 820px) {
+        .body-content {
+          grid-template-columns: 1fr;
+        }
+        .date-bar {
+          grid-template-columns: 1fr;
+          gap: 4px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="flyer">
+      <div class="torn">
+        <nav>
+          <a href="#">HOME</a><a href="#">EVENTS</a><a href="#">FORUM</a
+          ><a href="#">LEARN</a><a href="#">JOBS</a><a href="#">PUZZLES</a
+          ><a href="#">ABOUT</a>
+        </nav>
+        <h1 class="hero-head">
+          <span class="l1">CODE</span>
+          <span class="l2">SELF</span>
+          <span class="l3">STUDY</span>
+        </h1>
+        <span class="scream">★ ALL AGES · ALL LANGUAGES · NO COVER ★</span>
+        <div class="date-bar">
+          <span class="big">SAT</span>
+          <span class="big">9:00</span>
+          <span class="small">
+            BERKELEY, CA · EVERY WEEK SINCE '14<br />
+            5,000+ PROGRAMMERS · STILL GOING
+          </span>
+          <a class="cta" href="https://www.meetup.com/codeselfstudy/">RSVP</a>
+        </div>
+      </div>
+
+      <div class="body-content">
+        <section class="lineup">
+          <h2>Tonight's Lineup</h2>
+          <ul>
+            <li>
+              <span class="n headline">◆</span>
+              <div>
+                <strong>Community</strong> — meet programmers who show up week
+                after week.
+              </div>
+            </li>
+            <li>
+              <span class="n">◆</span>
+              <div>
+                <strong>Mentorship</strong> — bring a question, leave with a
+                study plan.
+              </div>
+            </li>
+            <li>
+              <span class="n">◆</span>
+              <div>
+                <strong>Networking</strong> — introductions that turn into
+                interviews.
+              </div>
+            </li>
+            <li>
+              <span class="n">◆</span>
+              <div>
+                <strong>Puzzles</strong> — weekly challenges, always discussed.
+              </div>
+            </li>
+          </ul>
+          <div class="smudge">
+            <span>PYTHON</span><span>RUST</span><span>HASKELL</span
+            ><span>CLOJURE</span><span>TS</span><span>GO</span>
+          </div>
+          <p style="margin-top: 14px; font-size: 15px">
+            Dozens of meetups teach you to code. We're building a local
+            community of motivated programmers instead. Self-study. Mentorship.
+            No curriculum. No gatekeeping. Show up.
+          </p>
+        </section>
+
+        <aside>
+          <div class="mono">
+            &gt; WHO: YOU<br />
+            &gt; WHERE: BERKELEY<br />
+            &gt; WHEN: SATURDAYS<br />
+            &gt; BRING: LAPTOP,<br />
+            &nbsp;&nbsp;A QUESTION<br />
+            &gt; COST: $0.00
+          </div>
+          <div class="sticker">★ Since 2014 ★</div>
+          <div class="xerox"></div>
+          <div class="sticker" style="transform: rotate(-5deg)">
+            Ask about study plans
+          </div>
+        </aside>
+      </div>
+
+      <div class="tearoff">
+        <div class="tab">Join →</div>
+        <div class="tab">Join →</div>
+        <div class="tab">Join →</div>
+        <div class="tab">Join →</div>
+        <div class="tab">Join →</div>
+        <div class="tab">Join →</div>
+        <div class="tab">Join →</div>
+        <div class="tab">Join →</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/mockups/21-norton.html
+++ b/mockups/21-norton.html
@@ -1,0 +1,441 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Norton</title>
+    <style>
+      :root {
+        --blue: #0000aa;
+        --dk-blue: #00007f;
+        --cyan: #00aaaa;
+        --white: #ffffff;
+        --grey: #aaaaaa;
+        --yellow: #ffff55;
+        --black: #000000;
+        --green: #55ff55;
+        --red: #ff5555;
+        --magenta: #ff55ff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--blue);
+        color: var(--white);
+        font-family:
+          "Px437 IBM VGA8", "Perfect DOS VGA 437", "VT323", "Courier New",
+          ui-monospace, Menlo, monospace;
+        font-size: 16px;
+        line-height: 1.25;
+        min-height: 100vh;
+        background-image: linear-gradient(
+          to bottom,
+          transparent 0,
+          transparent 1px,
+          rgba(0, 0, 0, 0.18) 1px,
+          rgba(0, 0, 0, 0.18) 2px
+        );
+        background-size: 100% 2px;
+      }
+      .screen {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 12px;
+      }
+      a {
+        color: var(--yellow);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--cyan);
+        color: var(--black);
+      }
+      .top-bar {
+        background: var(--cyan);
+        color: var(--black);
+        padding: 1px 10px;
+        display: flex;
+        justify-content: space-between;
+        font-weight: 700;
+      }
+      .menu {
+        display: flex;
+        gap: 16px;
+      }
+      .menu .k {
+        color: var(--red);
+      }
+      .panels {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+        margin: 10px 0;
+      }
+      .panel {
+        border: 1px solid var(--cyan);
+        position: relative;
+        background: var(--blue);
+      }
+      .panel-title {
+        position: absolute;
+        top: -1px;
+        left: 12px;
+        background: var(--blue);
+        color: var(--yellow);
+        padding: 0 8px;
+        line-height: 1;
+        transform: translateY(-50%);
+        font-weight: 700;
+      }
+      .panel-body {
+        padding: 14px 16px;
+      }
+      .col-head {
+        display: grid;
+        grid-template-columns: 1fr 90px 90px;
+        gap: 8px;
+        color: var(--yellow);
+        border-bottom: 1px solid var(--cyan);
+        padding: 4px 16px;
+        font-weight: 700;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 1fr 90px 90px;
+        gap: 8px;
+        padding: 2px 16px;
+      }
+      .row:hover {
+        background: var(--cyan);
+        color: var(--black);
+      }
+      .row.sel {
+        background: var(--cyan);
+        color: var(--black);
+      }
+      .row .name::before {
+        content: "▒ ";
+        color: var(--yellow);
+      }
+      .row.sel .name::before {
+        color: var(--black);
+      }
+      .right .row .name::before {
+        content: "» ";
+      }
+      .status {
+        background: var(--cyan);
+        color: var(--black);
+        padding: 1px 10px;
+        text-align: center;
+      }
+      .hero {
+        margin: 12px 0;
+        border: 2px solid var(--white);
+        background: var(--dk-blue);
+        padding: 16px 22px;
+      }
+      .hero .ascii {
+        white-space: pre;
+        color: var(--cyan);
+        font-size: 12px;
+        line-height: 1.05;
+        margin: 0 0 10px;
+      }
+      .hero h1 {
+        margin: 6px 0 6px;
+        font-size: 28px;
+        color: var(--yellow);
+        text-shadow: 0 0 6px rgba(255, 255, 85, 0.5);
+        letter-spacing: 2px;
+      }
+      .hero p {
+        margin: 4px 0;
+      }
+      .hero .blink {
+        color: var(--green);
+        animation: blink 1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          visibility: hidden;
+        }
+      }
+      .cta {
+        display: inline-block;
+        background: var(--yellow);
+        color: var(--black);
+        padding: 4px 12px;
+        margin-top: 8px;
+        font-weight: 700;
+        text-decoration: none;
+      }
+      .cta:hover {
+        background: var(--green);
+      }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 8px;
+        margin: 12px 0;
+      }
+      .stat {
+        border: 1px solid var(--cyan);
+        padding: 8px 12px;
+      }
+      .stat .lbl {
+        color: var(--cyan);
+        font-size: 13px;
+      }
+      .stat .val {
+        color: var(--yellow);
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .fkey-bar {
+        display: grid;
+        grid-template-columns: repeat(10, 1fr);
+        gap: 1px;
+        background: var(--blue);
+      }
+      .fkey {
+        background: var(--cyan);
+        color: var(--black);
+        padding: 2px 4px;
+        font-size: 13px;
+        text-align: left;
+        display: flex;
+        gap: 4px;
+        font-weight: 700;
+      }
+      .fkey .fn {
+        color: var(--white);
+        background: var(--black);
+        padding: 0 3px;
+      }
+      .dialog {
+        border: 2px solid var(--white);
+        background: var(--cyan);
+        color: var(--black);
+        padding: 8px 14px;
+        margin: 12px auto;
+        max-width: 540px;
+        font-weight: 700;
+        position: relative;
+      }
+      .dialog::before {
+        content: "";
+        position: absolute;
+        right: 4px;
+        top: 4px;
+        width: 12px;
+        height: 12px;
+        background: var(--black);
+        color: var(--cyan);
+        font-size: 10px;
+        line-height: 12px;
+        text-align: center;
+      }
+      .dialog .ok {
+        display: inline-block;
+        background: var(--blue);
+        color: var(--yellow);
+        padding: 0 14px;
+        margin-top: 6px;
+        text-decoration: none;
+      }
+      @media (max-width: 820px) {
+        .panels,
+        .stats {
+          grid-template-columns: 1fr;
+        }
+        .fkey-bar {
+          grid-template-columns: repeat(5, 1fr);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="screen">
+      <div class="top-bar">
+        <div class="menu">
+          <span><span class="k">L</span>eft</span>
+          <span><span class="k">F</span>iles</span>
+          <span><span class="k">C</span>ommands</span>
+          <span><span class="k">O</span>ptions</span>
+          <span><span class="k">R</span>ight</span>
+        </div>
+        <div>CSS Commander &mdash; v12.0</div>
+      </div>
+
+      <section class="hero">
+        <pre class="ascii">
+╔═════════════════════════════════════════════════════════════════════╗
+║   ██████╗ ██████╗ ██████╗ ███████╗   ███████╗███████╗██╗     ███████╗
+║  ██╔════╝██╔═══██╗██╔══██╗██╔════╝   ██╔════╝██╔════╝██║     ██╔════╝
+║  ██║     ██║   ██║██║  ██║█████╗     ███████╗█████╗  ██║     █████╗
+║  ██║     ██║   ██║██║  ██║██╔══╝     ╚════██║██╔══╝  ██║     ██╔══╝
+║  ╚██████╗╚██████╔╝██████╔╝███████╗   ███████║███████╗███████╗██║
+║   ╚═════╝ ╚═════╝ ╚═════╝ ╚══════╝   ╚══════╝╚══════╝╚══════╝╚═╝
+╚═════════════════════════════════════════════════════════════════════╝</pre
+        >
+        <h1>S T U D Y . E X E</h1>
+        <p>
+          <span style="color: var(--cyan)">&gt;</span> A friendly Bay Area
+          programming community of
+          <span style="color: var(--yellow)">5,247</span>
+          members. Self-study with mentorship. All languages, all levels.
+        </p>
+        <p>
+          <span style="color: var(--cyan)">&gt;</span> Loaded successfully.
+          Press <span style="color: var(--yellow)">[F2]</span> to enlist.
+          <span class="blink">█</span>
+        </p>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >[ JOIN THE COMMUNITY ]</a
+        >
+      </section>
+
+      <section class="panels">
+        <div class="panel left">
+          <div class="panel-title">[ NAVIGATION ]</div>
+          <div class="col-head">
+            <span>Name</span><span>Size</span><span>Date</span>
+          </div>
+          <div class="panel-body" style="padding: 0">
+            <div class="row sel">
+              <span class="name">..</span><span>&lt;UP&gt;</span
+              ><span>04-18-26</span>
+            </div>
+            <div class="row">
+              <span class="name">events.bat</span><span>weekly</span
+              ><span>04-19-26</span>
+            </div>
+            <div class="row">
+              <span class="name">learn.dir</span><span>guides</span
+              ><span>04-15-26</span>
+            </div>
+            <div class="row">
+              <span class="name">forum.app</span><span>active</span
+              ><span>04-18-26</span>
+            </div>
+            <div class="row">
+              <span class="name">jobs.lst</span><span>6 open</span
+              ><span>04-17-26</span>
+            </div>
+            <div class="row">
+              <span class="name">puzzles.gam</span><span>fri</span
+              ><span>04-19-26</span>
+            </div>
+            <div class="row">
+              <span class="name">tools.cfg</span><span>refs</span
+              ><span>04-12-26</span>
+            </div>
+            <div class="row">
+              <span class="name">about.txt</span><span>2 kb</span
+              ><span>2014-08</span>
+            </div>
+          </div>
+        </div>
+        <div class="panel right">
+          <div class="panel-title">[ FEATURES ]</div>
+          <div class="col-head">
+            <span>Module</span><span>Status</span><span>Users</span>
+          </div>
+          <div class="panel-body" style="padding: 0">
+            <div class="row">
+              <span class="name">community.exe</span
+              ><span style="color: var(--green)">RUNNING</span><span>5247</span>
+            </div>
+            <div class="row">
+              <span class="name">mentorship.dll</span
+              ><span style="color: var(--green)">LOADED</span><span>any</span>
+            </div>
+            <div class="row">
+              <span class="name">networking.com</span
+              ><span style="color: var(--green)">ACTIVE</span><span>jobs</span>
+            </div>
+            <div class="row">
+              <span class="name">studyplan.bat</span
+              ><span style="color: var(--yellow)">ON-DEMAND</span
+              ><span>ask</span>
+            </div>
+            <div class="row">
+              <span class="name">readinggrp.app</span
+              ><span style="color: var(--green)">ACTIVE</span><span>~30</span>
+            </div>
+            <div class="row">
+              <span class="name">bootcamp.sup</span
+              ><span style="color: var(--cyan)">OPTIONAL</span><span>self</span>
+            </div>
+            <div class="row">
+              <span class="name">cliquebehavior.exe</span
+              ><span style="color: var(--red)">NOT FOUND</span><span>good</span>
+            </div>
+            <div class="row">
+              <span class="name">curriculum.dat</span
+              ><span style="color: var(--red)">DISABLED</span><span>-</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="stats">
+        <div class="stat">
+          <div class="lbl">MEMBERS</div>
+          <div class="val">5247</div>
+        </div>
+        <div class="stat">
+          <div class="lbl">LANGUAGES</div>
+          <div class="val">30+</div>
+        </div>
+        <div class="stat">
+          <div class="lbl">YEARS UP</div>
+          <div class="val">11</div>
+        </div>
+        <div class="stat">
+          <div class="lbl">DUES</div>
+          <div class="val">$0.00</div>
+        </div>
+      </section>
+
+      <div class="dialog">
+        ► A new study session has been scheduled. Click below to confirm.
+        <br />
+        <a class="ok" href="https://www.meetup.com/codeselfstudy/"
+          >&lt; OK &gt;</a
+        >
+        <a
+          class="ok"
+          href="#"
+          style="background: var(--blue); color: var(--white)"
+          >&lt; Cancel &gt;</a
+        >
+      </div>
+
+      <div class="status">
+        Path: C:\CSS\HOME\ &middot; 5247 members &middot; 30+ languages &middot;
+        idle
+      </div>
+
+      <nav class="fkey-bar">
+        <div class="fkey"><span class="fn">F1</span>Help</div>
+        <div class="fkey"><span class="fn">F2</span>Join</div>
+        <div class="fkey"><span class="fn">F3</span>View</div>
+        <div class="fkey"><span class="fn">F4</span>Forum</div>
+        <div class="fkey"><span class="fn">F5</span>Events</div>
+        <div class="fkey"><span class="fn">F6</span>Learn</div>
+        <div class="fkey"><span class="fn">F7</span>Jobs</div>
+        <div class="fkey"><span class="fn">F8</span>Puzzles</div>
+        <div class="fkey"><span class="fn">F9</span>Menu</div>
+        <div class="fkey"><span class="fn">F10</span>Quit</div>
+      </nav>
+    </div>
+  </body>
+</html>

--- a/mockups/22-ansi-scene.html
+++ b/mockups/22-ansi-scene.html
@@ -1,0 +1,318 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — ANSI Scene</title>
+    <style>
+      :root {
+        --bg: #000000;
+        --black: #000;
+        --blue: #0000aa;
+        --green: #00aa00;
+        --cyan: #00aaaa;
+        --red: #aa0000;
+        --magenta: #aa00aa;
+        --grey: #aaaaaa;
+        --dgrey: #6e6e6e;
+        --bblue: #5555ff;
+        --bgreen: #55ff55;
+        --bcyan: #55ffff;
+        --bred: #ff5555;
+        --bmag: #ff55ff;
+        --byel: #ffff55;
+        --bwht: #ffffff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--grey);
+        font-family:
+          "Px437 IBM VGA8", "Perfect DOS VGA 437", "Cascadia Mono",
+          "JetBrains Mono", "Courier New", ui-monospace, Menlo, monospace;
+        font-size: 15px;
+        line-height: 1;
+        min-height: 100vh;
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(255, 255, 255, 0.04) 0 1px,
+          transparent 1px 3px
+        );
+        pointer-events: none;
+        z-index: 100;
+      }
+      .crt {
+        max-width: 920px;
+        margin: 0 auto;
+        padding: 18px;
+        white-space: pre;
+        line-height: 1.05;
+      }
+      a {
+        color: var(--byel);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--byel);
+        color: var(--black);
+      }
+      .conn {
+        color: var(--green);
+      }
+      .ok {
+        color: var(--bgreen);
+      }
+      .y {
+        color: var(--byel);
+      }
+      .c {
+        color: var(--bcyan);
+      }
+      .m {
+        color: var(--bmag);
+      }
+      .r {
+        color: var(--bred);
+      }
+      .w {
+        color: var(--bwht);
+      }
+      .g {
+        color: var(--bgreen);
+      }
+      .dim {
+        color: var(--dgrey);
+      }
+      .b {
+        color: var(--bblue);
+      }
+      .fb {
+        color: var(--blue);
+      } /* dim blue frame */
+      .fc {
+        color: var(--cyan);
+      } /* dim cyan frame */
+      .fm {
+        color: var(--magenta);
+      } /* dim magenta frame */
+      .fr {
+        color: var(--red);
+      } /* dim red frame */
+      .blink {
+        animation: blink 0.8s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      h1.sr {
+        position: absolute;
+        left: -9999px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="crt">
+      <h1 class="sr">Code Self Study BBS</h1>
+      <span class="conn">CONNECT 2400/ARQ/V42BIS</span>
+      <span class="dim">Logging in as guest@codeselfstudy . . . </span
+      ><span class="ok">[OK]</span>
+
+      <span class="m"
+        >╔════════════════════════════════════════════════════════════════════════════╗</span
+      >
+      <span class="m">║</span
+      ><span class="fr"
+        >▓▒░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░▒▓</span
+      ><span class="m">║</span> <span class="m">║</span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="y"> ██████╗ ██████╗ ██████╗ ███████╗</span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="y">██╔════╝██╔═══██╗██╔══██╗██╔════╝</span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="y">██║ ██║ ██║██║ ██║█████╗ </span> <span class="m">║</span>
+      <span class="m">║</span> <span class="y">██║ ██║ ██║██║ ██║██╔══╝ </span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="y">╚██████╗╚██████╔╝██████╔╝███████╗</span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="y"> ╚═════╝ ╚═════╝ ╚═════╝ ╚══════╝</span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="r">███████╗███████╗██╗ ███████╗</span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="r">██╔════╝██╔════╝██║ ██╔════╝</span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="r">███████╗█████╗ ██║ █████╗ </span> <span class="m">║</span>
+      <span class="m">║</span> <span class="r">╚════██║██╔══╝ ██║ ██╔══╝ </span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="r">███████║███████╗███████╗██║ </span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="r">╚══════╝╚══════╝╚══════╝╚═╝ </span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="c">███████╗████████╗██╗ ██╗██████╗ ██╗ ██╗</span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="c">██╔════╝╚══██╔══╝██║ ██║██╔══██╗╚██╗ ██╔╝</span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="c">███████╗ ██║ ██║ ██║██║ ██║ ╚████╔╝ </span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="c">╚════██║ ██║ ██║ ██║██║ ██║ ╚██╔╝ </span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="c">███████║ ██║ ╚██████╔╝██████╔╝ ██║ </span>
+      <span class="m">║</span> <span class="m">║</span>
+      <span class="c">╚══════╝ ╚═╝ ╚═════╝ ╚═════╝ ╚═╝ </span>
+      <span class="m">║</span> <span class="m">║</span> <span class="m">║</span>
+      <span class="m">║</span><span class="fr">▓▒░</span>
+      <span class="w">Berkeley, CA</span> <span class="dim">·</span>
+      <span class="w">Bay Area</span> <span class="dim">·</span>
+      <span class="w">All Languages</span> <span class="dim">·</span>
+      <span class="w">All Levels</span> <span class="fr">░▒▓</span
+      ><span class="m">║</span> <span class="m">║</span
+      ><span class="fr"
+        >▓▒░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░▒▓</span
+      ><span class="m">║</span>
+      <span class="m"
+        >╚════════════════════════════════════════════════════════════════════════════╝</span
+      >
+
+      <span class="fc">┌─[ </span><span class="y">main menu</span
+      ><span class="fc">
+        ]──────────────────────────────────────────────────────────────┐</span
+      >
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="fc">│</span> <span class="r">[</span><span class="y">H</span
+      ><span class="r">]</span> <a href="#"><span class="w">home</span></a>
+      <span class="r">[</span><span class="y">F</span><span class="r">]</span>
+      <a href="#"><span class="w">forum &amp; chat</span></a>
+      <span class="r">[</span><span class="y">P</span><span class="r">]</span>
+      <a href="#"><span class="w">puzzles</span></a> <span class="fc">│</span>
+      <span class="fc">│</span> <span class="r">[</span><span class="y">E</span
+      ><span class="r">]</span> <a href="#"><span class="w">events</span></a>
+      <span class="r">[</span><span class="y">J</span><span class="r">]</span>
+      <a href="#"><span class="w">jobs board</span></a> <span class="r">[</span
+      ><span class="y">T</span><span class="r">]</span>
+      <a href="#"><span class="w">tools</span></a> <span class="fc">│</span>
+      <span class="fc">│</span> <span class="r">[</span><span class="y">L</span
+      ><span class="r">]</span> <a href="#"><span class="w">learn</span></a>
+      <span class="r">[</span><span class="y">A</span><span class="r">]</span>
+      <a href="#"><span class="w">about</span></a> <span class="r">[</span
+      ><span class="y">G</span><span class="r">]</span>
+      <a href="https://www.meetup.com/codeselfstudy/"
+        ><span class="g">go ─ join now</span></a
+      >
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="fc">│</span>
+      <span class="fc"
+        >└──────────────────────────────────────────────────────────────────────────────┘</span
+      >
+
+      <span class="fb"
+        >╒══════════════════════════════════════════════════════════════════════════════╕</span
+      >
+      <span class="fb">│</span> <span class="c">▓▒░ </span
+      ><span class="w">SYSTEM BULLETIN — APR ’26</span
+      ><span class="c"> ░▒▓</span> <span class="fb">│</span>
+      <span class="fb"
+        >╞══════════════════════════════════════════════════════════════════════════════╡</span
+      >
+      <span class="fb">│</span> <span class="fb">│</span>
+      <span class="fb">│</span> <span class="y">▶</span> a friendly programming
+      community of <span class="g">5,247</span> members in berkeley
+      <span class="fb">│</span> <span class="fb">│</span> and the san francisco
+      bay area. all languages, all levels, all <span class="fb">│</span>
+      <span class="fb">│</span> welcome. self-study with mentorship.
+      <span class="fb">│</span> <span class="fb">│</span>
+      <span class="fb">│</span> <span class="fb">│</span>
+      <span class="y">▶</span> the format is straightforward. show up at a
+      meetup, bring a project <span class="fb">│</span>
+      <span class="fb">│</span> or a question, get help from the regulars. the
+      experienced members <span class="fb">│</span>
+      <span class="fb">│</span> help the beginners. that is, in short, the whole
+      trick. <span class="fb">│</span> <span class="fb">│</span>
+      <span class="fb">│</span> <span class="fb">│</span>
+      <span class="y">▶</span> press <span class="r">[G]</span> below to
+      <a href="https://www.meetup.com/codeselfstudy/"
+        ><span class="g">join the community</span></a
+      >
+      on meetup.com <span class="fb">│</span> <span class="fb">│</span>
+      <span class="fb">│</span>
+      <span class="fb"
+        >╘══════════════════════════════════════════════════════════════════════════════╛</span
+      >
+
+      <span class="fc">┌─[ </span><span class="y">why people come</span
+      ><span class="fc"> ]───────────────┐</span> <span class="fc">┌─[ </span
+      ><span class="y">languages in rotation</span
+      ><span class="fc"> ]─────┐</span> <span class="fc">│</span>
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="m">►</span> <span class="w">community</span>
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="g">▒</span> python <span class="g">▒</span> typescript
+      <span class="fc">│</span> <span class="fc">│</span> show up; meet people
+      who <span class="fc">│</span> <span class="fc">│</span>
+      <span class="g">▒</span> rust <span class="g">▒</span> haskell
+      <span class="fc">│</span> <span class="fc">│</span> keep showing up.
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="g">▒</span> go <span class="g">▒</span> clojure
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="g">▒</span> elixir <span class="g">▒</span> racket
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="m">►</span> <span class="w">mentorship</span>
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="g">▒</span> ruby <span class="g">▒</span> scala
+      <span class="fc">│</span> <span class="fc">│</span> experienced members
+      help <span class="fc">│</span> <span class="fc">│</span>
+      <span class="g">▒</span> c++ <span class="g">▒</span> sql
+      <span class="fc">│</span> <span class="fc">│</span> beginners. ask for
+      plans. <span class="fc">│</span> <span class="fc">│</span>
+      <span class="g">▒</span> elm <span class="g">▒</span> lua
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="g">▒</span> erlang <span class="g">▒</span> common lisp
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="m">►</span> <span class="w">networking</span>
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="fc">│</span> <span class="fc">│</span> members find work via
+      <span class="fc">│</span> <span class="fc">│</span>
+      <span class="dim">…+ many more, see /forum</span>
+      <span class="fc">│</span> <span class="fc">│</span> introductions in the
+      group. <span class="fc">│</span> <span class="fc">│</span>
+      <span class="fc">│</span>
+      <span class="fc">└──────────────────────────────────┘</span>
+      <span class="fc">└──────────────────────────────────┘</span>
+
+      <span class="dim">─[ </span><span class="c">scroller</span
+      ><span class="dim">
+        ]─────────────────────────────────────────────────────────────────</span
+      >
+      <span class="m">★ greetz to all the local sysops ★</span>
+      <span class="g">no curriculum · no gatekeeping ·</span>
+      <span class="g">no bootcamp pitch ·</span>
+      <span class="y">show up · bring a question · leave with friends ·</span>
+      <span class="c"
+        >all dialects loaded · since 2014 · still going · saturdays in berkeley
+        ·</span
+      >
+
+      <span class="dim"
+        >──────────────────────────────────────────────────────────────────────────────</span
+      >
+
+      guest@codeselfstudy:~$ <span class="g">join</span>
+      <span class="y">--community</span><span class="blink">█</span>
+    </div>
+  </body>
+</html>

--- a/mockups/23-teletext.html
+++ b/mockups/23-teletext.html
@@ -1,0 +1,284 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Teletext</title>
+    <style>
+      :root {
+        --bg: #000000;
+        --white: #ffffff;
+        --red: #ff0000;
+        --green: #00ff00;
+        --yellow: #ffff00;
+        --blue: #0000ff;
+        --magenta: #ff00ff;
+        --cyan: #00ffff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: #050505;
+        color: var(--white);
+        font-family:
+          "Bedstead", "Cascadia Mono", "VT323", "Px437 IBM VGA8",
+          "Perfect DOS VGA 437", "Courier New", ui-monospace, monospace;
+        font-size: 22px;
+        line-height: 1;
+        font-weight: 700;
+        min-height: 100vh;
+        letter-spacing: 0.01em;
+      }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+      .tube {
+        max-width: 880px;
+        margin: 24px auto;
+        padding: 18px;
+        background: var(--bg);
+        border-radius: 18px / 28px;
+        box-shadow:
+          inset 0 0 60px rgba(0, 0, 0, 0.9),
+          0 0 0 8px #1a1a1a,
+          0 0 0 14px #0a0a0a;
+        position: relative;
+        overflow: hidden;
+      }
+      .tube::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, 0) 0 1px,
+          rgba(0, 0, 0, 0.25) 1px 2px
+        );
+        pointer-events: none;
+        mix-blend-mode: multiply;
+      }
+      .page {
+        white-space: pre;
+        line-height: 1.05;
+      }
+      .row {
+        display: block;
+      }
+      .bg-red {
+        background: var(--red);
+      }
+      .bg-green {
+        background: var(--green);
+        color: var(--bg);
+      }
+      .bg-yellow {
+        background: var(--yellow);
+        color: var(--bg);
+      }
+      .bg-blue {
+        background: var(--blue);
+      }
+      .bg-magenta {
+        background: var(--magenta);
+        color: var(--bg);
+      }
+      .bg-cyan {
+        background: var(--cyan);
+        color: var(--bg);
+      }
+      .bg-white {
+        background: var(--white);
+        color: var(--bg);
+      }
+      .fg-red {
+        color: var(--red);
+      }
+      .fg-green {
+        color: var(--green);
+      }
+      .fg-yellow {
+        color: var(--yellow);
+      }
+      .fg-blue {
+        color: var(--blue);
+      }
+      .fg-magenta {
+        color: var(--magenta);
+      }
+      .fg-cyan {
+        color: var(--cyan);
+      }
+      .fg-white {
+        color: var(--white);
+      }
+      .double {
+        font-size: 44px;
+        line-height: 1;
+        letter-spacing: 0.02em;
+      }
+      .blink {
+        animation: blink 0.9s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      h1.sr,
+      h2.sr,
+      h3.sr {
+        position: absolute;
+        left: -9999px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="tube">
+      <h1 class="sr">Code Self Study Teletext</h1>
+      <div class="page">
+        <span class="fg-cyan">P101 CSS</span>
+        <span class="fg-yellow">CODE SELF STUDY</span>
+        <span class="fg-white">Sat 18 Apr 09:00:01</span>
+
+        <span class="bg-red fg-yellow double"> CSS </span
+        ><span class="bg-yellow fg-red double"> 101 </span
+        ><span class="bg-blue fg-white double"> index </span>
+        <span class="bg-red fg-yellow double"> CSS </span
+        ><span class="bg-yellow fg-red double"> 101 </span
+        ><span class="bg-blue fg-white double"> index </span>
+
+        <span class="fg-cyan"
+          >▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙</span
+        >
+
+        <span class="fg-yellow"> Welcome to the Code Self Study teletext </span>
+        <span class="fg-white"> service. A friendly programming </span>
+        <span class="fg-white"> community of </span
+        ><span class="fg-green">5,247</span
+        ><span class="fg-white"> members in Berkeley </span>
+        <span class="fg-white"> and the San Francisco Bay Area. </span>
+        <span class="fg-white"> All languages. All levels. Welcome. </span>
+
+        <span class="fg-cyan"
+          >▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙</span
+        >
+
+        <span class="fg-magenta"> INDEX</span> <span class="fg-cyan">page</span>
+        <a href="#"
+          ><span class="fg-white"> Home . . . . . . . . . . . . . </span
+          ><span class="fg-yellow">100</span></a
+        >
+        <a href="#"
+          ><span class="fg-white"> Events &amp; meetups . . . . . . . </span
+          ><span class="fg-yellow">200</span></a
+        >
+        <a href="#"
+          ><span class="fg-white"> Forum &amp; chat . . . . . . . . . </span
+          ><span class="fg-yellow">300</span></a
+        >
+        <a href="#"
+          ><span class="fg-white"> Learn &amp; study guides . . . . . </span
+          ><span class="fg-yellow">400</span></a
+        >
+        <a href="#"
+          ><span class="fg-white"> Jobs board . . . . . . . . . . </span
+          ><span class="fg-yellow">500</span></a
+        >
+        <a href="#"
+          ><span class="fg-white"> Puzzles &amp; challenges . . . . . </span
+          ><span class="fg-yellow">600</span></a
+        >
+        <a href="#"
+          ><span class="fg-white"> Tools &amp; references . . . . . . </span
+          ><span class="fg-yellow">700</span></a
+        >
+        <a href="#"
+          ><span class="fg-white"> About . . . . . . . . . . . . . </span
+          ><span class="fg-yellow">800</span></a
+        >
+        <a href="https://www.meetup.com/codeselfstudy/"
+          ><span class="fg-green"> &gt; Join the community . . . . . </span
+          ><span class="fg-green">900</span></a
+        >
+
+        <span class="fg-cyan"
+          >▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙</span
+        >
+
+        <span class="bg-red fg-white"> 1 </span>
+        <span class="fg-red">COMMUNITY</span>
+        <span class="fg-white">Show up. Meet programmers who keep </span>
+        <span class="fg-white">showing up week after week. </span>
+
+        <span class="bg-yellow fg-blue"> 2 </span>
+        <span class="fg-yellow">MENTORSHIP</span>
+        <span class="fg-white">Experienced members help beginners. </span>
+        <span class="fg-white">Ask for a study plan or code review. </span>
+
+        <span class="bg-cyan fg-blue"> 3 </span>
+        <span class="fg-cyan">NETWORKING</span>
+        <span class="fg-white">Members have landed jobs through </span>
+        <span class="fg-white">introductions inside the group. </span>
+
+        <span class="fg-magenta"
+          >▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟</span
+        >
+
+        <span class="bg-green fg-blue"> WHAT'S ON </span>
+        <span class="fg-yellow"> Sat 09:00 Berkeley </span>
+
+        <span class="fg-white"> Weekly meetup . . . . . . . in person </span>
+        <span class="fg-white"> Reading group: Crafting Interpreters </span>
+        <span class="fg-white"> Puzzle of the week . . . . shortest p </span>
+        <span class="fg-white"> New jobs posted . . . . . . . . . . 6 </span>
+
+        <span class="fg-magenta"
+          >▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟</span
+        >
+
+        <span class="bg-blue fg-yellow"> LANGUAGES </span>
+        <span class="fg-cyan"> in active rotation </span>
+
+        <span class="fg-green"> python </span>
+        <span class="fg-yellow"> rust </span>
+        <span class="fg-magenta"> haskell </span>
+        <span class="fg-cyan"> go </span> <span class="fg-cyan"> ts </span>
+        <span class="fg-green"> clojure </span>
+        <span class="fg-yellow"> elixir </span>
+        <span class="fg-magenta"> racket </span>
+        <span class="fg-magenta"> ruby </span>
+        <span class="fg-cyan"> scala </span> <span class="fg-green"> c++ </span>
+        <span class="fg-yellow"> sql </span>
+
+        <span class="fg-cyan"
+          >▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙▟▙</span
+        >
+
+        <span class="bg-red fg-white"> RED </span
+        ><span class="bg-green fg-blue"> GREEN </span
+        ><span class="bg-yellow fg-blue"> YELLOW </span
+        ><span class="bg-cyan fg-blue"> CYAN </span>
+        <a href="#"
+          ><span class="fg-red">100 </span
+          ><span class="fg-white">home </span></a
+        ><a href="#"
+          ><span class="fg-green">200 </span
+          ><span class="fg-white">events </span></a
+        ><a href="#"
+          ><span class="fg-yellow">300 </span
+          ><span class="fg-white">forum </span></a
+        ><a href="https://www.meetup.com/codeselfstudy/"
+          ><span class="fg-cyan">900 </span><span class="fg-green">join</span
+          ><span class="blink">█</span></a
+        >
+      </div>
+    </div>
+  </body>
+</html>

--- a/mockups/24-vt100.html
+++ b/mockups/24-vt100.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — VT100</title>
+    <style>
+      :root {
+        --bg: #050a05;
+        --fg: #b6f3b6;
+        --bright: #ddffdd;
+        --dim: #4f8a4f;
+        --shadow: rgba(120, 255, 120, 0.35);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: #000;
+        color: var(--fg);
+        font-family:
+          "VT323", "IBM Plex Mono", "JetBrains Mono", "Courier New",
+          ui-monospace, Menlo, monospace;
+        font-size: 19px;
+        line-height: 1.35;
+        min-height: 100vh;
+        padding: 24px 0 60px;
+      }
+      .crt {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 32px 40px;
+        background: radial-gradient(
+          ellipse at center,
+          #061e0a 0%,
+          #021004 70%,
+          #000 100%
+        );
+        border-radius: 16px / 38px;
+        position: relative;
+        overflow: hidden;
+        box-shadow:
+          inset 0 0 80px rgba(0, 0, 0, 0.85),
+          0 0 0 6px #1a1a1a,
+          0 0 0 12px #0a0a0a,
+          0 30px 60px rgba(0, 0, 0, 0.7);
+        text-shadow: 0 0 4px var(--shadow);
+        white-space: pre-wrap;
+      }
+      .crt::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, 0) 0 1px,
+          rgba(0, 0, 0, 0.22) 1px 3px
+        );
+        pointer-events: none;
+      }
+      .crt::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(
+          ellipse at 50% 0%,
+          rgba(255, 255, 255, 0.06),
+          transparent 60%
+        );
+        pointer-events: none;
+      }
+      a {
+        color: var(--bright);
+        text-decoration: underline;
+        text-decoration-color: var(--dim);
+      }
+      a:hover {
+        background: var(--bright);
+        color: var(--bg);
+        text-shadow: none;
+      }
+      .b {
+        color: var(--bright);
+      }
+      .d {
+        color: var(--dim);
+      }
+      .blink {
+        animation: blink 1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cursor {
+        display: inline-block;
+        width: 0.55em;
+        background: var(--bright);
+        color: var(--bright);
+        animation: blink 1s steps(1) infinite;
+      }
+      hr {
+        border: 0;
+        border-top: 1px dashed var(--dim);
+        margin: 14px 0;
+      }
+      h1.sr {
+        position: absolute;
+        left: -9999px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="crt">
+      <h1 class="sr">Code Self Study terminal</h1>
+      <span class="d">DEC VT100 ─ tty/css0 ─ 24x80 ─ login banner</span>
+
+      <span class="d">Trying 192.0.2.14...</span>
+      <span class="d">Connected to css.local. Escape character is '^]'.</span>
+
+      <span class="d"
+        >─────────────────────────────────────────────────────────────────────</span
+      >
+      <span class="b">code-self-study</span>
+      <span class="d">issue 5247 · est. 2014</span>
+      <span class="d"
+        >─────────────────────────────────────────────────────────────────────</span
+      >
+
+      <span class="d"> Berkeley, CA ─ unauthorized study is encouraged</span>
+      <span class="d">
+        All connections are logged in friendly memory only.</span
+      >
+
+      login: <span class="b">guest</span> password:
+      <span class="d">····················</span>
+
+      Last login: Sat Apr 18 09:00:01 on console You have
+      <span class="b">new mail.</span>
+
+      <span class="d"
+        >─[ message of the day
+        ]─────────────────────────────────────────────</span
+      >
+
+      <span class="b">Welcome.</span> Code Self Study is a friendly programming
+      community of <span class="b">5,247</span> members in Berkeley and the San
+      Francisco Bay Area. All languages, all levels of experience are welcome.
+      The format is self-study with mentorship. Show up at a meetup, bring a
+      question or a project, get help from the regulars. The experienced members
+      help the beginners. No curriculum, no gatekeeping, no bootcamp pitch. To
+      enlist:
+      <a href="https://www.meetup.com/codeselfstudy/">$ join --community</a>
+
+      <span class="d"
+        >────────────────────────────────────────────────────────────────────</span
+      >
+
+      guest@css:~$ <span class="b">cat /etc/css/about.txt</span>
+      <span class="b">community </span> show up; meet programmers who keep
+      showing up. <span class="b">mentorship </span> experienced members help
+      beginners — questions, study plans, project reviews.
+      <span class="b">networking </span> members have landed jobs through
+      introductions made inside the group. guest@css:~$
+      <span class="b">ls /var/log/events</span> total
+      <span class="b">11y</span> drwxr-xr-x meetup-saturday-9am.log -rw-r--r--
+      forum-threads.live -rw-r--r-- reading-group-crafting-interpreters.live
+      -rw-r--r-- puzzles-weekly.live -rw-r--r-- jobs-board.live guest@css:~$
+      <span class="b">finger languages</span>
+      <span class="b">Active dialects (rotating, partial list):</span>
+      <a href="#">python</a> <a href="#">javascript</a>
+      <a href="#">typescript</a> <a href="#">go</a> <a href="#">rust</a>
+      <a href="#">haskell</a> <a href="#">clojure</a> <a href="#">elixir</a>
+      <a href="#">racket</a> <a href="#">scheme</a> <a href="#">common-lisp</a>
+      <a href="#">elm</a> <a href="#">purescript</a> <a href="#">ruby</a>
+      <a href="#">scala</a> <a href="#">c</a> <a href="#">c++</a>
+      <a href="#">f#</a> <a href="#">lua</a> <a href="#">julia</a>
+      <a href="#">erlang</a> <a href="#">r</a> <a href="#">sql</a>
+      <a href="#">octave</a> ...
+      <span class="d">use `man &lt;name&gt;` for details</span>
+
+      guest@css:~$ <span class="b">whoami</span> someone who is about to enlist.
+      guest@css:~$ <span class="b">join --community</span> Confirm? [<span
+        class="b"
+        >Y</span
+      >/n] <span class="cursor">y</span>
+
+      <a href="https://www.meetup.com/codeselfstudy/"
+        >▶ Connecting to meetup.com/codeselfstudy ─ press RETURN to confirm</a
+      >
+
+      <hr />
+      <span class="d"
+        >tty/css0 · uptime 11y 87d · load 0.42 0.38 0.31 · signal: clear</span
+      >
+      guest@css:~$ <span class="cursor"> </span>
+    </div>
+  </body>
+</html>

--- a/mockups/25-c64.html
+++ b/mockups/25-c64.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — C64</title>
+    <style>
+      :root {
+        --border: #7869c4;
+        --bg: #4843b6;
+        --fg: #b3a9ee;
+        --bright: #ffffff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--border);
+        color: var(--fg);
+        font-family:
+          "C64 Pro Mono", "C64", "Px437 IBM VGA8", "VT323", "Courier New",
+          ui-monospace, Menlo, monospace;
+        font-size: 18px;
+        line-height: 1.1;
+        font-weight: 700;
+        min-height: 100vh;
+        padding: 28px 16px 60px;
+      }
+      a {
+        color: var(--bright);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--bright);
+        color: var(--bg);
+      }
+      .case {
+        max-width: 880px;
+        margin: 0 auto;
+        background: var(--border);
+        padding: 26px;
+        position: relative;
+        box-shadow:
+          inset 0 0 0 6px var(--border),
+          0 0 0 8px #2c2486,
+          0 0 0 14px #1a1455;
+      }
+      .case::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, 0) 0 1px,
+          rgba(0, 0, 0, 0.18) 1px 3px
+        );
+        pointer-events: none;
+        z-index: 5;
+      }
+      .screen {
+        background: var(--bg);
+        padding: 22px;
+        white-space: pre-wrap;
+        position: relative;
+      }
+      .b {
+        color: var(--bright);
+      }
+      .d {
+        color: #8a82d8;
+      }
+      .blink {
+        animation: blink 0.9s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cursor {
+        display: inline-block;
+        width: 0.6em;
+        height: 1.05em;
+        background: var(--bright);
+        vertical-align: text-bottom;
+        animation: blink 0.9s steps(1) infinite;
+      }
+      .pet {
+        white-space: pre;
+        line-height: 1;
+        font-size: 18px;
+      }
+      .row {
+        display: block;
+      }
+      h1.sr,
+      h2.sr {
+        position: absolute;
+        left: -9999px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="case">
+      <div class="screen">
+        <h1 class="sr">Code Self Study C64 boot</h1>
+        <span class="b"> **** CODE SELF STUDY BASIC V12 ****</span>
+
+        <span class="b"> 65536 BYTES OF FRIENDSHIP FREE</span>
+
+        <span class="d">READY.</span>
+        <span class="b">LOAD"$",8</span>
+
+        <span class="b">SEARCHING FOR $</span>
+        <span class="b">LOADING</span>
+        <span class="b">READY.</span>
+        <span class="b">LIST</span>
+
+        <span class="d">0 </span
+        ><span class="b">REM ─ CODE SELF STUDY ─ EST 2014 ─ BERKELEY CA</span>
+        <span class="d">10 </span
+        ><span class="b">PRINT "WELCOME TO CODE SELF STUDY"</span>
+        <span class="d">20 </span
+        ><span class="b">PRINT "A BAY AREA PROGRAMMING COMMUNITY."</span>
+        <span class="d">30 </span><span class="b">LET MEMBERS = 5247</span>
+        <span class="d">40 </span
+        ><span class="b">LET LANGUAGES = "ALL OF THEM"</span>
+        <span class="d">50 </span
+        ><span class="b">LET FORMAT = "SELF-STUDY + MENTORSHIP"</span>
+        <span class="d">60 </span><span class="b">LET COVER = 0</span>
+        <span class="d">70 </span
+        ><span class="b">PRINT "SHOW UP. ASK A QUESTION."</span>
+        <span class="d">80 </span
+        ><span class="b">PRINT "MEET PROGRAMMERS WHO KEEP SHOWING UP."</span>
+        <span class="d">90 </span><span class="b">GOSUB 200 :REM ─ JOIN ─</span>
+        <span class="d">100 </span><span class="b">GOTO 10</span>
+
+        <span class="d">READY.</span>
+        <span class="b">RUN</span>
+
+        <span class="b">─────────────────────────────────────────────────</span>
+        <span class="b"> WELCOME TO CODE SELF STUDY</span>
+        <span class="b"> A BAY AREA PROGRAMMING COMMUNITY.</span>
+        <span class="b"> SHOW UP. ASK A QUESTION.</span>
+        <span class="b"> MEET PROGRAMMERS WHO KEEP SHOWING UP.</span>
+        <span class="b">─────────────────────────────────────────────────</span>
+
+        <span class="d">▌</span><span class="b">DIRECTORY</span
+        ><span class="d"> ─ PRESS A KEY ─ </span
+        ><span class="b">SEE BELOW</span>
+
+        <span class="b">F1 </span>
+        <a href="#">EVENTS .... THIS SAT, 9 AM, BERKELEY</a>
+        <span class="b">F3 </span> <a href="#">FORUM ..... ONGOING THREADS</a>
+        <span class="b">F5 </span>
+        <a href="#">LEARN ..... STUDY GUIDES + GROUPS</a>
+        <span class="b">F7 </span> <a href="#">JOBS ...... POSTED BY MEMBERS</a>
+        <span class="b">F2 </span> <a href="#">PUZZLES ... WEEKLY CHALLENGE</a>
+        <span class="b">F4 </span>
+        <a href="#">TOOLS ..... CURATED REFERENCES</a>
+        <span class="b">F6 </span> <a href="#">ABOUT ..... A SHORT HISTORY</a>
+        <span class="b">F8 </span>
+        <a href="https://www.meetup.com/codeselfstudy/">JOIN ......</a>
+        <a href="https://www.meetup.com/codeselfstudy/"
+          ><span class="b">►► PRESS HERE ◄◄</span></a
+        >
+
+        <span class="b">─────────────────────────────────────────────────</span>
+        <span class="b">FEATURES</span>
+        <span class="b">─────────────────────────────────────────────────</span>
+        <span class="b">► COMMUNITY </span> SHOW UP. MEET PEOPLE WHO KEEP
+        SHOWING UP WEEK BY WEEK.
+
+        <span class="b">► MENTORSHIP </span> EXPERIENCED MEMBERS HELP BEGINNERS.
+        ASK FOR A PLAN.
+
+        <span class="b">► NETWORKING </span> MEMBERS HAVE LANDED JOBS THROUGH
+        INTROS AT MEETUPS.
+
+        <span class="b">─────────────────────────────────────────────────</span>
+        <span class="b">LANGUAGES IN ROTATION</span>
+        <span class="b">─────────────────────────────────────────────────</span>
+        PYTHON RUST HASKELL GO TYPESCRIPT CLOJURE ELIXIR RACKET RUBY SCALA C++
+        SQL ELM LUA JULIA ...
+
+        <span class="b">─────────────────────────────────────────────────</span>
+        <span class="b">200 ─ SUBROUTINE: JOIN</span>
+        <span class="b">─────────────────────────────────────────────────</span>
+        <a href="https://www.meetup.com/codeselfstudy/"
+          ><span class="b">►► JOIN THE COMMUNITY ON MEETUP.COM ◄◄</span></a
+        >
+        RETURN
+
+        <span class="d">READY.</span>
+        <span class="cursor"> </span>
+      </div>
+    </div>
+  </body>
+</html>

--- a/mockups/26-brutalist-muted.html
+++ b/mockups/26-brutalist-muted.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Muted brutalist</title>
+    <style>
+      :root {
+        --paper: #ece7df;
+        --ink: #1c1b18;
+        --soft: #d8d2c5;
+        --rule: #2a2823;
+        --ochre: #b07d2f;
+        --olive: #6e7548;
+        --slate: #4a5568;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 2px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        font-size: 14px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        border: 2px solid transparent;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--soft);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 36px 28px 72px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.5fr 1fr;
+        gap: 20px;
+      }
+      .panel {
+        border: 2px solid var(--rule);
+        background: var(--paper);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--soft);
+      }
+      .hero .main h1 {
+        font-size: clamp(36px, 5.5vw, 76px);
+        line-height: 1;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 2px solid var(--ink);
+      }
+      .btn:hover {
+        background: var(--ochre);
+        color: var(--ink);
+        border-color: var(--ink);
+      }
+      .side h2 {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .side .stat {
+        font-size: 84px;
+        font-weight: 800;
+        line-height: 0.95;
+        margin: 4px 0 6px;
+        letter-spacing: -0.04em;
+      }
+      .side .stat span {
+        color: var(--ochre);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px solid var(--rule);
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 14px;
+      }
+      .side li b {
+        font-weight: 700;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin-top: 24px;
+      }
+      .features .panel {
+        padding: 22px;
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+        color: var(--ink);
+      }
+      .features .num {
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        color: var(--olive);
+        margin-bottom: 10px;
+      }
+      .features .panel:nth-child(2) .num {
+        color: var(--ochre);
+      }
+      .features .panel:nth-child(3) .num {
+        color: var(--slate);
+      }
+      .big {
+        margin-top: 24px;
+        padding: 28px;
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 18px;
+      }
+      .tag {
+        border: 1.5px solid var(--rule);
+        padding: 3px 8px;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+      }
+      .tag.a {
+        background: var(--ochre);
+        color: var(--paper);
+      }
+      .tag.b {
+        background: var(--olive);
+        color: var(--paper);
+      }
+      .tag.c {
+        background: var(--slate);
+        color: var(--paper);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="panel main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side">
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9am</b></li>
+            <li><span>Location</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <div class="num">01 · Community</div>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">02 · Mentorship</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">03 · Networking</div>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/27-brutalist-concrete.html
+++ b/mockups/27-brutalist-concrete.html
@@ -1,0 +1,372 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Concrete brutalist</title>
+    <style>
+      :root {
+        --concrete: #c9c5be;
+        --concrete-dark: #9d9890;
+        --shadow: #45433f;
+        --ink: #14130f;
+        --rust: #94432a;
+        --kraft: #b69968;
+        --steel: #4d6271;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--concrete);
+        background-image:
+          radial-gradient(
+            circle at 20% 30%,
+            rgba(0, 0, 0, 0.06) 0,
+            transparent 40%
+          ),
+          radial-gradient(
+            circle at 80% 70%,
+            rgba(0, 0, 0, 0.05) 0,
+            transparent 40%
+          ),
+          repeating-radial-gradient(
+            circle at 50% 50%,
+            rgba(0, 0, 0, 0.015) 0 1px,
+            transparent 1px 3px
+          );
+        color: var(--ink);
+        font-family:
+          "IBM Plex Sans", "Helvetica Neue", ui-sans-serif, system-ui,
+          sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      header {
+        padding: 24px 28px 0;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+      .top {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-end;
+        gap: 16px;
+        flex-wrap: wrap;
+        border-bottom: 6px solid var(--ink);
+        padding-bottom: 12px;
+      }
+      .mark {
+        font-weight: 800;
+        font-size: 13px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--ink);
+      }
+      .mark .slash {
+        color: var(--rust);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 22px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-weight: 600;
+      }
+      nav a:hover {
+        background: var(--ink);
+        color: var(--concrete);
+        padding: 0 4px;
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 28px 28px 80px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 5fr 3fr;
+        gap: 0;
+        border: 4px solid var(--ink);
+        background: var(--ink);
+      }
+      .hero > div {
+        padding: 36px 32px;
+      }
+      .hero .lede {
+        background: var(--concrete-dark);
+      }
+      .hero .lede h1 {
+        font-size: clamp(42px, 6vw, 88px);
+        line-height: 0.95;
+        margin: 0;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+        color: var(--ink);
+      }
+      .hero .lede h1 em {
+        font-style: normal;
+        color: var(--rust);
+      }
+      .hero .lede p {
+        margin: 24px 0 28px;
+        max-width: 36ch;
+        font-size: 18px;
+        font-weight: 500;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        padding: 14px 22px;
+        background: var(--ink);
+        color: var(--kraft);
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        font-size: 14px;
+      }
+      .btn:hover {
+        background: var(--rust);
+        color: var(--concrete);
+      }
+      .hero .pier {
+        background: var(--shadow);
+        color: var(--concrete);
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        justify-content: center;
+      }
+      .pier .row {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 8px 0;
+        border-bottom: 1px dashed var(--concrete-dark);
+        font-size: 14px;
+        letter-spacing: 0.04em;
+      }
+      .pier .row:last-child {
+        border: 0;
+      }
+      .pier .row b {
+        font-weight: 700;
+        color: var(--kraft);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .pier .stamp {
+        margin-top: 12px;
+        align-self: flex-start;
+        border: 2px solid var(--kraft);
+        color: var(--kraft);
+        padding: 6px 10px;
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+      }
+      .columns {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        margin-top: 28px;
+        border: 4px solid var(--ink);
+      }
+      .columns > div {
+        padding: 26px;
+        border-right: 4px solid var(--ink);
+        background: var(--concrete);
+      }
+      .columns > div:last-child {
+        border-right: 0;
+      }
+      .columns h3 {
+        margin: 0 0 8px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .columns p {
+        margin: 0;
+        font-size: 15px;
+      }
+      .columns .ref {
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.16em;
+        margin-bottom: 12px;
+        color: var(--steel);
+      }
+      .slab {
+        margin-top: 28px;
+        background: var(--ink);
+        color: var(--concrete);
+        padding: 36px 32px;
+        border: 4px solid var(--ink);
+      }
+      .slab h2 {
+        margin: 0 0 12px;
+        font-size: clamp(28px, 3.6vw, 44px);
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .slab h2 span {
+        color: var(--kraft);
+      }
+      .slab p {
+        max-width: 60ch;
+        margin: 0;
+        font-size: 16px;
+        color: var(--concrete);
+      }
+      .langs {
+        margin-top: 24px;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 0;
+        border-top: 1px solid var(--concrete-dark);
+        border-left: 1px solid var(--concrete-dark);
+      }
+      .langs span {
+        padding: 8px 12px;
+        border-right: 1px solid var(--concrete-dark);
+        border-bottom: 1px solid var(--concrete-dark);
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 13px;
+        letter-spacing: 0.04em;
+      }
+      footer {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 16px 28px 28px;
+        border-top: 6px solid var(--ink);
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .columns {
+          grid-template-columns: 1fr;
+        }
+        .columns > div {
+          border-right: 0;
+          border-bottom: 4px solid var(--ink);
+        }
+        .columns > div:last-child {
+          border-bottom: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="top">
+        <div class="mark">
+          Code <span class="slash">/</span> Self <span class="slash">/</span>
+          Study
+        </div>
+        <nav>
+          <ul>
+            <li><a href="#">Events</a></li>
+            <li><a href="#">Learn</a></li>
+            <li><a href="#">Forum</a></li>
+            <li><a href="#">Jobs</a></li>
+            <li><a href="#">Puzzles</a></li>
+            <li><a href="#">About</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <div class="wrap">
+      <section class="hero">
+        <div class="lede">
+          <h1>A room. <em>Real chairs.</em> Other programmers.</h1>
+          <p>
+            Code Self Study is a friendly programming community of 5,000+ people
+            in Berkeley and the San Francisco Bay Area. Show up. Bring your
+            work. Meet the regulars.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community →</a
+          >
+        </div>
+        <div class="pier">
+          <div class="row"><span>Established</span><b>2014</b></div>
+          <div class="row"><span>Members</span><b>5,247</b></div>
+          <div class="row"><span>Saturdays</span><b>9 am, Berkeley</b></div>
+          <div class="row"><span>Cover</span><b>Free</b></div>
+          <div class="row"><span>Languages</span><b>All of them</b></div>
+          <div class="stamp">Reinforced concrete · 2014</div>
+        </div>
+      </section>
+
+      <section class="columns">
+        <div>
+          <div class="ref">SECT 01 · COMMUNITY</div>
+          <h3>Show up.</h3>
+          <p>
+            Meet programmers who keep showing up week after week. The hard part
+            is done: the room exists.
+          </p>
+        </div>
+        <div>
+          <div class="ref">SECT 02 · MENTORSHIP</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div>
+          <div class="ref">SECT 03 · NETWORKING</div>
+          <h3>Doors open.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group.
+          </p>
+        </div>
+      </section>
+
+      <section class="slab">
+        <h2>All languages. <span>All levels.</span></h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          highly-motivated programmers instead. The format is self-study with
+          mentorship.
+        </p>
+        <div class="langs">
+          <span>python</span><span>js</span><span>typescript</span
+          ><span>go</span><span>rust</span><span>haskell</span
+          ><span>clojure</span><span>elixir</span><span>racket</span
+          ><span>scheme</span><span>c</span><span>c++</span><span>ruby</span
+          ><span>scala</span><span>erlang</span><span>elm</span><span>lua</span
+          ><span>sql</span><span>julia</span><span>r</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Bearing wall · Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/28-brutalist-stained.html
+++ b/mockups/28-brutalist-stained.html
@@ -1,0 +1,384 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Stained-glass brutalist</title>
+    <style>
+      :root {
+        --paper: #f3efe6;
+        --ink: #161616;
+        --lead: #1c1c1c;
+        --amber: rgba(218, 145, 32, 0.55);
+        --teal: rgba(34, 120, 138, 0.55);
+        --plum: rgba(116, 50, 110, 0.5);
+        --moss: rgba(78, 116, 56, 0.55);
+        --sky: rgba(74, 118, 178, 0.5);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 600;
+        line-height: 1.5;
+        background-image:
+          radial-gradient(
+            circle at 10% 10%,
+            rgba(255, 220, 150, 0.25),
+            transparent 35%
+          ),
+          radial-gradient(
+            circle at 90% 90%,
+            rgba(150, 200, 220, 0.2),
+            transparent 40%
+          );
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 28px;
+        border-bottom: 4px solid var(--lead);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 800;
+        font-size: 18px;
+        padding: 6px 12px;
+        border: 4px solid var(--lead);
+        background: var(--paper);
+        letter-spacing: 0.04em;
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 6px 10px;
+        border: 3px solid var(--lead);
+        font-size: 14px;
+        background: var(--paper);
+      }
+      nav a:hover {
+        background: var(--amber);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 36px 28px 80px;
+      }
+      .hero {
+        position: relative;
+        border: 5px solid var(--lead);
+        padding: 0;
+        min-height: 380px;
+        background: var(--paper);
+        overflow: hidden;
+      }
+      .pane {
+        position: absolute;
+        border: 4px solid var(--lead);
+        backdrop-filter: blur(2px);
+      }
+      .p1 {
+        top: -60px;
+        left: -40px;
+        width: 360px;
+        height: 360px;
+        background: var(--amber);
+      }
+      .p2 {
+        top: 40px;
+        left: 220px;
+        width: 320px;
+        height: 320px;
+        background: var(--teal);
+      }
+      .p3 {
+        top: -30px;
+        right: -40px;
+        width: 300px;
+        height: 280px;
+        background: var(--plum);
+      }
+      .p4 {
+        bottom: -60px;
+        left: 120px;
+        width: 380px;
+        height: 240px;
+        background: var(--moss);
+      }
+      .p5 {
+        bottom: 30px;
+        right: 80px;
+        width: 280px;
+        height: 240px;
+        background: var(--sky);
+      }
+      .hero-text {
+        position: relative;
+        z-index: 2;
+        padding: 36px 32px;
+        max-width: 36ch;
+      }
+      .hero-text h1 {
+        margin: 0 0 16px;
+        font-size: clamp(38px, 5.6vw, 76px);
+        line-height: 0.96;
+        font-weight: 900;
+        letter-spacing: -0.025em;
+        color: var(--lead);
+        background: var(--paper);
+        display: inline;
+        box-shadow:
+          8px 0 0 var(--paper),
+          -8px 0 0 var(--paper);
+        padding: 2px 0;
+      }
+      .hero-text p {
+        margin-top: 22px;
+        background: var(--paper);
+        display: inline-block;
+        padding: 6px 10px;
+        border: 3px solid var(--lead);
+        font-size: 16px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--lead);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 800;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        font-size: 14px;
+        border: 4px solid var(--lead);
+        margin-top: 18px;
+      }
+      .btn:hover {
+        background: var(--amber);
+        color: var(--lead);
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin-top: 24px;
+      }
+      .feat {
+        position: relative;
+        border: 5px solid var(--lead);
+        padding: 22px;
+        background: var(--paper);
+        overflow: hidden;
+      }
+      .feat::before {
+        content: "";
+        position: absolute;
+        inset: auto -40px -40px auto;
+        width: 180px;
+        height: 180px;
+        border: 3px solid var(--lead);
+      }
+      .feat:nth-child(1)::before {
+        background: var(--amber);
+      }
+      .feat:nth-child(2)::before {
+        background: var(--teal);
+      }
+      .feat:nth-child(3)::before {
+        background: var(--moss);
+      }
+      .feat .num {
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 12px;
+        letter-spacing: 0.18em;
+        color: var(--lead);
+        opacity: 0.7;
+        margin-bottom: 8px;
+      }
+      .feat h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 900;
+        position: relative;
+        z-index: 1;
+      }
+      .feat p {
+        margin: 0;
+        font-size: 15px;
+        font-weight: 500;
+        position: relative;
+        z-index: 1;
+        background: var(--paper);
+        display: inline;
+      }
+      .big {
+        margin-top: 24px;
+        position: relative;
+        border: 5px solid var(--lead);
+        padding: 32px;
+        background: var(--paper);
+        overflow: hidden;
+      }
+      .big::before {
+        content: "";
+        position: absolute;
+        top: 30px;
+        right: -80px;
+        width: 280px;
+        height: 280px;
+        background: var(--plum);
+        border: 4px solid var(--lead);
+      }
+      .big::after {
+        content: "";
+        position: absolute;
+        bottom: -60px;
+        right: 140px;
+        width: 220px;
+        height: 220px;
+        background: var(--sky);
+        border: 4px solid var(--lead);
+      }
+      .big h2 {
+        font-size: clamp(28px, 4vw, 50px);
+        font-weight: 900;
+        margin: 0 0 12px;
+        letter-spacing: -0.02em;
+        position: relative;
+        z-index: 1;
+      }
+      .big p {
+        max-width: 56ch;
+        margin: 0 0 18px;
+        position: relative;
+        z-index: 1;
+        font-weight: 500;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        position: relative;
+        z-index: 1;
+      }
+      .tag {
+        background: var(--paper);
+        border: 3px solid var(--lead);
+        padding: 3px 8px;
+        font-size: 13px;
+      }
+      footer {
+        padding: 24px 28px;
+        border-top: 4px solid var(--lead);
+        font-size: 13px;
+        text-align: center;
+      }
+      @media (max-width: 820px) {
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">CODE / SELF / STUDY</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="pane p1"></div>
+        <div class="pane p2"></div>
+        <div class="pane p3"></div>
+        <div class="pane p4"></div>
+        <div class="pane p5"></div>
+        <div class="hero-text">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            5,000+ programmers in Berkeley and the Bay Area. All languages, all
+            levels. Self-study with mentorship.
+          </p>
+          <br />
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community →</a
+          >
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="feat">
+          <div class="num">01 · COMMUNITY</div>
+          <h3>Show up.</h3>
+          <p>
+            Meet programmers who keep showing up week after week — the hard part
+            is done: the room exists.
+          </p>
+        </div>
+        <div class="feat">
+          <div class="num">02 · MENTORSHIP</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners with study plans, code reviews,
+            and stuck commits.
+          </p>
+        </div>
+        <div class="feat">
+          <div class="num">03 · NETWORKING</div>
+          <h3>Doors open.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the group
+            — quietly, no pitch.
+          </p>
+        </div>
+      </section>
+
+      <section class="big">
+        <h2>All languages. All levels.</h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          highly-motivated programmers instead. The format is self-study with
+          mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag">Python</span><span class="tag">JavaScript</span
+          ><span class="tag">TypeScript</span><span class="tag">Go</span
+          ><span class="tag">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>Code Self Study · Berkeley, CA · Est. 2014</footer>
+  </body>
+</html>

--- a/mockups/29-brutalist-forest.html
+++ b/mockups/29-brutalist-forest.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Forest brutalist</title>
+    <style>
+      :root {
+        --cream: #f0ead6;
+        --bark: #2c2a22;
+        --moss: #2f4a30;
+        --moss-deep: #1f3320;
+        --tan: #b88e54;
+        --rust: #8e3b1f;
+        --slate: #5a6a55;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--cream);
+        color: var(--bark);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 600;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        background: var(--moss-deep);
+        color: var(--cream);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        flex-wrap: wrap;
+        gap: 12px;
+        border-bottom: 6px solid var(--bark);
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.18em;
+        font-size: 14px;
+        text-transform: uppercase;
+        background: var(--cream);
+        color: var(--bark);
+        padding: 6px 12px;
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 6px 12px;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-weight: 700;
+        color: var(--cream);
+      }
+      nav a:hover {
+        background: var(--tan);
+        color: var(--moss-deep);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 32px 28px 80px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.5fr 1fr;
+        gap: 0;
+        border: 5px solid var(--bark);
+        background: var(--bark);
+      }
+      .hero > div {
+        padding: 32px 30px;
+      }
+      .hero .lede {
+        background: var(--moss);
+        color: var(--cream);
+      }
+      .hero .lede .badge {
+        display: inline-block;
+        border: 2px solid var(--cream);
+        padding: 4px 10px;
+        font-size: 12px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        margin-bottom: 18px;
+      }
+      .hero .lede h1 {
+        font-size: clamp(40px, 5.6vw, 78px);
+        line-height: 0.96;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.025em;
+      }
+      .hero .lede p {
+        margin: 0 0 22px;
+        max-width: 36ch;
+        font-size: 17px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--tan);
+        color: var(--moss-deep);
+        padding: 12px 18px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        font-size: 14px;
+        border: 3px solid var(--cream);
+      }
+      .btn:hover {
+        background: var(--cream);
+      }
+      .hero .panel {
+        background: var(--cream);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .hero .panel h2 {
+        margin: 0;
+        font-size: 12px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .hero .panel .stat {
+        font-size: 90px;
+        line-height: 0.95;
+        font-weight: 800;
+        letter-spacing: -0.04em;
+        margin: 6px 0 4px;
+      }
+      .hero .panel .sub {
+        font-size: 14px;
+        color: var(--slate);
+        margin-bottom: 18px;
+      }
+      .hero .panel ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        border-top: 1.5px solid var(--bark);
+      }
+      .hero .panel li {
+        display: flex;
+        justify-content: space-between;
+        padding: 10px 0;
+        border-bottom: 1.5px solid var(--bark);
+        font-size: 14px;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        margin-top: 24px;
+        border: 5px solid var(--bark);
+      }
+      .features > div {
+        padding: 24px;
+        border-right: 5px solid var(--bark);
+        background: var(--cream);
+      }
+      .features > div:last-child {
+        border-right: 0;
+      }
+      .features .marker {
+        width: 28px;
+        height: 28px;
+        background: var(--moss);
+        margin-bottom: 12px;
+      }
+      .features > div:nth-child(2) .marker {
+        background: var(--tan);
+      }
+      .features > div:nth-child(3) .marker {
+        background: var(--rust);
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+      }
+      .trail {
+        margin-top: 24px;
+        border: 5px solid var(--bark);
+        background: var(--cream);
+        padding: 28px;
+      }
+      .trail h2 {
+        font-size: clamp(28px, 4vw, 48px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .trail p {
+        max-width: 60ch;
+      }
+      .langs {
+        margin-top: 18px;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 0;
+        border-top: 2px solid var(--bark);
+        border-left: 2px solid var(--bark);
+      }
+      .langs span {
+        padding: 8px 14px;
+        border-right: 2px solid var(--bark);
+        border-bottom: 2px solid var(--bark);
+        font-size: 14px;
+        background: var(--cream);
+      }
+      .langs span:nth-child(7n) {
+        background: var(--moss);
+        color: var(--cream);
+      }
+      .langs span:nth-child(11n) {
+        background: var(--tan);
+      }
+      footer {
+        background: var(--moss-deep);
+        color: var(--cream);
+        padding: 18px 28px;
+        font-size: 13px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        text-align: center;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+        .features > div {
+          border-right: 0;
+          border-bottom: 5px solid var(--bark);
+        }
+        .features > div:last-child {
+          border-bottom: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="lede">
+          <div class="badge">Trailhead · est. 2014</div>
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community →</a
+          >
+        </div>
+        <div class="panel">
+          <h2>Members</h2>
+          <div class="stat">5,247</div>
+          <div class="sub">Bay Area programmers</div>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9 am</b></li>
+            <li><span>Trailhead</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div>
+          <div class="marker"></div>
+          <h3>Community</h3>
+          <p>
+            Show up. Meet programmers who keep showing up week after week. The
+            hard part is done: the room exists.
+          </p>
+        </div>
+        <div>
+          <div class="marker"></div>
+          <h3>Mentorship</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit. Ask for a study plan.
+          </p>
+        </div>
+        <div>
+          <div class="marker"></div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. Quietly, no pitch.
+          </p>
+        </div>
+      </section>
+
+      <section class="trail">
+        <h2>All languages. All levels.</h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          highly-motivated programmers instead. The format is self-study with
+          mentorship.
+        </p>
+        <div class="langs">
+          <span>Python</span><span>JavaScript</span><span>TypeScript</span
+          ><span>Go</span><span>Rust</span><span>Haskell</span
+          ><span>Clojure</span><span>Elixir</span><span>Racket</span
+          ><span>Scheme</span><span>C</span><span>C++</span><span>Ruby</span
+          ><span>Scala</span><span>Erlang</span><span>Elm</span><span>Lua</span
+          ><span>SQL</span><span>Julia</span><span>R</span>
+        </div>
+      </section>
+    </div>
+    <footer>Code Self Study — Berkeley, CA — Est. 2014</footer>
+  </body>
+</html>

--- a/mockups/30-bbs-pcboard.html
+++ b/mockups/30-bbs-pcboard.html
@@ -1,0 +1,188 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — PCBoard BBS</title>
+    <style>
+      :root {
+        --bg: #000060;
+        --frame: #0000a8;
+        --cyan: #54fefe;
+        --bcyan: #54ffff;
+        --yellow: #fefe54;
+        --white: #ffffff;
+        --gray: #aaaaaa;
+        --green: #54fe54;
+        --red: #fe5454;
+        --magenta: #fe54fe;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: #000;
+        color: var(--white);
+        font-family:
+          "Px437 IBM VGA8", "Perfect DOS VGA 437", "Cascadia Mono", "VT323",
+          "Courier New", ui-monospace, Menlo, monospace;
+        font-size: 17px;
+        line-height: 1.15;
+        font-weight: 700;
+        letter-spacing: 0.01em;
+        min-height: 100vh;
+      }
+      .crt {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 18px;
+        background: var(--bg);
+        border-radius: 14px / 28px;
+        position: relative;
+        overflow: hidden;
+        box-shadow:
+          inset 0 0 60px rgba(0, 0, 0, 0.8),
+          0 0 0 8px #1a1a1a,
+          0 0 0 14px #050505;
+      }
+      .crt::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, 0) 0 1px,
+          rgba(0, 0, 0, 0.22) 1px 3px
+        );
+        pointer-events: none;
+      }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--bcyan);
+        color: var(--bg);
+      }
+      pre.page {
+        white-space: pre;
+        position: relative;
+        z-index: 1;
+        margin: 0;
+        font-family: inherit;
+        font-size: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+        color: inherit;
+      }
+      .c {
+        color: var(--cyan);
+      }
+      .y {
+        color: var(--yellow);
+      }
+      .w {
+        color: var(--white);
+      }
+      .g {
+        color: var(--green);
+      }
+      .r {
+        color: var(--red);
+      }
+      .m {
+        color: var(--magenta);
+      }
+      .gr {
+        color: var(--gray);
+      }
+      .bf {
+        color: var(--frame);
+      }
+      .blink {
+        animation: blink 0.9s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cursor {
+        display: inline-block;
+        width: 0.6em;
+        height: 1em;
+        background: var(--bcyan);
+        vertical-align: text-bottom;
+        animation: blink 0.9s steps(1) infinite;
+      }
+      h1.sr,
+      h2.sr {
+        position: absolute;
+        left: -9999px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="crt">
+      <h1 class="sr">Code Self Study PCBoard</h1>
+      <!-- prettier-ignore -->
+      <pre class="page"><span class="c">╔══════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="c">║</span>  <span class="y">PCBoard (R) v15.4/M10 - Node 01</span>     <span class="w">CODE SELF STUDY BBS</span>     <span class="g">5247 Users</span>  <span class="c">║</span>
+<span class="c">╚══════════════════════════════════════════════════════════════════════════════╝</span>
+
+<span class="m">  ╓──────────────────────────────────────────────────────────────────────────╖</span>
+<span class="m">  ║</span>   <span class="y">@</span><span class="w">CODE</span><span class="y">@</span> <span class="y">@</span><span class="w">SELF</span><span class="y">@</span> <span class="y">@</span><span class="w">STUDY</span><span class="y">@</span>            <span class="c">a friendly programming community</span>   <span class="m">║</span>
+<span class="m">  ║</span>   <span class="gr">────────────────────────</span>            <span class="gr">────────────────────────────────</span>   <span class="m">║</span>
+<span class="m">  ║</span>   <span class="g">5,000+ members</span> <span class="gr">·</span> <span class="g">Berkeley, CA</span> <span class="gr">·</span> <span class="g">San Francisco Bay Area</span> <span class="gr">·</span> <span class="g">est. 2014</span>   <span class="m">║</span>
+<span class="m">  ╙──────────────────────────────────────────────────────────────────────────╜</span>
+
+  <span class="c">Conference  </span><span class="w">(0) </span><span class="y">Main Board</span> <span class="gr">───────────────────────────────────────────────</span>
+
+  <span class="c">(N)</span> <span class="w">News</span>           <span class="gr">. . .</span>  the Saturday meetup, who showed up, what they built
+  <span class="c">(B)</span> <span class="w">Bulletins</span>      <span class="gr">. . .</span>  reading group, puzzle of the week, jobs board
+  <span class="c">(F)</span> <span class="w">File areas</span>     <span class="gr">. . .</span>  study plans, references, recommended reading
+  <span class="c">(M)</span> <span class="w">Messages</span>       <span class="gr">. . .</span>  forum threads — questions answered by regulars
+  <span class="c">(D)</span> <span class="w">Doors</span>          <span class="gr">. . .</span>  weekly puzzles, code review queue, pair-up board
+  <span class="c">(C)</span> <span class="w">Chat</span>           <span class="gr">. . .</span>  online right now: <span class="g">37</span> users
+  <span class="c">(J)</span> <span class="w">Join community</span> <span class="gr">. . .</span>  <a href="https://www.meetup.com/codeselfstudy/"><span class="y">→ meetup.com/codeselfstudy ←</span></a>
+  <span class="c">(G)</span> <span class="w">Goodbye</span>        <span class="gr">. . .</span>  log off
+
+<span class="bf">▓▒░</span><span class="c">─── BULLETIN 01 ─────────────────────────────────────────────────────────</span><span class="bf">░▒▓</span>
+
+  <span class="y">Welcome.</span>  Code Self Study is a programming community of <span class="g">5,000+</span> members
+  in Berkeley and the Bay Area.  All languages, all levels of experience.
+
+  The format is <span class="c">self-study with mentorship</span>.  Show up at a meetup, bring a
+  question or a project, get help from the regulars.  Experienced members
+  help beginners.  No curriculum, no gatekeeping, no bootcamp pitch.
+
+<span class="bf">▓▒░</span><span class="c">─── BULLETIN 02  ·  WHY PEOPLE COME ────────────────────────────────────</span><span class="bf">░▒▓</span>
+
+  <span class="y">[1]</span> <span class="w">Community</span>     show up; meet programmers who keep showing up
+  <span class="y">[2]</span> <span class="w">Mentorship</span>    experienced members help beginners — plans, reviews
+  <span class="y">[3]</span> <span class="w">Networking</span>    members have landed jobs through introductions
+
+<span class="bf">▓▒░</span><span class="c">─── FILE AREA 04  ·  LANGUAGES IN ROTATION ────────────────────────────</span><span class="bf">░▒▓</span>
+
+  <a href="#"><span class="g">PYTHON  </span></a>  <a href="#"><span class="g">RUST    </span></a>  <a href="#"><span class="g">HASKELL </span></a>  <a href="#"><span class="g">GO      </span></a>  <a href="#"><span class="g">CLOJURE </span></a>
+  <a href="#"><span class="g">TYPESCRT</span></a>  <a href="#"><span class="g">ELIXIR  </span></a>  <a href="#"><span class="g">RACKET  </span></a>  <a href="#"><span class="g">SCALA   </span></a>  <a href="#"><span class="g">RUBY    </span></a>
+  <a href="#"><span class="g">C++     </span></a>  <a href="#"><span class="g">SQL     </span></a>  <a href="#"><span class="g">JULIA   </span></a>  <a href="#"><span class="g">LUA     </span></a>  <a href="#"><span class="g">+more   </span></a>
+
+<span class="bf">▓▒░</span><span class="c">─── DOOR 09  ·  JOIN THE COMMUNITY ────────────────────────────────────</span><span class="bf">░▒▓</span>
+
+  <a href="https://www.meetup.com/codeselfstudy/"><span class="y">  ►► PRESS J TO ENTER ──→ meetup.com/codeselfstudy ◄◄  </span></a>
+
+<span class="c">═══════════════════════════════════════════════════════════════════════════════</span>
+ <span class="gr">Time on:</span> <span class="w">00:11</span>  <span class="gr">|</span>  <span class="gr">CPS:</span> <span class="w">2400</span>  <span class="gr">|</span>  <span class="gr">Node:</span> <span class="w">01</span>  <span class="gr">|</span>  <span class="gr">SysOp:</span> <span class="w">@regulars</span>  <span class="gr">|</span>  <span class="gr">Carrier:</span> <span class="g">OK</span>
+
+ <span class="y">(H)elp  (N)ews  (B)ulletins  (M)essages  (J)oin  (G)oodbye</span>
+
+ <span class="c">Main Board Command?</span> <span class="cursor"> </span></pre>
+    </div>
+  </body>
+</html>

--- a/mockups/31-bbs-renegade.html
+++ b/mockups/31-bbs-renegade.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Renegade BBS</title>
+    <style>
+      :root {
+        --bg: #100000;
+        --fg: #ff7b00;
+        --bright: #ffd27a;
+        --dim: #8a3a00;
+        --red: #ff3333;
+        --green: #66ff66;
+        --cyan: #5dd9ff;
+        --bar: #b03000;
+        --bar-fg: #ffffff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: #000;
+        color: var(--fg);
+        font-family:
+          "Px437 IBM VGA8", "Perfect DOS VGA 437", "VT323", "Cascadia Mono",
+          "Courier New", ui-monospace, Menlo, monospace;
+        font-size: 17px;
+        line-height: 1.2;
+        font-weight: 700;
+        min-height: 100vh;
+      }
+      .crt {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 18px;
+        background: var(--bg);
+        border-radius: 14px / 28px;
+        position: relative;
+        overflow: hidden;
+        box-shadow:
+          inset 0 0 60px rgba(0, 0, 0, 0.85),
+          0 0 0 8px #1a1a1a,
+          0 0 0 14px #050505;
+        text-shadow: 0 0 4px rgba(255, 123, 0, 0.4);
+      }
+      .crt::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, 0) 0 1px,
+          rgba(0, 0, 0, 0.25) 1px 3px
+        );
+        pointer-events: none;
+      }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--bright);
+        color: var(--bg);
+        text-shadow: none;
+      }
+      pre.page {
+        white-space: pre;
+        position: relative;
+        z-index: 1;
+        margin: 0;
+        font-family: inherit;
+        font-size: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+        color: inherit;
+      }
+      .b {
+        color: var(--bright);
+      }
+      .d {
+        color: var(--dim);
+      }
+      .r {
+        color: var(--red);
+      }
+      .g {
+        color: var(--green);
+      }
+      .c {
+        color: var(--cyan);
+      }
+      .lightbar {
+        background: var(--bar);
+        color: var(--bar-fg);
+        text-shadow: none;
+        padding: 0 4px;
+      }
+      .lb-key {
+        color: var(--bright);
+      }
+      .blink {
+        animation: blink 0.9s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cursor {
+        display: inline-block;
+        width: 0.6em;
+        height: 1em;
+        background: var(--bright);
+        vertical-align: text-bottom;
+        animation: blink 0.9s steps(1) infinite;
+      }
+      h1.sr {
+        position: absolute;
+        left: -9999px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="crt">
+      <h1 class="sr">Code Self Study Renegade BBS</h1>
+      <!-- prettier-ignore -->
+      <pre class="page"><span class="r">▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄</span>
+<span class="r">█</span>  <span class="b">Renegade v1.21 · Node 01</span>     <span class="r">[</span><span class="b">CODE-SELF-STUDY</span><span class="r">]</span>      <span class="d">SysOp: regulars</span>      <span class="r">█</span>
+<span class="r">▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀</span>
+
+  <span class="d">┌─</span> <span class="b">login banner</span> <span class="d">──────────────────────────────────────────────────────┐</span>
+  <span class="d">│</span>  <span class="b">user .... </span> guest             <span class="d">│</span>  <span class="b">level ... </span> 30 (visitor)        <span class="d">│</span>
+  <span class="d">│</span>  <span class="b">last on . </span> 2026-04-17 21:14   <span class="d">│</span>  <span class="b">mail .... </span> <span class="g">3 new bulletins</span>     <span class="d">│</span>
+  <span class="d">└──────────────────────────────────────────────────────────────────────────┘</span>
+
+  <span class="b">A friendly programming community of </span><span class="g">5,000+</span><span class="b"> members in Berkeley and</span>
+  <span class="b">the San Francisco Bay Area.</span>  All languages, all levels welcome.  Format:
+  <span class="c">self-study with mentorship</span>.  Show up at a meetup, bring a question or a
+  project, get help from the regulars.  No curriculum, no gatekeeping, no pitch.
+
+<span class="r">══════════════════════════════════ MAIN MENU ════════════════════════════════</span>
+
+  <span class="lightbar"> <span class="lb-key">M</span>essages    </span>  forum threads, ongoing discussions
+  <span class="lightbar"> <span class="lb-key">F</span>iles       </span>  study plans, references, reading lists
+  <span class="lightbar"> <span class="lb-key">B</span>ulletins   </span>  meetups, puzzle of the week, jobs
+  <span class="lightbar"> <span class="lb-key">D</span>oors       </span>  pair-up board, code-review queue
+  <span class="lightbar"> <span class="lb-key">U</span>sers online</span>  <span class="g">37</span> connected · <span class="g">5,247</span> registered
+  <span class="lightbar"> <span class="lb-key">C</span>hat room   </span>  live chat with sysop and regulars
+  <span class="lightbar"> <span class="lb-key">J</span>oin comm.  </span>  <a href="https://www.meetup.com/codeselfstudy/"><span class="b">→ meetup.com/codeselfstudy ←</span></a>
+  <span class="lightbar"> <span class="lb-key">G</span>oodbye     </span>  log off
+
+<span class="r">══════════════════════════════════ BULLETINS ════════════════════════════════</span>
+
+  <span class="b">[01]</span> <span class="g">why people show up</span> <span class="d">────────────────────────────────────────────</span>
+       <span class="b">community  </span>  real chairs, real people, week after week
+       <span class="b">mentorship </span>  experienced members help beginners
+       <span class="b">networking </span>  introductions inside the group, no pitch
+
+  <span class="b">[02]</span> <span class="g">languages in active rotation</span> <span class="d">──────────────────────────────────</span>
+       <a href="#">python</a>  <a href="#">js</a>  <a href="#">typescript</a>  <a href="#">go</a>  <a href="#">rust</a>  <a href="#">haskell</a>  <a href="#">clojure</a>
+       <a href="#">elixir</a>  <a href="#">racket</a>  <a href="#">scheme</a>  <a href="#">c</a>  <a href="#">c++</a>  <a href="#">ruby</a>  <a href="#">scala</a>
+       <a href="#">erlang</a>  <a href="#">elm</a>  <a href="#">lua</a>  <a href="#">sql</a>  <a href="#">julia</a>  <a href="#">r</a>  <a href="#">+more</a>
+
+  <span class="b">[03]</span> <span class="g">this week</span> <span class="d">─────────────────────────────────────────────────────</span>
+       <span class="b">Sat 09:00 </span>  weekly meetup, Berkeley
+       <span class="b">Sun 17:00 </span>  reading group · Crafting Interpreters
+       <span class="b">All week  </span>  forum + puzzle + jobs
+
+<span class="r">═════════════════════════════════════════════════════════════════════════════</span>
+
+  <span class="d">Time left:</span> <span class="b">59:00</span>   <span class="d">· Speed:</span> <span class="b">9600</span>   <span class="d">· Carrier:</span> <span class="g">DETECTED</span>
+
+  <span class="b">Main Menu Command?</span> <span class="cursor"> </span></pre>
+    </div>
+  </body>
+</html>

--- a/mockups/32-bbs-wwiv.html
+++ b/mockups/32-bbs-wwiv.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — WWIV BBS</title>
+    <style>
+      :root {
+        --bg: #0000a8;
+        --white: #ffffff;
+        --cyan: #54fefe;
+        --yellow: #fefe54;
+        --green: #54fe54;
+        --gray: #c0c0c0;
+        --dim: #5454fe;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: #000;
+        color: var(--white);
+        font-family:
+          "Px437 IBM VGA8", "Perfect DOS VGA 437", "VT323", "Cascadia Mono",
+          "Courier New", ui-monospace, Menlo, monospace;
+        font-size: 17px;
+        line-height: 1.18;
+        font-weight: 700;
+        min-height: 100vh;
+      }
+      .crt {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 18px;
+        background: var(--bg);
+        border-radius: 14px / 28px;
+        position: relative;
+        overflow: hidden;
+        box-shadow:
+          inset 0 0 60px rgba(0, 0, 0, 0.7),
+          0 0 0 8px #1a1a1a,
+          0 0 0 14px #050505;
+      }
+      .crt::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, 0) 0 1px,
+          rgba(0, 0, 0, 0.18) 1px 3px
+        );
+        pointer-events: none;
+      }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--yellow);
+        color: var(--bg);
+      }
+      pre.page {
+        white-space: pre;
+        position: relative;
+        z-index: 1;
+        margin: 0;
+        font-family: inherit;
+        font-size: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+        color: inherit;
+      }
+      .c {
+        color: var(--cyan);
+      }
+      .y {
+        color: var(--yellow);
+      }
+      .g {
+        color: var(--green);
+      }
+      .gr {
+        color: var(--gray);
+      }
+      .d {
+        color: var(--dim);
+      }
+      .blink {
+        animation: blink 0.9s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cursor {
+        display: inline-block;
+        width: 0.6em;
+        height: 1em;
+        background: var(--white);
+        vertical-align: text-bottom;
+        animation: blink 0.9s steps(1) infinite;
+      }
+      h1.sr {
+        position: absolute;
+        left: -9999px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="crt">
+      <h1 class="sr">Code Self Study WWIV BBS</h1>
+      <!-- prettier-ignore -->
+      <pre class="page"><span class="y">┌──────────────────────────────────────────────────────────────────────────────┐</span>
+<span class="y">│</span>  <span class="c">WWIV v4.30</span>     <span class="y">CODE-SELF-STUDY @1</span>     <span class="g">Berkeley · est. 2014</span>           <span class="y">│</span>
+<span class="y">└──────────────────────────────────────────────────────────────────────────────┘</span>
+
+   <span class="c">▒▒▒▒▒▒</span>  <span class="y">CODE</span>  <span class="c">▒▒▒▒▒▒</span>  <span class="y">SELF</span>  <span class="c">▒▒▒▒▒▒</span>  <span class="y">STUDY</span>  <span class="c">▒▒▒▒▒▒</span>
+
+  <span class="gr">Welcome to the WWIV node for </span><span class="y">Code Self Study</span><span class="gr">, a friendly</span>
+  <span class="gr">programming community of </span><span class="g">5,247</span><span class="gr"> members in Berkeley and the</span>
+  <span class="gr">San Francisco Bay Area.  All languages, all levels welcome.</span>
+
+  <span class="gr">Format: </span><span class="c">self-study with mentorship</span><span class="gr">.  Show up, bring a question</span>
+  <span class="gr">or a project, get help from the regulars.</span>
+
+<span class="d">──────────────────────────────────────────────────────────────────────────────</span>
+<span class="y">                              M A I N   M E N U</span>
+<span class="d">──────────────────────────────────────────────────────────────────────────────</span>
+
+  <span class="c">[A]</span><span class="gr">.</span> <span class="y">News &amp; bulletins  </span>      <span class="c">[F]</span><span class="gr">.</span> <span class="y">File transfers</span>
+  <span class="c">[B]</span><span class="gr">.</span> <span class="y">Sub-boards (forum)</span>      <span class="c">[D]</span><span class="gr">.</span> <span class="y">Doors (puzzles)</span>
+  <span class="c">[C]</span><span class="gr">.</span> <span class="y">Chat with users   </span>      <span class="c">[V]</span><span class="gr">.</span> <span class="y">Voting booths</span>
+  <span class="c">[E]</span><span class="gr">.</span> <span class="y">Email regulars    </span>      <span class="c">[U]</span><span class="gr">.</span> <span class="y">User listing</span>
+  <span class="c">[N]</span><span class="gr">.</span> <span class="y">Net status (FidoNet)</span>    <span class="c">[K]</span><span class="gr">.</span> <span class="y">Kalendar of events</span>
+  <span class="c">[J]</span><span class="gr">.</span> <a href="https://www.meetup.com/codeselfstudy/"><span class="g">JOIN COMMUNITY → meetup.com/codeselfstudy</span></a>
+  <span class="c">[G]</span><span class="gr">.</span> <span class="y">Goodbye / log off</span>
+
+<span class="d">──────────────────────────────────────────────────────────────────────────────</span>
+<span class="y">                            S U B - B O A R D S</span>
+<span class="d">──────────────────────────────────────────────────────────────────────────────</span>
+
+  <span class="gr"> # </span> <span class="c">name                                     </span>   <span class="gr">posts</span>   <span class="gr">last</span>
+  <span class="gr">────────────────────────────────────────────────────────────────────────────</span>
+  <span class="y"> 01</span>  <a href="#">general . . . . . . . . . . . . . . . . </a>   <span class="g">3214</span>   2h
+  <span class="y"> 02</span>  <a href="#">study plans &amp; mentorship . . . . . . . </a>    <span class="g">847</span>  12m
+  <span class="y"> 03</span>  <a href="#">code review queue . . . . . . . . . . . </a>    <span class="g">512</span>   1h
+  <span class="y"> 04</span>  <a href="#">jobs &amp; intros (members only) . . . . . </a>    <span class="g">218</span>   3h
+  <span class="y"> 05</span>  <a href="#">puzzle of the week . . . . . . . . . . .</a>    <span class="g">404</span>  30m
+  <span class="y"> 06</span>  <a href="#">reading group: Crafting Interpreters . .</a>     <span class="g">93</span>   1d
+  <span class="y"> 07</span>  <a href="#">show-and-tell . . . . . . . . . . . . . </a>    <span class="g">621</span>  45m
+
+<span class="d">──────────────────────────────────────────────────────────────────────────────</span>
+<span class="y">                  L A N G U A G E S   I N   R O T A T I O N</span>
+<span class="d">──────────────────────────────────────────────────────────────────────────────</span>
+
+  <a href="#"><span class="c">python    </span></a>  <a href="#"><span class="c">javascript</span></a>  <a href="#"><span class="c">typescript</span></a>  <a href="#"><span class="c">go        </span></a>
+  <a href="#"><span class="c">rust      </span></a>  <a href="#"><span class="c">haskell   </span></a>  <a href="#"><span class="c">clojure   </span></a>  <a href="#"><span class="c">elixir    </span></a>
+  <a href="#"><span class="c">racket    </span></a>  <a href="#"><span class="c">scheme    </span></a>  <a href="#"><span class="c">c         </span></a>  <a href="#"><span class="c">c++       </span></a>
+  <a href="#"><span class="c">ruby      </span></a>  <a href="#"><span class="c">scala     </span></a>  <a href="#"><span class="c">erlang    </span></a>  <a href="#"><span class="c">elm       </span></a>
+  <a href="#"><span class="c">lua       </span></a>  <a href="#"><span class="c">sql       </span></a>  <a href="#"><span class="c">julia     </span></a>  <a href="#"><span class="c">r         </span></a>
+
+<span class="d">──────────────────────────────────────────────────────────────────────────────</span>
+
+  <span class="y">[Time left: 60m]   [Mins online: 11]   [Speed: 9600]   [Node: 01]</span>
+
+  <span class="c">Your choice?</span> <span class="cursor"> </span></pre>
+    </div>
+  </body>
+</html>

--- a/mockups/33-modernist-museum.html
+++ b/mockups/33-modernist-museum.html
@@ -1,0 +1,452 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Modernist museum</title>
+    <style>
+      :root {
+        --paper: #fafaf7;
+        --ink: #111111;
+        --rule: #c8c6bf;
+        --muted: #6b6a64;
+        --accent: #c4452b;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 400;
+        line-height: 1.55;
+        -webkit-font-smoothing: antialiased;
+      }
+      a {
+        color: inherit;
+      }
+      header {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 28px 40px 0;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: end;
+        gap: 24px;
+        border-bottom: 1px solid var(--ink);
+        padding-bottom: 14px;
+      }
+      .mark {
+        font-weight: 300;
+        font-size: 13px;
+        letter-spacing: 0.34em;
+        text-transform: uppercase;
+      }
+      .mark b {
+        font-weight: 700;
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 28px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        font-size: 12px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-weight: 500;
+      }
+      nav a:hover {
+        color: var(--accent);
+      }
+      .wrap {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 56px 40px 80px;
+      }
+      .meta-row {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 32px;
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin-bottom: 64px;
+      }
+      .meta-row b {
+        display: block;
+        color: var(--ink);
+        font-weight: 500;
+        font-size: 13px;
+        margin-top: 4px;
+        letter-spacing: 0.06em;
+        text-transform: none;
+      }
+      .lede {
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 48px;
+        align-items: end;
+        padding-bottom: 72px;
+        border-bottom: 1px solid var(--rule);
+      }
+      .lede .num {
+        font-size: 11px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+      .lede h1 {
+        font-size: clamp(40px, 6vw, 92px);
+        line-height: 1;
+        margin: 0;
+        font-weight: 300;
+        letter-spacing: -0.02em;
+      }
+      .lede h1 em {
+        font-style: italic;
+        color: var(--accent);
+      }
+      .lede aside {
+        font-size: 13px;
+        color: var(--muted);
+        max-width: 22ch;
+      }
+      .grid {
+        margin-top: 72px;
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        column-gap: 32px;
+        row-gap: 64px;
+      }
+      .work {
+        grid-column: span 4;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .plate {
+        aspect-ratio: 4 / 5;
+        position: relative;
+        border: 1px solid var(--rule);
+        background: #f0eee7;
+        overflow: hidden;
+      }
+      .plate::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+      }
+      .plate.a::before {
+        background:
+          radial-gradient(
+            circle at 30% 40%,
+            #ddd9cd 0,
+            #ddd9cd 32%,
+            transparent 33%
+          ),
+          linear-gradient(135deg, #f0eee7 60%, #e1ddd0 100%);
+      }
+      .plate.b::before {
+        background:
+          linear-gradient(180deg, #cfd6cd 0 38%, transparent 38%),
+          linear-gradient(180deg, #f0eee7 0%, #f0eee7 100%);
+      }
+      .plate.c::before {
+        background:
+          radial-gradient(ellipse at 50% 80%, #c4452b22 0%, transparent 60%),
+          linear-gradient(0deg, #ebe7da 0 60%, transparent 60%);
+      }
+      .plate.d::before {
+        background: repeating-linear-gradient(
+          90deg,
+          #f0eee7 0 24px,
+          #e1ddd0 24px 26px
+        );
+      }
+      .plate.e::before {
+        background: linear-gradient(135deg, #2c3147 0%, #4a5275 100%);
+        opacity: 0.85;
+      }
+      .plate.f::before {
+        background:
+          radial-gradient(circle at 65% 35%, #ffffff 0 8%, transparent 9%),
+          radial-gradient(circle at 35% 70%, #c4452b 0 6%, transparent 7%),
+          linear-gradient(180deg, #f0eee7, #ddd9cd);
+      }
+      .plate .id {
+        position: absolute;
+        bottom: 10px;
+        left: 12px;
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        color: var(--muted);
+      }
+      .work h3 {
+        font-size: 17px;
+        font-weight: 500;
+        margin: 4px 0 0;
+        letter-spacing: -0.005em;
+      }
+      .work p {
+        margin: 0;
+        font-size: 13px;
+        color: var(--muted);
+      }
+      .work .tag {
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--accent);
+      }
+      .statement {
+        margin-top: 96px;
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        column-gap: 32px;
+        padding-top: 32px;
+        border-top: 1px solid var(--ink);
+      }
+      .statement h2 {
+        grid-column: 1 / span 4;
+        font-size: 13px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        font-weight: 500;
+        margin: 0;
+      }
+      .statement .body {
+        grid-column: 5 / span 7;
+        font-size: clamp(18px, 1.4vw, 22px);
+        font-weight: 300;
+        line-height: 1.5;
+        max-width: 60ch;
+      }
+      .statement .body em {
+        font-style: italic;
+        color: var(--accent);
+      }
+      .visit {
+        margin-top: 96px;
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        gap: 32px;
+        align-items: end;
+        padding-top: 32px;
+        border-top: 1px solid var(--rule);
+      }
+      .visit dl {
+        grid-column: span 3;
+        margin: 0;
+        font-size: 13px;
+      }
+      .visit dt {
+        color: var(--muted);
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+      }
+      .visit dd {
+        margin: 4px 0 0;
+        font-weight: 500;
+      }
+      .visit .cta {
+        grid-column: 10 / span 3;
+        text-align: right;
+      }
+      .visit .cta a {
+        text-decoration: none;
+        font-size: 12px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        font-weight: 500;
+        color: var(--accent);
+        border-bottom: 1px solid var(--accent);
+        padding-bottom: 2px;
+      }
+      .visit .cta a:hover {
+        color: var(--ink);
+        border-color: var(--ink);
+      }
+      footer {
+        max-width: 1280px;
+        margin: 80px auto 0;
+        padding: 20px 40px 40px;
+        border-top: 1px solid var(--ink);
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--muted);
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 980px) {
+        .work {
+          grid-column: span 6;
+        }
+        .meta-row {
+          grid-template-columns: repeat(2, 1fr);
+        }
+        .statement h2,
+        .statement .body {
+          grid-column: span 12;
+        }
+        .visit dl,
+        .visit .cta {
+          grid-column: span 6;
+        }
+        .visit .cta {
+          text-align: left;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="mark"><b>Code Self Study</b> — Berkeley, CA</div>
+      <nav>
+        <ul>
+          <li><a href="#">Events</a></li>
+          <li><a href="#">Learn</a></li>
+          <li><a href="#">Forum</a></li>
+          <li><a href="#">Jobs</a></li>
+          <li><a href="#">Puzzles</a></li>
+          <li><a href="#">About</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="wrap">
+      <div class="meta-row">
+        <div>On view <b>Saturdays, 9 am</b></div>
+        <div>Members <b>5,247</b></div>
+        <div>Languages <b>All of them</b></div>
+        <div>Admission <b>Free</b></div>
+      </div>
+
+      <section class="lede">
+        <div>
+          <div class="num">№ 01 — current exhibition</div>
+        </div>
+        <h1>
+          Study code. <em>Together.</em><br />
+          In person.
+        </h1>
+        <aside>
+          A friendly programming community of 5,000+ people in Berkeley and the
+          San Francisco Bay Area. All languages, all levels welcome.
+        </aside>
+      </section>
+
+      <section class="grid">
+        <article class="work">
+          <div class="plate a"><span class="id">PL-001 · 2014–</span></div>
+          <span class="tag">Community</span>
+          <h3>The room exists.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done.
+          </p>
+        </article>
+
+        <article class="work">
+          <div class="plate b"><span class="id">PL-002 · ongoing</span></div>
+          <span class="tag">Mentorship</span>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners with study plans, code reviews,
+            stuck commits.
+          </p>
+        </article>
+
+        <article class="work">
+          <div class="plate c"><span class="id">PL-003 · ongoing</span></div>
+          <span class="tag">Networking</span>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group.
+          </p>
+        </article>
+
+        <article class="work">
+          <div class="plate d"><span class="id">PL-004 · weekly</span></div>
+          <span class="tag">Programme</span>
+          <h3>Saturday meetup.</h3>
+          <p>
+            9 am, Berkeley. Bring a project, a question, or just a notebook and
+            a coffee.
+          </p>
+        </article>
+
+        <article class="work">
+          <div class="plate e"><span class="id">PL-005 · series</span></div>
+          <span class="tag">Reading group</span>
+          <h3>Crafting Interpreters.</h3>
+          <p>
+            One chapter a week. Implement in any language you like — there is
+            usually company.
+          </p>
+        </article>
+
+        <article class="work">
+          <div class="plate f"><span class="id">PL-006 · weekly</span></div>
+          <span class="tag">Puzzles</span>
+          <h3>Puzzle of the week.</h3>
+          <p>
+            Short problems chosen by members. Solutions discussed at the next
+            meetup.
+          </p>
+        </article>
+      </section>
+
+      <section class="statement">
+        <h2>Statement</h2>
+        <div class="body">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead —
+          <em>self-study with mentorship</em>, in a real room, in person. All
+          languages. All levels.
+        </div>
+      </section>
+
+      <section class="visit">
+        <dl>
+          <dt>Visit</dt>
+          <dd>Saturdays, 9 am</dd>
+        </dl>
+        <dl>
+          <dt>Where</dt>
+          <dd>Berkeley, CA</dd>
+        </dl>
+        <dl>
+          <dt>Admission</dt>
+          <dd>Free for all members</dd>
+        </dl>
+        <div class="cta">
+          <a href="https://www.meetup.com/codeselfstudy/"
+            >Join the community →</a
+          >
+        </div>
+      </section>
+    </main>
+    <footer>
+      <span>Code Self Study — Berkeley · Bay Area</span>
+      <span>№ exhibition 01 / 2026</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/34-japanese-editorial.html
+++ b/mockups/34-japanese-editorial.html
@@ -1,0 +1,529 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Japanese editorial</title>
+    <style>
+      :root {
+        --paper: #f5f1e8;
+        --paper-dark: #ebe5d4;
+        --ink: #1c1a16;
+        --ink-soft: #4a463e;
+        --vermilion: #b04632;
+        --indigo: #2d3a55;
+        --rule: #b6ad96;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Cormorant Garamond", "EB Garamond", "Iowan Old Style",
+          "Hoefler Text", Georgia, serif;
+        font-weight: 400;
+        line-height: 1.6;
+        background-image:
+          radial-gradient(
+            circle at 20% 10%,
+            rgba(0, 0, 0, 0.03),
+            transparent 30%
+          ),
+          radial-gradient(
+            circle at 80% 80%,
+            rgba(0, 0, 0, 0.025),
+            transparent 35%
+          ),
+          repeating-linear-gradient(
+            45deg,
+            transparent 0 6px,
+            rgba(28, 26, 22, 0.012) 6px 7px
+          );
+      }
+      a {
+        color: inherit;
+      }
+      .sans {
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+      }
+      header {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 36px 48px 0;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 40px;
+        align-items: end;
+      }
+      .seal {
+        width: 56px;
+        height: 56px;
+        background: var(--vermilion);
+        color: var(--paper);
+        display: grid;
+        place-items: center;
+        font-family: "Cormorant Garamond", Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 28px;
+        letter-spacing: -0.02em;
+        box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.15);
+      }
+      .masthead {
+        border-bottom: 1px solid var(--ink);
+        padding-bottom: 12px;
+        display: flex;
+        justify-content: space-between;
+        align-items: end;
+        gap: 20px;
+        flex-wrap: wrap;
+      }
+      .masthead .name {
+        font-family: "Cormorant Garamond", Georgia, serif;
+        font-style: italic;
+        font-size: 26px;
+        font-weight: 500;
+        letter-spacing: -0.01em;
+      }
+      .masthead nav ul {
+        list-style: none;
+        display: flex;
+        gap: 22px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      .masthead nav a {
+        text-decoration: none;
+        font-size: 12px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+      }
+      .masthead nav a:hover {
+        color: var(--vermilion);
+      }
+      .colophon {
+        max-width: 1200px;
+        margin: 12px auto 0;
+        padding: 0 48px;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        flex-wrap: wrap;
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 64px 48px 80px;
+      }
+      .lede {
+        display: grid;
+        grid-template-columns: 7fr 5fr;
+        gap: 56px;
+        align-items: start;
+      }
+      .lede .head {
+        position: relative;
+      }
+      .lede .head::after {
+        content: "";
+        position: absolute;
+        bottom: -28px;
+        left: 0;
+        width: 84px;
+        height: 1px;
+        background: var(--vermilion);
+      }
+      .kicker {
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-size: 12px;
+        letter-spacing: 0.28em;
+        text-transform: uppercase;
+        color: var(--vermilion);
+        margin-bottom: 14px;
+      }
+      .lede h1 {
+        font-size: clamp(44px, 6vw, 92px);
+        line-height: 1.04;
+        margin: 0 0 6px;
+        font-weight: 400;
+        letter-spacing: -0.02em;
+      }
+      .lede h1 em {
+        font-style: italic;
+      }
+      .lede .sub {
+        font-style: italic;
+        font-size: clamp(20px, 1.8vw, 26px);
+        color: var(--ink-soft);
+      }
+      .lede .body {
+        padding-top: 12px;
+      }
+      .lede .body p {
+        margin: 0 0 14px;
+        font-size: 17px;
+        line-height: 1.7;
+      }
+      .lede .body p::first-letter {
+        font-size: 3.4em;
+        line-height: 0.9;
+        float: left;
+        padding: 6px 10px 0 0;
+        font-weight: 500;
+        font-style: italic;
+        color: var(--vermilion);
+      }
+      .lede .cta {
+        margin-top: 24px;
+        display: inline-block;
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-size: 12px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        text-decoration: none;
+        color: var(--ink);
+        border-bottom: 1.5px solid var(--vermilion);
+        padding-bottom: 4px;
+      }
+      .lede .cta:hover {
+        color: var(--vermilion);
+      }
+      .ma {
+        height: 96px;
+      }
+      .three {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 56px;
+        align-items: start;
+        padding-top: 40px;
+        border-top: 1px solid var(--rule);
+      }
+      .three .ch {
+        font-family: "Cormorant Garamond", Georgia, serif;
+        font-style: italic;
+        font-weight: 500;
+        font-size: 64px;
+        line-height: 1;
+        color: var(--vermilion);
+        margin-bottom: 8px;
+      }
+      .three h3 {
+        margin: 0 0 6px;
+        font-weight: 500;
+        font-size: 22px;
+        letter-spacing: -0.005em;
+      }
+      .three p {
+        margin: 0;
+        color: var(--ink-soft);
+        font-size: 16px;
+        line-height: 1.65;
+        max-width: 32ch;
+      }
+      .quiet {
+        margin-top: 72px;
+        padding: 36px 0;
+        border-top: 1px solid var(--rule);
+        border-bottom: 1px solid var(--rule);
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 56px;
+        align-items: center;
+      }
+      .quiet .label {
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-size: 11px;
+        letter-spacing: 0.28em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      .quiet blockquote {
+        margin: 0;
+        font-style: italic;
+        font-size: clamp(22px, 2.2vw, 32px);
+        line-height: 1.4;
+        color: var(--ink);
+        font-weight: 500;
+      }
+      .quiet blockquote span {
+        color: var(--vermilion);
+      }
+      .meeting {
+        margin-top: 72px;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 56px;
+        align-items: start;
+      }
+      .meeting h2 {
+        font-size: clamp(28px, 3.6vw, 42px);
+        margin: 0 0 12px;
+        font-weight: 500;
+        letter-spacing: -0.01em;
+      }
+      .meeting .body {
+        font-size: 16px;
+        color: var(--ink);
+        line-height: 1.7;
+      }
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-size: 14px;
+      }
+      .table td {
+        padding: 12px 0;
+        border-bottom: 1px solid var(--rule);
+        vertical-align: top;
+      }
+      .table td:first-child {
+        color: var(--ink-soft);
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-size: 11px;
+        width: 38%;
+        padding-right: 16px;
+      }
+      .langs {
+        margin-top: 56px;
+      }
+      .langs .label {
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-size: 11px;
+        letter-spacing: 0.28em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        margin-bottom: 14px;
+      }
+      .langs ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        column-count: 4;
+        column-gap: 32px;
+      }
+      .langs li {
+        padding: 6px 0;
+        border-bottom: 1px solid var(--rule);
+        break-inside: avoid;
+        display: flex;
+        justify-content: space-between;
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-size: 13px;
+      }
+      .langs li small {
+        color: var(--ink-soft);
+        font-size: 11px;
+        letter-spacing: 0.1em;
+      }
+      footer {
+        max-width: 1200px;
+        margin: 64px auto 0;
+        padding: 18px 48px 36px;
+        border-top: 1px solid var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-size: 11px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 880px) {
+        .lede,
+        .three,
+        .quiet,
+        .meeting {
+          grid-template-columns: 1fr;
+        }
+        .langs ul {
+          column-count: 2;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="seal">己</div>
+      <div class="masthead">
+        <div class="name">Code Self Study — a quiet weekly</div>
+        <nav>
+          <ul>
+            <li><a href="#">Events</a></li>
+            <li><a href="#">Learn</a></li>
+            <li><a href="#">Forum</a></li>
+            <li><a href="#">Jobs</a></li>
+            <li><a href="#">Puzzles</a></li>
+            <li><a href="#">About</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <div class="colophon">
+      <span>Vol. XII · Bay Area · Spring 2026</span>
+      <span>Members 5,247 · Free admission</span>
+    </div>
+
+    <main class="wrap">
+      <section class="lede">
+        <div class="head">
+          <div class="kicker">— Number 01 · the room</div>
+          <h1>Study code.<br /><em>Together.</em><br />In person.</h1>
+          <div class="sub">
+            A small, friendly community of programmers in the Bay Area.
+          </div>
+        </div>
+        <div class="body">
+          <p>
+            Code Self Study has met, week after week, since 2014 — five thousand
+            programmers in Berkeley and the wider Bay Area, working quietly side
+            by side on whatever they happened to be learning that morning. All
+            languages. All levels. The hard part is done; the room already
+            exists.
+          </p>
+          <p>
+            The format is unhurried: bring a notebook, a question, a stuck
+            commit, or a long-running project. Sit down with people who keep
+            showing up. Ask. Answer. Drink the coffee. Repeat next Saturday.
+          </p>
+          <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community →</a
+          >
+        </div>
+      </section>
+
+      <div class="ma" aria-hidden="true"></div>
+
+      <section class="three">
+        <div>
+          <div class="ch">一</div>
+          <h3>Community</h3>
+          <p>
+            Show up. Meet programmers who keep showing up week after week. The
+            hard part is done.
+          </p>
+        </div>
+        <div>
+          <div class="ch">二</div>
+          <h3>Mentorship</h3>
+          <p>
+            Experienced members help beginners — questions, study plans, code
+            reviews, stuck commits.
+          </p>
+        </div>
+        <div>
+          <div class="ch">三</div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. Quietly, no pitch.
+          </p>
+        </div>
+      </section>
+
+      <section class="quiet">
+        <div class="label">From the colophon</div>
+        <blockquote>
+          Dozens of groups will teach you to code. We build a local community of
+          <span>highly-motivated programmers</span> instead.
+        </blockquote>
+      </section>
+
+      <section class="meeting">
+        <div>
+          <h2>The Saturday meeting.</h2>
+          <p class="body">
+            One room, one morning a week, a table of regulars, a few first-time
+            visitors, and a kettle. No talks. No slides. People bring whatever
+            they are working on and help one another along.
+          </p>
+          <p class="body">
+            If you are new — show up. If you are stuck — bring the stuck thing.
+            If you are advanced — there is almost certainly someone who would
+            welcome an hour of your help.
+          </p>
+        </div>
+        <table class="table">
+          <tr>
+            <td>When</td>
+            <td>Saturdays, 9 am</td>
+          </tr>
+          <tr>
+            <td>Where</td>
+            <td>Berkeley, CA</td>
+          </tr>
+          <tr>
+            <td>Format</td>
+            <td>Self-study with mentorship</td>
+          </tr>
+          <tr>
+            <td>Cover</td>
+            <td>Free</td>
+          </tr>
+          <tr>
+            <td>Bring</td>
+            <td>A laptop and a question</td>
+          </tr>
+          <tr>
+            <td>Founded</td>
+            <td>2014</td>
+          </tr>
+        </table>
+      </section>
+
+      <section class="langs">
+        <div class="label">Languages in rotation</div>
+        <ul>
+          <li>Python <small>weekly</small></li>
+          <li>JavaScript <small>weekly</small></li>
+          <li>TypeScript <small>weekly</small></li>
+          <li>Go <small>weekly</small></li>
+          <li>Rust <small>weekly</small></li>
+          <li>Haskell <small>often</small></li>
+          <li>Clojure <small>often</small></li>
+          <li>Elixir <small>often</small></li>
+          <li>Racket <small>often</small></li>
+          <li>Scheme <small>sometimes</small></li>
+          <li>Common Lisp <small>sometimes</small></li>
+          <li>Ruby <small>sometimes</small></li>
+          <li>Scala <small>sometimes</small></li>
+          <li>C++ <small>sometimes</small></li>
+          <li>Lua <small>sometimes</small></li>
+          <li>SQL <small>weekly</small></li>
+        </ul>
+      </section>
+    </main>
+    <footer>
+      <span>Code Self Study — Berkeley, Bay Area</span>
+      <span>己 · Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/35-field-guide.html
+++ b/mockups/35-field-guide.html
@@ -1,0 +1,643 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Field guide</title>
+    <style>
+      :root {
+        --paper: #f4eedf;
+        --paper-edge: #ddd3b8;
+        --ink: #1f2117;
+        --ink-soft: #4a4d3d;
+        --olive: #6b7a3a;
+        --rust: #8a3a1c;
+        --rule: #b9b09a;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "EB Garamond", "Iowan Old Style", "Hoefler Text", Georgia, serif;
+        font-weight: 400;
+        line-height: 1.55;
+        background-image:
+          radial-gradient(
+            circle at 20% 30%,
+            rgba(0, 0, 0, 0.025),
+            transparent 35%
+          ),
+          radial-gradient(
+            circle at 80% 70%,
+            rgba(0, 0, 0, 0.02),
+            transparent 35%
+          ),
+          repeating-linear-gradient(
+            0deg,
+            transparent 0 18px,
+            rgba(31, 33, 23, 0.04) 18px 19px
+          );
+      }
+      a {
+        color: inherit;
+      }
+      .mono {
+        font-family:
+          "IBM Plex Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+      }
+      header {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 28px 40px 0;
+      }
+      .title-block {
+        border-top: 4px double var(--ink);
+        border-bottom: 4px double var(--ink);
+        padding: 18px 0;
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 24px;
+        align-items: center;
+      }
+      .title-block .vol {
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      .title-block .name {
+        font-family: "EB Garamond", Georgia, serif;
+        font-size: clamp(22px, 2.4vw, 32px);
+        font-weight: 600;
+        text-align: center;
+        letter-spacing: -0.005em;
+      }
+      .title-block .name em {
+        font-style: italic;
+        color: var(--olive);
+      }
+      .title-block .right {
+        text-align: right;
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      nav.bar {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 10px 40px;
+        border-bottom: 1px solid var(--rule);
+      }
+      nav.bar ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        gap: 26px;
+        flex-wrap: wrap;
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+      }
+      nav.bar a {
+        text-decoration: none;
+      }
+      nav.bar a:hover {
+        color: var(--rust);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 36px 40px 80px;
+      }
+      .lede {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 40px;
+        align-items: start;
+        padding-bottom: 32px;
+        border-bottom: 1px solid var(--rule);
+      }
+      .lede .meta {
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--olive);
+        margin-bottom: 14px;
+      }
+      .lede h1 {
+        font-size: clamp(38px, 5.4vw, 76px);
+        line-height: 1;
+        margin: 0 0 12px;
+        font-weight: 500;
+        letter-spacing: -0.01em;
+      }
+      .lede h1 em {
+        font-style: italic;
+        color: var(--rust);
+      }
+      .lede .sci {
+        font-style: italic;
+        color: var(--ink-soft);
+        font-size: 18px;
+      }
+      .lede .body p {
+        margin: 0 0 12px;
+        font-size: 16px;
+        line-height: 1.7;
+      }
+      .lede .body p:first-child::first-letter {
+        font-size: 3em;
+        line-height: 0.9;
+        float: left;
+        padding: 4px 8px 0 0;
+        font-weight: 600;
+        font-style: italic;
+        color: var(--rust);
+      }
+      .cta {
+        display: inline-block;
+        margin-top: 12px;
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 12px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        text-decoration: none;
+        padding: 8px 0;
+        border-top: 1px solid var(--ink);
+        border-bottom: 1px solid var(--ink);
+      }
+      .cta:hover {
+        color: var(--rust);
+        border-color: var(--rust);
+      }
+
+      .specimens {
+        margin-top: 36px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 28px;
+      }
+      .spec {
+        border: 1px solid var(--rule);
+        background: var(--paper);
+        padding: 16px;
+      }
+      .plate {
+        background: var(--paper-edge);
+        border: 1px solid var(--rule);
+        height: 130px;
+        position: relative;
+        overflow: hidden;
+        margin-bottom: 12px;
+      }
+      .plate.a {
+        background:
+          radial-gradient(circle at 30% 60%, #6b7a3a55 0 18%, transparent 19%),
+          radial-gradient(circle at 65% 35%, #8a3a1c44 0 14%, transparent 15%),
+          var(--paper-edge);
+      }
+      .plate.b {
+        background:
+          repeating-linear-gradient(
+            90deg,
+            transparent 0 22px,
+            #b9b09a 22px 23px
+          ),
+          var(--paper-edge);
+      }
+      .plate.c {
+        background:
+          radial-gradient(circle at 50% 50%, #4a4d3d 0 6px, transparent 7px),
+          radial-gradient(circle at 25% 30%, #4a4d3d 0 4px, transparent 5px),
+          radial-gradient(circle at 75% 70%, #4a4d3d 0 4px, transparent 5px),
+          var(--paper-edge);
+      }
+      .plate .lab {
+        position: absolute;
+        bottom: 6px;
+        right: 8px;
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        color: var(--ink-soft);
+      }
+      .spec .ord {
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--olive);
+      }
+      .spec h3 {
+        margin: 4px 0 2px;
+        font-size: 22px;
+        font-weight: 600;
+        letter-spacing: -0.005em;
+      }
+      .spec h3 em {
+        font-style: italic;
+        font-weight: 400;
+        font-size: 14px;
+        color: var(--ink-soft);
+        margin-left: 6px;
+      }
+      .spec p {
+        margin: 6px 0 0;
+        font-size: 14.5px;
+        line-height: 1.55;
+      }
+
+      .key {
+        margin-top: 48px;
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 36px;
+        padding-top: 28px;
+        border-top: 1px solid var(--rule);
+      }
+      .key h2 {
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 12px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        margin: 0;
+        color: var(--ink-soft);
+      }
+      .key .body {
+        font-size: 17px;
+        line-height: 1.7;
+      }
+      .key .body em {
+        font-style: italic;
+        color: var(--rust);
+      }
+      .key .table {
+        margin-top: 18px;
+        width: 100%;
+        border-collapse: collapse;
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 13px;
+      }
+      .key .table td {
+        padding: 8px 0;
+        border-bottom: 1px dotted var(--rule);
+      }
+      .key .table td:first-child {
+        color: var(--ink-soft);
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-size: 11px;
+        width: 28%;
+      }
+
+      .index {
+        margin-top: 48px;
+        padding-top: 28px;
+        border-top: 1px solid var(--rule);
+      }
+      .index h2 {
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 12px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        margin: 0 0 14px;
+        color: var(--ink-soft);
+      }
+      .index ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        column-count: 4;
+        column-gap: 24px;
+      }
+      .index li {
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 13px;
+        padding: 4px 0;
+        border-bottom: 1px dotted var(--rule);
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+        break-inside: avoid;
+      }
+      .index li small {
+        color: var(--ink-soft);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+      }
+      footer {
+        max-width: 1180px;
+        margin: 64px auto 0;
+        padding: 16px 40px 32px;
+        border-top: 4px double var(--ink);
+        font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 880px) {
+        .lede,
+        .specimens,
+        .key {
+          grid-template-columns: 1fr;
+        }
+        .index ul {
+          column-count: 2;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="title-block">
+        <div class="vol">Vol. XII · Plate 01</div>
+        <div class="name">A Field Guide to <em>Code Self Study</em></div>
+        <div class="right">Berkeley, CA · 2014–</div>
+      </div>
+    </header>
+    <nav class="bar">
+      <ul>
+        <li><a href="#">Plates</a></li>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+
+    <main class="wrap">
+      <section class="lede">
+        <div>
+          <div class="meta">Genus · Community · No. 01</div>
+          <h1>The Bay Area <em>programmer.</em></h1>
+          <div class="sci">Programmator congregans var. <em>Berkeley</em></div>
+          <div class="body" style="margin-top: 18px">
+            <p>
+              Common throughout the Bay Area, particularly in Berkeley.
+              Gregarious; observed in groups of five or more on Saturday
+              mornings. Plumage varies — Python, JavaScript, Rust, Haskell,
+              Clojure, and several dozen lesser dialects have been documented in
+              the same flock.
+            </p>
+            <p>
+              The species is best identified by its habit of returning, week
+              after week, to the same study site, where it sits beside other
+              members of the flock and quietly works on whatever it is learning
+              that morning.
+            </p>
+          </div>
+          <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+            >Add to your sightings — meetup.com/codeselfstudy →</a
+          >
+        </div>
+        <div class="body">
+          <table
+            class="key table"
+            style="width: 100%; border-collapse: collapse"
+          >
+            <tr>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  color: var(--ink-soft);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 11px;
+                  letter-spacing: 0.16em;
+                  text-transform: uppercase;
+                "
+              >
+                Range
+              </td>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 13px;
+                "
+              >
+                Berkeley · S.F. Bay Area
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  color: var(--ink-soft);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 11px;
+                  letter-spacing: 0.16em;
+                  text-transform: uppercase;
+                "
+              >
+                Population
+              </td>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 13px;
+                "
+              >
+                5,247 (2026 census)
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  color: var(--ink-soft);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 11px;
+                  letter-spacing: 0.16em;
+                  text-transform: uppercase;
+                "
+              >
+                Active since
+              </td>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 13px;
+                "
+              >
+                2014
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  color: var(--ink-soft);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 11px;
+                  letter-spacing: 0.16em;
+                  text-transform: uppercase;
+                "
+              >
+                Best observed
+              </td>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 13px;
+                "
+              >
+                Saturdays, 9 am
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  color: var(--ink-soft);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 11px;
+                  letter-spacing: 0.16em;
+                  text-transform: uppercase;
+                "
+              >
+                Habitat
+              </td>
+              <td
+                style="
+                  padding: 8px 0;
+                  border-bottom: 1px dotted var(--rule);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 13px;
+                "
+              >
+                A real room, in person
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  padding: 8px 0;
+                  color: var(--ink-soft);
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 11px;
+                  letter-spacing: 0.16em;
+                  text-transform: uppercase;
+                "
+              >
+                Admission
+              </td>
+              <td
+                style="
+                  padding: 8px 0;
+                  font-family: &quot;IBM Plex Mono&quot;, monospace;
+                  font-size: 13px;
+                "
+              >
+                Free
+              </td>
+            </tr>
+          </table>
+        </div>
+      </section>
+
+      <section class="specimens">
+        <article class="spec">
+          <div class="plate a"><span class="lab">PL-01 · COMMUNITY</span></div>
+          <div class="ord">Order I · Communitas</div>
+          <h3>Show up. <em>Coetus</em></h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done — the room exists.
+          </p>
+        </article>
+        <article class="spec">
+          <div class="plate b"><span class="lab">PL-02 · MENTORSHIP</span></div>
+          <div class="ord">Order II · Mentorship</div>
+          <h3>Ask for a plan. <em>Auxilium</em></h3>
+          <p>
+            Experienced members help beginners — questions, study plans, code
+            reviews, stuck commits.
+          </p>
+        </article>
+        <article class="spec">
+          <div class="plate c"><span class="lab">PL-03 · NETWORKING</span></div>
+          <div class="ord">Order III · Networking</div>
+          <h3>Doors open. <em>Introitus</em></h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. Quietly, no pitch.
+          </p>
+        </article>
+      </section>
+
+      <section class="key">
+        <h2>Habitat note</h2>
+        <div class="body">
+          Dozens of groups will teach you to code. We build a local community of
+          <em>highly-motivated programmers</em> instead. The format is
+          self-study with mentorship — show up at a meetup, bring a question or
+          a project, get help from the regulars. No curriculum, no gatekeeping,
+          no bootcamp pitch.
+        </div>
+      </section>
+
+      <section class="index">
+        <h2>Index of dialects observed in the field</h2>
+        <ul>
+          <li><span>Python</span><small>weekly</small></li>
+          <li><span>JavaScript</span><small>weekly</small></li>
+          <li><span>TypeScript</span><small>weekly</small></li>
+          <li><span>Go</span><small>weekly</small></li>
+          <li><span>Rust</span><small>weekly</small></li>
+          <li><span>Haskell</span><small>often</small></li>
+          <li><span>Clojure</span><small>often</small></li>
+          <li><span>Elixir</span><small>often</small></li>
+          <li><span>Racket</span><small>often</small></li>
+          <li><span>Scheme</span><small>seen</small></li>
+          <li><span>Common Lisp</span><small>seen</small></li>
+          <li><span>Ruby</span><small>seen</small></li>
+          <li><span>Scala</span><small>seen</small></li>
+          <li><span>C++</span><small>seen</small></li>
+          <li><span>C</span><small>seen</small></li>
+          <li><span>Lua</span><small>seen</small></li>
+          <li><span>SQL</span><small>weekly</small></li>
+          <li><span>Erlang</span><small>seen</small></li>
+          <li><span>Elm</span><small>seen</small></li>
+          <li><span>Julia</span><small>seen</small></li>
+        </ul>
+      </section>
+    </main>
+    <footer>
+      <span>Code Self Study Field Guide · Berkeley, Bay Area</span>
+      <span>Vol. XII · Plate 01 · Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/36-brutalist-rust.html
+++ b/mockups/36-brutalist-rust.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (rust &amp; walnut)</title>
+    <style>
+      :root {
+        --paper: #efe7da;
+        --ink: #221d18;
+        --soft: #ddd0bb;
+        --rule: #2e2820;
+        --ochre: #a64a2c;
+        --olive: #7a5236;
+        --slate: #5e5550;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 2px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        font-size: 14px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        border: 2px solid transparent;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--soft);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 36px 28px 72px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.5fr 1fr;
+        gap: 20px;
+      }
+      .panel {
+        border: 2px solid var(--rule);
+        background: var(--paper);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--soft);
+      }
+      .hero .main h1 {
+        font-size: clamp(36px, 5.5vw, 76px);
+        line-height: 1;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 2px solid var(--ink);
+      }
+      .btn:hover {
+        background: var(--ochre);
+        color: var(--paper);
+        border-color: var(--ink);
+      }
+      .side h2 {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .side .stat {
+        font-size: 84px;
+        font-weight: 800;
+        line-height: 0.95;
+        margin: 4px 0 6px;
+        letter-spacing: -0.04em;
+      }
+      .side .stat span {
+        color: var(--ochre);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px solid var(--rule);
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 14px;
+      }
+      .side li b {
+        font-weight: 700;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin-top: 24px;
+      }
+      .features .panel {
+        padding: 22px;
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+        color: var(--ink);
+      }
+      .features .num {
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        color: var(--olive);
+        margin-bottom: 10px;
+      }
+      .features .panel:nth-child(2) .num {
+        color: var(--ochre);
+      }
+      .features .panel:nth-child(3) .num {
+        color: var(--slate);
+      }
+      .big {
+        margin-top: 24px;
+        padding: 28px;
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 18px;
+      }
+      .tag {
+        border: 1.5px solid var(--rule);
+        padding: 3px 8px;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+      }
+      .tag.a {
+        background: var(--ochre);
+        color: var(--paper);
+      }
+      .tag.b {
+        background: var(--olive);
+        color: var(--paper);
+      }
+      .tag.c {
+        background: var(--slate);
+        color: var(--paper);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="panel main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side">
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9am</b></li>
+            <li><span>Location</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <div class="num">01 · Community</div>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">02 · Mentorship</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">03 · Networking</div>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/37-brutalist-pastel-sky.html
+++ b/mockups/37-brutalist-pastel-sky.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (pastel sky)</title>
+    <style>
+      :root {
+        --paper: #f1eff2;
+        --ink: #1f2235;
+        --soft: #d8dfeb;
+        --rule: #2a2f48;
+        --ochre: #6b86b3;
+        --olive: #8e88b8;
+        --slate: #6c7588;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 2px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        font-size: 14px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        border: 2px solid transparent;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--soft);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 36px 28px 72px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.5fr 1fr;
+        gap: 20px;
+      }
+      .panel {
+        border: 2px solid var(--rule);
+        background: var(--paper);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--soft);
+      }
+      .hero .main h1 {
+        font-size: clamp(36px, 5.5vw, 76px);
+        line-height: 1;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 2px solid var(--ink);
+      }
+      .btn:hover {
+        background: var(--ochre);
+        color: var(--paper);
+        border-color: var(--ink);
+      }
+      .side h2 {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .side .stat {
+        font-size: 84px;
+        font-weight: 800;
+        line-height: 0.95;
+        margin: 4px 0 6px;
+        letter-spacing: -0.04em;
+      }
+      .side .stat span {
+        color: var(--ochre);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px solid var(--rule);
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 14px;
+      }
+      .side li b {
+        font-weight: 700;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin-top: 24px;
+      }
+      .features .panel {
+        padding: 22px;
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+        color: var(--ink);
+      }
+      .features .num {
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        color: var(--olive);
+        margin-bottom: 10px;
+      }
+      .features .panel:nth-child(2) .num {
+        color: var(--ochre);
+      }
+      .features .panel:nth-child(3) .num {
+        color: var(--slate);
+      }
+      .big {
+        margin-top: 24px;
+        padding: 28px;
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 18px;
+      }
+      .tag {
+        border: 1.5px solid var(--rule);
+        padding: 3px 8px;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+      }
+      .tag.a {
+        background: var(--ochre);
+        color: var(--paper);
+      }
+      .tag.b {
+        background: var(--olive);
+        color: var(--paper);
+      }
+      .tag.c {
+        background: var(--slate);
+        color: var(--paper);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="panel main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side">
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9am</b></li>
+            <li><span>Location</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <div class="num">01 · Community</div>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">02 · Mentorship</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">03 · Networking</div>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/38-brutalist-pastel-clay.html
+++ b/mockups/38-brutalist-pastel-clay.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (pastel clay)</title>
+    <style>
+      :root {
+        --paper: #f3ece2;
+        --ink: #2b211b;
+        --soft: #e6d6c2;
+        --rule: #382c24;
+        --ochre: #c47a4d;
+        --olive: #6b8499;
+        --slate: #6b6258;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 2px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        font-size: 14px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        border: 2px solid transparent;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--soft);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 36px 28px 72px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.5fr 1fr;
+        gap: 20px;
+      }
+      .panel {
+        border: 2px solid var(--rule);
+        background: var(--paper);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--soft);
+      }
+      .hero .main h1 {
+        font-size: clamp(36px, 5.5vw, 76px);
+        line-height: 1;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 2px solid var(--ink);
+      }
+      .btn:hover {
+        background: var(--ochre);
+        color: var(--paper);
+        border-color: var(--ink);
+      }
+      .side h2 {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .side .stat {
+        font-size: 84px;
+        font-weight: 800;
+        line-height: 0.95;
+        margin: 4px 0 6px;
+        letter-spacing: -0.04em;
+      }
+      .side .stat span {
+        color: var(--ochre);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px solid var(--rule);
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 14px;
+      }
+      .side li b {
+        font-weight: 700;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin-top: 24px;
+      }
+      .features .panel {
+        padding: 22px;
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+        color: var(--ink);
+      }
+      .features .num {
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        color: var(--olive);
+        margin-bottom: 10px;
+      }
+      .features .panel:nth-child(2) .num {
+        color: var(--ochre);
+      }
+      .features .panel:nth-child(3) .num {
+        color: var(--slate);
+      }
+      .big {
+        margin-top: 24px;
+        padding: 28px;
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 18px;
+      }
+      .tag {
+        border: 1.5px solid var(--rule);
+        padding: 3px 8px;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+      }
+      .tag.a {
+        background: var(--ochre);
+        color: var(--paper);
+      }
+      .tag.b {
+        background: var(--olive);
+        color: var(--paper);
+      }
+      .tag.c {
+        background: var(--slate);
+        color: var(--paper);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="panel main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side">
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9am</b></li>
+            <li><span>Location</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <div class="num">01 · Community</div>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">02 · Mentorship</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">03 · Networking</div>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/39-brutalist-navy-copper.html
+++ b/mockups/39-brutalist-navy-copper.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (navy &amp; copper)</title>
+    <style>
+      :root {
+        --paper: #ebe6dd;
+        --ink: #142033;
+        --soft: #d2dae6;
+        --rule: #1c2a44;
+        --ochre: #b66b35;
+        --olive: #4f6b8a;
+        --slate: #6e6258;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 2px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        font-size: 14px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        border: 2px solid transparent;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--soft);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 36px 28px 72px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.5fr 1fr;
+        gap: 20px;
+      }
+      .panel {
+        border: 2px solid var(--rule);
+        background: var(--paper);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--soft);
+      }
+      .hero .main h1 {
+        font-size: clamp(36px, 5.5vw, 76px);
+        line-height: 1;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 2px solid var(--ink);
+      }
+      .btn:hover {
+        background: var(--ochre);
+        color: var(--paper);
+        border-color: var(--ink);
+      }
+      .side h2 {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .side .stat {
+        font-size: 84px;
+        font-weight: 800;
+        line-height: 0.95;
+        margin: 4px 0 6px;
+        letter-spacing: -0.04em;
+      }
+      .side .stat span {
+        color: var(--ochre);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px solid var(--rule);
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 14px;
+      }
+      .side li b {
+        font-weight: 700;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin-top: 24px;
+      }
+      .features .panel {
+        padding: 22px;
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+        color: var(--ink);
+      }
+      .features .num {
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        color: var(--olive);
+        margin-bottom: 10px;
+      }
+      .features .panel:nth-child(2) .num {
+        color: var(--ochre);
+      }
+      .features .panel:nth-child(3) .num {
+        color: var(--slate);
+      }
+      .big {
+        margin-top: 24px;
+        padding: 28px;
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 18px;
+      }
+      .tag {
+        border: 1.5px solid var(--rule);
+        padding: 3px 8px;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+      }
+      .tag.a {
+        background: var(--ochre);
+        color: var(--paper);
+      }
+      .tag.b {
+        background: var(--olive);
+        color: var(--paper);
+      }
+      .tag.c {
+        background: var(--slate);
+        color: var(--paper);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="panel main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side">
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9am</b></li>
+            <li><span>Location</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <div class="num">01 · Community</div>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">02 · Mentorship</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">03 · Networking</div>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/40-brutalist-mono-cobalt.html
+++ b/mockups/40-brutalist-mono-cobalt.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (mono &amp; cobalt)</title>
+    <style>
+      :root {
+        --paper: #ededea;
+        --ink: #181818;
+        --soft: #d6d6d2;
+        --rule: #181818;
+        --ochre: #2b48b3;
+        --olive: #565654;
+        --slate: #8a8a86;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 2px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        font-size: 14px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        border: 2px solid transparent;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--soft);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 36px 28px 72px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.5fr 1fr;
+        gap: 20px;
+      }
+      .panel {
+        border: 2px solid var(--rule);
+        background: var(--paper);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--soft);
+      }
+      .hero .main h1 {
+        font-size: clamp(36px, 5.5vw, 76px);
+        line-height: 1;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 2px solid var(--ink);
+      }
+      .btn:hover {
+        background: var(--ochre);
+        color: var(--paper);
+        border-color: var(--ink);
+      }
+      .side h2 {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .side .stat {
+        font-size: 84px;
+        font-weight: 800;
+        line-height: 0.95;
+        margin: 4px 0 6px;
+        letter-spacing: -0.04em;
+      }
+      .side .stat span {
+        color: var(--ochre);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px solid var(--rule);
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 14px;
+      }
+      .side li b {
+        font-weight: 700;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin-top: 24px;
+      }
+      .features .panel {
+        padding: 22px;
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+        color: var(--ink);
+      }
+      .features .num {
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        color: var(--olive);
+        margin-bottom: 10px;
+      }
+      .features .panel:nth-child(2) .num {
+        color: var(--ochre);
+      }
+      .features .panel:nth-child(3) .num {
+        color: var(--slate);
+      }
+      .big {
+        margin-top: 24px;
+        padding: 28px;
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 18px;
+      }
+      .tag {
+        border: 1.5px solid var(--rule);
+        padding: 3px 8px;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+      }
+      .tag.a {
+        background: var(--ochre);
+        color: var(--paper);
+      }
+      .tag.b {
+        background: var(--olive);
+        color: var(--paper);
+      }
+      .tag.c {
+        background: var(--slate);
+        color: var(--paper);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="panel main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side">
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9am</b></li>
+            <li><span>Location</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <div class="num">01 · Community</div>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">02 · Mentorship</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">03 · Networking</div>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/41-brutalist-stamped.html
+++ b/mockups/41-brutalist-stamped.html
@@ -1,0 +1,417 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (stamped)</title>
+    <style>
+      :root {
+        --paper: #ece6d8;
+        --ink: #1a1612;
+        --soft: #ddd2bd;
+        --rule: #1a1612;
+        --plum: #5a2740;
+        --ochre: #b27a2b;
+        --slate: #5e5550;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+        background-image:
+          radial-gradient(rgba(26, 22, 18, 0.05) 1px, transparent 1px),
+          radial-gradient(rgba(26, 22, 18, 0.04) 1px, transparent 1px);
+        background-size:
+          14px 14px,
+          21px 21px;
+        background-position:
+          0 0,
+          7px 7px;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 3px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+        background: var(--paper);
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        font-size: 14px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+        background: var(--ink);
+        color: var(--paper);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        border: 2px solid transparent;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--soft);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 56px 28px 96px;
+        position: relative;
+      }
+      .stamp {
+        position: absolute;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        border: 4px double var(--plum);
+        color: var(--plum);
+        padding: 8px 18px;
+        font-size: 22px;
+        opacity: 0.55;
+        pointer-events: none;
+        background: rgba(236, 230, 216, 0.4);
+        font-family: "Courier New", ui-monospace, monospace;
+      }
+      .stamp.s1 {
+        top: 16px;
+        right: 32px;
+        transform: rotate(-9deg);
+      }
+      .stamp.s2 {
+        bottom: 320px;
+        left: -20px;
+        transform: rotate(-22deg);
+        font-size: 16px;
+        opacity: 0.45;
+      }
+      .stamp.s3 {
+        top: 460px;
+        right: 14px;
+        transform: rotate(7deg);
+        font-size: 18px;
+        color: var(--ochre);
+        border-color: var(--ochre);
+        opacity: 0.5;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.6fr 1fr;
+        gap: 24px;
+      }
+      .panel {
+        border: 3px solid var(--rule);
+        background: var(--paper);
+        padding: 28px;
+        position: relative;
+      }
+      .hero .main {
+        background: var(--soft);
+        transform: rotate(-0.4deg);
+        box-shadow: 8px 8px 0 var(--ink);
+      }
+      .hero .side {
+        transform: rotate(0.6deg);
+        box-shadow: -6px 8px 0 var(--plum);
+      }
+      .hero .main h1 {
+        font-size: clamp(38px, 5.8vw, 80px);
+        line-height: 0.98;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.025em;
+      }
+      .hero .main h1 em {
+        font-style: normal;
+        background: var(--plum);
+        color: var(--paper);
+        padding: 0 8px;
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 3px solid var(--ink);
+        box-shadow: 4px 4px 0 var(--ochre);
+      }
+      .btn:hover {
+        background: var(--plum);
+        color: var(--paper);
+        box-shadow: 4px 4px 0 var(--ink);
+      }
+      .side h2 {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .side .stat {
+        font-size: 90px;
+        font-weight: 800;
+        line-height: 0.95;
+        margin: 4px 0 6px;
+        letter-spacing: -0.04em;
+      }
+      .side .stat span {
+        color: var(--ochre);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px dashed var(--rule);
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px dashed var(--rule);
+        font-size: 14px;
+      }
+      .side li b {
+        font-weight: 700;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 28px;
+        margin-top: 48px;
+      }
+      .features .panel {
+        padding: 22px;
+      }
+      .features .panel:nth-child(1) {
+        transform: rotate(-0.5deg);
+        box-shadow: 5px 5px 0 var(--ochre);
+      }
+      .features .panel:nth-child(2) {
+        transform: rotate(0.4deg);
+        box-shadow: 5px 5px 0 var(--plum);
+      }
+      .features .panel:nth-child(3) {
+        transform: rotate(-0.2deg);
+        box-shadow: 5px 5px 0 var(--ink);
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+      }
+      .features .num {
+        display: inline-block;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        margin-bottom: 10px;
+        padding: 2px 8px;
+        background: var(--ink);
+        color: var(--paper);
+      }
+      .big {
+        margin-top: 48px;
+        padding: 32px;
+        background: var(--paper);
+        box-shadow: 6px 6px 0 var(--plum);
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 18px;
+      }
+      .tag {
+        border: 2px solid var(--rule);
+        padding: 4px 10px;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+        background: var(--paper);
+        transform: rotate(-0.5deg);
+      }
+      .tag:nth-child(2n) {
+        transform: rotate(0.6deg);
+      }
+      .tag:nth-child(3n) {
+        transform: rotate(-1deg);
+      }
+      .tag.a {
+        background: var(--plum);
+        color: var(--paper);
+      }
+      .tag.b {
+        background: var(--ochre);
+        color: var(--paper);
+      }
+      .tag.c {
+        background: var(--ink);
+        color: var(--paper);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 3px solid var(--rule);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+        background: var(--paper);
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+        .stamp {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <span class="stamp s1">Approved · Berkeley · 2014</span>
+      <span class="stamp s2">No Bootcamp Pitch</span>
+      <span class="stamp s3">All Languages</span>
+
+      <section class="hero">
+        <div class="panel main">
+          <h1>Study code. <em>Together.</em> In&nbsp;person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side">
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9am</b></li>
+            <li><span>Location</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <span class="num">01 · Community</span>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel">
+          <span class="num">02 · Mentorship</span>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel">
+          <span class="num">03 · Networking</span>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/42-brutalist-graph.html
+++ b/mockups/42-brutalist-graph.html
@@ -1,0 +1,397 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (graph)</title>
+    <style>
+      :root {
+        --paper: #ecede8;
+        --ink: #15201f;
+        --soft: #d2dedb;
+        --rule: #15201f;
+        --teal: #2f6964;
+        --ochre: #b07d2f;
+        --slate: #5a6663;
+        --grid: rgba(21, 32, 31, 0.09);
+        --grid-major: rgba(21, 32, 31, 0.18);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        background-image:
+          linear-gradient(var(--grid) 1px, transparent 1px),
+          linear-gradient(90deg, var(--grid) 1px, transparent 1px),
+          linear-gradient(var(--grid-major) 1px, transparent 1px),
+          linear-gradient(90deg, var(--grid-major) 1px, transparent 1px);
+        background-size:
+          16px 16px,
+          16px 16px,
+          80px 80px,
+          80px 80px;
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 2px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+        background: var(--paper);
+      }
+      .logo {
+        font-family: ui-monospace, "JetBrains Mono", "Cascadia Mono", monospace;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        font-size: 13px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+      }
+      .logo::before {
+        content: "+ ";
+        color: var(--teal);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        border: 2px solid transparent;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--soft);
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 40px 32px 80px;
+      }
+      .panel {
+        border: 2px solid var(--rule);
+        background: var(--paper);
+        padding: 28px;
+        position: relative;
+      }
+      .panel::before,
+      .panel::after {
+        position: absolute;
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        color: var(--slate);
+        background: var(--paper);
+        padding: 0 4px;
+      }
+      .panel::before {
+        content: attr(data-coord);
+        top: -8px;
+        left: 16px;
+      }
+      .panel::after {
+        content: attr(data-stamp);
+        bottom: -8px;
+        right: 16px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.5fr 1fr;
+        gap: 24px;
+      }
+      .hero .main {
+        background: var(--soft);
+      }
+      .hero .main h1 {
+        font-size: clamp(36px, 5.4vw, 76px);
+        line-height: 1;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+      }
+      .callout {
+        position: relative;
+        margin: 6px 0 16px;
+        padding-left: 20px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--teal);
+      }
+      .callout::before {
+        content: "↳";
+        position: absolute;
+        left: 0;
+        top: -2px;
+        font-size: 14px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 2px solid var(--ink);
+        font-family: ui-monospace, monospace;
+      }
+      .btn:hover {
+        background: var(--teal);
+        color: var(--paper);
+      }
+      .side h2 {
+        margin: 0;
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .side .stat {
+        font-size: 84px;
+        font-weight: 800;
+        line-height: 0.95;
+        margin: 4px 0 6px;
+        letter-spacing: -0.04em;
+      }
+      .side .stat span {
+        color: var(--ochre);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px solid var(--rule);
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 14px;
+        font-family: ui-monospace, monospace;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 32px;
+      }
+      .features .panel {
+        padding: 22px;
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+      }
+      .features .num {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.18em;
+        color: var(--teal);
+        margin-bottom: 10px;
+        text-transform: uppercase;
+      }
+      .features .panel:nth-child(2) .num {
+        color: var(--ochre);
+      }
+      .features .panel:nth-child(3) .num {
+        color: var(--slate);
+      }
+      .big {
+        margin-top: 32px;
+        padding: 32px;
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 0;
+        margin-top: 18px;
+        border: 1px solid var(--rule);
+      }
+      .tag {
+        font-family: ui-monospace, monospace;
+        padding: 8px 10px;
+        font-size: 12px;
+        letter-spacing: 0.04em;
+        border-right: 1px solid var(--rule);
+        border-bottom: 1px solid var(--rule);
+        background: var(--paper);
+      }
+      .tag.a {
+        background: var(--teal);
+        color: var(--paper);
+      }
+      .tag.b {
+        background: var(--ochre);
+        color: var(--paper);
+      }
+      .tag.c {
+        background: var(--ink);
+        color: var(--paper);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+        background: var(--paper);
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="panel main" data-coord="A1 · Hero" data-stamp="rev. 04.19">
+          <h1>Study code. Together. In person.</h1>
+          <div class="callout">Berkeley · Bay Area · Saturdays · 9am</div>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side" data-coord="A2 · Stats" data-stamp="2014→">
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Meetup</span><span>Sat 09:00</span></li>
+            <li><span>City</span><span>Berkeley</span></li>
+            <li><span>Format</span><span>Self-study</span></li>
+            <li><span>Cover</span><span>Free</span></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel" data-coord="B1 · 01" data-stamp="community">
+          <div class="num">01 / Community</div>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel" data-coord="B2 · 02" data-stamp="mentorship">
+          <div class="num">02 / Mentorship</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel" data-coord="B3 · 03" data-stamp="networking">
+          <div class="num">03 / Networking</div>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section
+        class="panel big"
+        data-coord="C1 · Index"
+        data-stamp="languages.txt"
+      >
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA · sheet 01/01</span>
+      <span>scale 1:1 · est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/43-brutalist-halftone.html
+++ b/mockups/43-brutalist-halftone.html
@@ -1,0 +1,409 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (halftone)</title>
+    <style>
+      :root {
+        --paper: #ece9e1;
+        --ink: #1a1d2b;
+        --soft: #d6dae5;
+        --rule: #1a1d2b;
+        --indigo: #3a4a8c;
+        --rust: #b75a36;
+        --slate: #58607a;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 2px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        font-size: 14px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        border: 2px solid transparent;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--soft);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 36px 28px 80px;
+      }
+      .panel {
+        border: 2px solid var(--rule);
+        background: var(--paper);
+        padding: 28px;
+        position: relative;
+        overflow: hidden;
+      }
+      .ht {
+        position: absolute;
+        inset: 0;
+        background-image: radial-gradient(
+          var(--indigo) 1.6px,
+          transparent 1.8px
+        );
+        background-size: 10px 10px;
+        opacity: 0.18;
+        pointer-events: none;
+        mask-image: linear-gradient(135deg, #000 0%, #000 30%, transparent 60%);
+        -webkit-mask-image: linear-gradient(
+          135deg,
+          #000 0%,
+          #000 30%,
+          transparent 60%
+        );
+      }
+      .ht.tr {
+        mask-image: linear-gradient(225deg, #000 0%, #000 30%, transparent 60%);
+        -webkit-mask-image: linear-gradient(
+          225deg,
+          #000 0%,
+          #000 30%,
+          transparent 60%
+        );
+      }
+      .ht.rust {
+        background-image: radial-gradient(var(--rust) 1.6px, transparent 1.8px);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.6fr 1fr;
+        gap: 24px;
+      }
+      .hero .main {
+        background: var(--soft);
+      }
+      .hero .main h1 {
+        font-size: clamp(40px, 6.4vw, 92px);
+        line-height: 0.95;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+        position: relative;
+        z-index: 1;
+      }
+      .hero .main h1 em {
+        font-style: normal;
+        color: var(--rust);
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+        position: relative;
+        z-index: 1;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--paper);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 2px solid var(--ink);
+        position: relative;
+        z-index: 1;
+      }
+      .btn:hover {
+        background: var(--rust);
+      }
+      .side h2 {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--slate);
+        position: relative;
+        z-index: 1;
+      }
+      .side .stat {
+        font-size: 96px;
+        font-weight: 800;
+        line-height: 0.9;
+        margin: 4px 0 6px;
+        letter-spacing: -0.05em;
+        position: relative;
+        z-index: 1;
+      }
+      .side .stat span {
+        color: var(--rust);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px solid var(--rule);
+        position: relative;
+        z-index: 1;
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 14px;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 32px;
+      }
+      .features .panel {
+        padding: 22px;
+        min-height: 220px;
+      }
+      .features .bignum {
+        position: absolute;
+        right: -14px;
+        bottom: -38px;
+        font-size: 220px;
+        font-weight: 800;
+        line-height: 1;
+        color: var(--rule);
+        opacity: 0.08;
+        pointer-events: none;
+        letter-spacing: -0.05em;
+      }
+      .features h3 {
+        margin: 0 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+        position: relative;
+        z-index: 1;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+        position: relative;
+        z-index: 1;
+      }
+      .features .num {
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        color: var(--indigo);
+        margin-bottom: 10px;
+        position: relative;
+        z-index: 1;
+        text-transform: uppercase;
+      }
+      .features .panel:nth-child(2) .num {
+        color: var(--rust);
+      }
+      .features .panel:nth-child(3) .num {
+        color: var(--slate);
+      }
+      .big {
+        margin-top: 32px;
+        padding: 32px;
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        position: relative;
+        z-index: 1;
+      }
+      .big p {
+        position: relative;
+        z-index: 1;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 18px;
+        position: relative;
+        z-index: 1;
+      }
+      .tag {
+        border: 1.5px solid var(--rule);
+        padding: 3px 8px;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+        background: var(--paper);
+      }
+      .tag.a {
+        background: var(--indigo);
+        color: var(--paper);
+      }
+      .tag.b {
+        background: var(--rust);
+        color: var(--paper);
+      }
+      .tag.c {
+        background: var(--ink);
+        color: var(--paper);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="panel main">
+          <span class="ht"></span>
+          <h1>Study code. <em>Together.</em><br />In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side">
+          <span class="ht tr rust"></span>
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9am</b></li>
+            <li><span>Location</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <span class="ht"></span>
+          <span class="bignum">01</span>
+          <div class="num">Community</div>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel">
+          <span class="ht rust"></span>
+          <span class="bignum">02</span>
+          <div class="num">Mentorship</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel">
+          <span class="ht"></span>
+          <span class="bignum">03</span>
+          <div class="num">Networking</div>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <span class="ht tr"></span>
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/44-brutalist-collage.html
+++ b/mockups/44-brutalist-collage.html
@@ -1,0 +1,413 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (collage)</title>
+    <style>
+      :root {
+        --paper: #d8c8a8;
+        --card: #f0e9da;
+        --ink: #221a12;
+        --rule: #221a12;
+        --tape: #ece2c8;
+        --terra: #a0492a;
+        --denim: #3a5a78;
+        --slate: #5e544a;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        background-image:
+          radial-gradient(rgba(0, 0, 0, 0.045) 1px, transparent 1px),
+          radial-gradient(rgba(0, 0, 0, 0.04) 1px, transparent 1px);
+        background-size:
+          5px 5px,
+          11px 11px;
+        background-position:
+          0 0,
+          2px 3px;
+        color: var(--ink);
+        font-family:
+          "Inter", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 500;
+        line-height: 1.5;
+      }
+      a {
+        color: inherit;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        border-bottom: 2px solid var(--rule);
+        flex-wrap: wrap;
+        gap: 12px;
+        background: var(--card);
+      }
+      .logo {
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        font-size: 14px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 2px solid var(--rule);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        border: 2px solid transparent;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--tape);
+      }
+      .wrap {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 56px 28px 96px;
+      }
+      .panel {
+        border: 2px solid var(--rule);
+        background: var(--card);
+        padding: 28px 28px 32px;
+        position: relative;
+        box-shadow: 4px 4px 0 rgba(34, 26, 18, 0.25);
+      }
+      .tape {
+        position: absolute;
+        background: var(--tape);
+        border: 1px solid rgba(34, 26, 18, 0.18);
+        width: 110px;
+        height: 22px;
+        opacity: 0.85;
+        box-shadow:
+          0 1px 2px rgba(0, 0, 0, 0.2),
+          inset 0 0 12px rgba(0, 0, 0, 0.04);
+      }
+      .tape.tl {
+        top: -10px;
+        left: 24px;
+        transform: rotate(-6deg);
+      }
+      .tape.tr {
+        top: -10px;
+        right: 24px;
+        transform: rotate(7deg);
+        background: #e6dabe;
+      }
+      .tape.bl {
+        bottom: -10px;
+        left: 32px;
+        transform: rotate(5deg);
+      }
+      .tape.br {
+        bottom: -10px;
+        right: 32px;
+        transform: rotate(-5deg);
+        background: #e6dabe;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.55fr 1fr;
+        gap: 32px;
+      }
+      .hero .main h1 {
+        font-size: clamp(36px, 5.6vw, 78px);
+        line-height: 0.98;
+        margin: 0 0 16px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .hero .main h1 em {
+        font-style: italic;
+        color: var(--terra);
+      }
+      .hero .main p {
+        font-size: 17px;
+        max-width: 38ch;
+        margin: 0 0 22px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--card);
+        padding: 12px 18px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 13px;
+        border: 2px solid var(--ink);
+      }
+      .btn:hover {
+        background: var(--terra);
+      }
+      .label {
+        position: absolute;
+        background: var(--ink);
+        color: var(--card);
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        padding: 3px 8px;
+        font-weight: 700;
+      }
+      .label.tl {
+        top: 14px;
+        left: -10px;
+        transform: rotate(-3deg);
+      }
+      .label.terra {
+        background: var(--terra);
+      }
+      .label.denim {
+        background: var(--denim);
+      }
+      .side {
+        transform: rotate(0.8deg);
+      }
+      .side h2 {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--slate);
+      }
+      .side .stat {
+        font-size: 84px;
+        font-weight: 800;
+        line-height: 0.95;
+        margin: 4px 0 6px;
+        letter-spacing: -0.04em;
+      }
+      .side .stat span {
+        color: var(--terra);
+      }
+      .side ul {
+        list-style: none;
+        padding: 0;
+        margin: 18px 0 0;
+        border-top: 1px solid var(--rule);
+      }
+      .side li {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--rule);
+        font-size: 14px;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 32px;
+        margin-top: 56px;
+      }
+      .features .panel {
+        padding: 24px;
+      }
+      .features .panel:nth-child(1) {
+        transform: rotate(-1.2deg);
+      }
+      .features .panel:nth-child(2) {
+        transform: rotate(0.6deg) translateY(8px);
+      }
+      .features .panel:nth-child(3) {
+        transform: rotate(-0.4deg);
+      }
+      .features h3 {
+        margin: 6px 0 6px;
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+      .features p {
+        margin: 0;
+        font-size: 15px;
+      }
+      .big {
+        margin-top: 56px;
+        padding: 32px;
+        transform: rotate(-0.3deg);
+      }
+      .big h2 {
+        font-size: clamp(26px, 3.5vw, 44px);
+        margin: 0 0 12px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 18px;
+      }
+      .tag {
+        border: 1.5px solid var(--rule);
+        padding: 4px 10px;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+        background: var(--card);
+        box-shadow: 2px 2px 0 rgba(34, 26, 18, 0.2);
+      }
+      .tag.a {
+        background: var(--terra);
+        color: var(--card);
+      }
+      .tag.b {
+        background: var(--denim);
+        color: var(--card);
+      }
+      .tag.c {
+        background: var(--ink);
+        color: var(--card);
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+        background: var(--card);
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+        .features .panel {
+          transform: none;
+        }
+        .side {
+          transform: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="panel main">
+          <span class="tape tl"></span>
+          <span class="tape tr"></span>
+          <span class="label tl">Berkeley · 2014→</span>
+          <h1>Study code. <em>Together.</em><br />In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages, all levels welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the community</a
+          >
+        </div>
+        <div class="panel side">
+          <span class="tape tl"></span>
+          <span class="tape br"></span>
+          <span class="label tl terra">Members</span>
+          <h2>Since 2014</h2>
+          <div class="stat">5<span>,</span>000<span>+</span></div>
+          <p style="margin: 0; font-size: 14px; color: var(--slate)">
+            programmers, all levels, all languages
+          </p>
+          <ul>
+            <li><span>Weekly meetup</span><b>Sat 9am</b></li>
+            <li><span>Location</span><b>Berkeley</b></li>
+            <li><span>Format</span><b>Self-study + mentorship</b></li>
+            <li><span>Cover</span><b>Free</b></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <span class="tape tl"></span>
+          <span class="label tl">01 · Community</span>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The hard part is
+            done: the room exists.
+          </p>
+        </div>
+        <div class="panel">
+          <span class="tape tr"></span>
+          <span class="label tl terra">02 · Mentorship</span>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners. Bring a question, a project, or
+            a stuck commit.
+          </p>
+        </div>
+        <div class="panel">
+          <span class="tape tl"></span>
+          <span class="label tl denim">03 · Networking</span>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group. No pitch, just people.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <span class="tape tl"></span>
+        <span class="tape tr"></span>
+        <span class="tape bl"></span>
+        <span class="tape br"></span>
+        <h2>All languages. All levels.</h2>
+        <p style="max-width: 65ch">
+          Dozens of groups will teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag a">Python</span><span class="tag">JavaScript</span
+          ><span class="tag b">TypeScript</span><span class="tag">Go</span
+          ><span class="tag c">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag a">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag b">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag c">SQL</span
+          ><span class="tag">+ more</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/45-brutalist-carbon.html
+++ b/mockups/45-brutalist-carbon.html
@@ -1,0 +1,431 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist (carbon copy)</title>
+    <style>
+      :root {
+        --paper: #ece2c8;
+        --paper-soft: #e2d6b8;
+        --ink: #2a1f12;
+        --ink-soft: rgba(42, 31, 18, 0.7);
+        --rule: #2a1f12;
+        --ribbon: #993528;
+        --ribbon-ghost: rgba(153, 53, 40, 0.45);
+        --slate: #5a4f40;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--paper);
+        background-image:
+          repeating-linear-gradient(
+            0deg,
+            rgba(42, 31, 18, 0.025) 0 1px,
+            transparent 1px 3px
+          ),
+          radial-gradient(rgba(42, 31, 18, 0.05) 1px, transparent 1px);
+        background-size:
+          100% 4px,
+          7px 7px;
+        color: var(--ink);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Cascadia Mono", "Courier New",
+          ui-monospace, monospace;
+        font-weight: 500;
+        line-height: 1.55;
+      }
+      a {
+        color: inherit;
+      }
+      .perforated {
+        height: 18px;
+        background:
+          radial-gradient(circle at 8px 9px, var(--paper) 4px, transparent 5px)
+            repeat-x,
+          var(--rule);
+        background-size: 16px 18px;
+        border-bottom: 2px solid var(--rule);
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 28px;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        font-size: 13px;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        border: 1.5px solid var(--rule);
+        text-shadow: 1.5px 1.5px 0 var(--ribbon-ghost);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 4px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        padding: 4px 10px;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        border: 1.5px solid transparent;
+      }
+      nav a:hover {
+        border-color: var(--rule);
+        background: var(--paper-soft);
+      }
+      .wrap {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 28px 32px 64px;
+      }
+      .memo {
+        border: 1.5px solid var(--rule);
+        background: var(--paper);
+        padding: 28px 32px;
+        position: relative;
+      }
+      .memo::before {
+        content: "MEMO · 04.19.2026";
+        position: absolute;
+        top: -10px;
+        left: 24px;
+        background: var(--paper);
+        padding: 0 8px;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+      }
+      .memo dl {
+        display: grid;
+        grid-template-columns: 80px 1fr;
+        gap: 4px 14px;
+        margin: 0 0 18px;
+        font-size: 13px;
+      }
+      .memo dt {
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        color: var(--slate);
+      }
+      .memo dd {
+        margin: 0;
+        border-bottom: 1px dotted var(--rule);
+      }
+      .hero h1 {
+        font-family:
+          "Special Elite", "Courier Prime", "Courier New", ui-monospace,
+          monospace;
+        font-size: clamp(34px, 4.8vw, 60px);
+        line-height: 1.05;
+        margin: 8px 0 16px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        text-shadow:
+          1.5px 1.5px 0 var(--ribbon-ghost),
+          3px 3px 0 rgba(42, 31, 18, 0.18);
+      }
+      .hero h1 em {
+        font-style: normal;
+        background: var(--rule);
+        color: var(--paper);
+        padding: 0 6px;
+      }
+      .hero p {
+        font-size: 15px;
+        max-width: 60ch;
+        margin: 0 0 22px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        background: var(--rule);
+        color: var(--paper);
+        padding: 10px 16px;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        font-size: 12px;
+        border: 1.5px solid var(--rule);
+        text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3);
+      }
+      .btn:hover {
+        background: var(--ribbon);
+        border-color: var(--ribbon);
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 24px;
+        margin-top: 24px;
+      }
+      .panel {
+        border: 1.5px solid var(--rule);
+        background: var(--paper);
+        padding: 22px 24px;
+        position: relative;
+      }
+      .panel .label {
+        position: absolute;
+        top: -10px;
+        left: 18px;
+        background: var(--paper);
+        padding: 0 8px;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+      }
+      .stat-block {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 6px 14px;
+        font-size: 13px;
+      }
+      .stat-block b {
+        color: var(--ribbon);
+      }
+      .stat-block span:nth-child(odd) {
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--slate);
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+        margin-top: 32px;
+      }
+      .features .panel {
+        padding: 20px;
+      }
+      .features h3 {
+        margin: 6px 0 6px;
+        font-size: 17px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        text-shadow: 1px 1px 0 var(--ribbon-ghost);
+      }
+      .features p {
+        margin: 0;
+        font-size: 13px;
+      }
+      .features .num {
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.18em;
+        color: var(--ribbon);
+        margin-bottom: 4px;
+        text-transform: uppercase;
+      }
+      .stamp {
+        position: absolute;
+        top: 18px;
+        right: 28px;
+        border: 2.5px double var(--ribbon);
+        color: var(--ribbon);
+        padding: 6px 14px;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        transform: rotate(-8deg);
+        opacity: 0.85;
+      }
+      .big {
+        margin-top: 32px;
+        padding: 24px 28px;
+      }
+      .big h2 {
+        font-family:
+          "Special Elite", "Courier Prime", "Courier New", ui-monospace,
+          monospace;
+        font-size: clamp(22px, 3vw, 34px);
+        margin: 0 0 12px;
+        font-weight: 700;
+        letter-spacing: -0.005em;
+        text-shadow: 1.5px 1.5px 0 var(--ribbon-ghost);
+      }
+      .langs {
+        margin-top: 16px;
+        font-size: 13px;
+        line-height: 1.9;
+        column-count: 3;
+        column-gap: 28px;
+      }
+      .langs a {
+        text-decoration: none;
+        display: block;
+        border-bottom: 1px dotted var(--rule);
+      }
+      .langs a:hover {
+        background: var(--ribbon);
+        color: var(--paper);
+        border-color: var(--ribbon);
+      }
+      .langs a::before {
+        content: "□ ";
+        color: var(--slate);
+      }
+      .signoff {
+        margin-top: 32px;
+        font-size: 12px;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+        border-top: 1px dashed var(--rule);
+        padding-top: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+      }
+      footer {
+        padding: 22px 28px;
+        border-top: 2px solid var(--rule);
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      @media (max-width: 820px) {
+        .grid,
+        .features {
+          grid-template-columns: 1fr;
+        }
+        .langs {
+          column-count: 2;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="perforated"></div>
+    <nav>
+      <div class="logo">Code · Self · Study</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="memo hero">
+        <span class="stamp">Carbon · Copy</span>
+        <dl>
+          <dt>From</dt>
+          <dd>The Regulars</dd>
+          <dt>To</dt>
+          <dd>Anyone learning to program in the Bay Area</dd>
+          <dt>Subj</dt>
+          <dd>Saturday meetup, Berkeley, 9 a.m.</dd>
+          <dt>File</dt>
+          <dd>codeselfstudy.org / 5,247 members / since 2014</dd>
+        </dl>
+
+        <h1>Study code. <em>Together.</em> In&nbsp;person.</h1>
+        <p>
+          A friendly programming community of 5,000+ people in Berkeley and the
+          San Francisco Bay Area. All languages, all levels welcome. The format
+          is self-study with mentorship — show up at a meetup, bring a question
+          or a project, get help from the regulars.
+        </p>
+        <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+          >▸ Join the community</a
+        >
+      </section>
+
+      <section class="grid">
+        <div class="panel">
+          <span class="label">Statement</span>
+          <p style="margin: 0; font-size: 14px">
+            Dozens of groups will teach you to code. We build a local community
+            of friendly, highly-motivated programmers instead. No curriculum, no
+            gatekeeping, no bootcamp pitch.
+          </p>
+        </div>
+        <div class="panel">
+          <span class="label">Roster</span>
+          <div class="stat-block">
+            <span>Members</span><span><b>5,247</b></span> <span>Year est.</span
+            ><span><b>2014</b></span> <span>City</span
+            ><span><b>Berkeley</b></span> <span>Cover</span
+            ><span><b>Free</b></span>
+          </div>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="panel">
+          <div class="num">01 · Community</div>
+          <h3>Show up. Meet people.</h3>
+          <p>
+            Programmers who keep showing up week after week. The room already
+            exists.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">02 · Mentorship</div>
+          <h3>Ask for a plan.</h3>
+          <p>
+            Experienced members help beginners with study plans, code reviews,
+            stuck commits.
+          </p>
+        </div>
+        <div class="panel">
+          <div class="num">03 · Networking</div>
+          <h3>Doors open quietly.</h3>
+          <p>
+            Members have landed jobs through introductions made inside the
+            group.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel big">
+        <h2>Languages in active rotation</h2>
+        <p style="margin: 0; font-size: 13px">
+          Anything that gets enough people in the room ends up in rotation. A
+          few currently regular:
+        </p>
+        <div class="langs">
+          <a href="#">Python</a><a href="#">JavaScript</a
+          ><a href="#">TypeScript</a><a href="#">Go</a><a href="#">Rust</a
+          ><a href="#">Haskell</a><a href="#">Clojure</a><a href="#">Elixir</a
+          ><a href="#">Racket</a><a href="#">Scheme</a><a href="#">C</a
+          ><a href="#">C++</a><a href="#">Ruby</a><a href="#">Scala</a
+          ><a href="#">Erlang</a><a href="#">Elm</a><a href="#">Lua</a
+          ><a href="#">SQL</a>
+        </div>
+        <div class="signoff">
+          <span>— filed by the regulars</span>
+          <span>cc: anyone curious</span>
+        </div>
+      </section>
+    </div>
+    <footer>
+      <span>Code Self Study — Berkeley, CA</span>
+      <span>Doc 04.19 · Est. 2014</span>
+    </footer>
+  </body>
+</html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -1,0 +1,229 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Mockups</title>
+    <style>
+      :root {
+        --bg: #0f1115;
+        --fg: #e7e9ee;
+        --muted: #9aa3b2;
+        --card: #151821;
+        --border: #242936;
+        --accent: #7dd3fc;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          sans-serif;
+        line-height: 1.5;
+      }
+      .wrap {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 64px 24px;
+      }
+      header h1 {
+        font-size: clamp(28px, 4vw, 44px);
+        margin: 0 0 8px;
+        letter-spacing: -0.02em;
+      }
+      header p {
+        color: var(--muted);
+        margin: 0 0 40px;
+        max-width: 60ch;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: 16px;
+      }
+      a.card {
+        display: block;
+        text-decoration: none;
+        color: inherit;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 20px;
+        transition:
+          transform 0.12s ease,
+          border-color 0.12s ease;
+      }
+      a.card:hover {
+        transform: translateY(-2px);
+        border-color: var(--accent);
+      }
+      .num {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: var(--accent);
+        font-size: 12px;
+        letter-spacing: 0.12em;
+      }
+      .card h2 {
+        font-size: 18px;
+        margin: 8px 0 6px;
+        letter-spacing: -0.01em;
+      }
+      .card p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      footer {
+        margin-top: 40px;
+        color: var(--muted);
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <header>
+        <h1>Code Self Study — homepage mockups</h1>
+        <p>
+          Ten standalone design directions for the homepage. Each file is pure
+          HTML/CSS with no build step. Open any one to preview.
+        </p>
+      </header>
+      <div class="grid">
+        <a class="card" href="01-terminal.html"
+          ><div class="num">01</div>
+          <h2>Terminal / Retro hacker</h2>
+          <p>Monospace, CRT glow, green-on-black nostalgia.</p></a
+        >
+        <a class="card" href="02-editorial.html"
+          ><div class="num">02</div>
+          <h2>Editorial / Dev magazine</h2>
+          <p>Serif headlines, drop caps, multi-column prose.</p></a
+        >
+        <a class="card" href="03-brutalist.html"
+          ><div class="num">03</div>
+          <h2>Neo-brutalist</h2>
+          <p>Hard shadows, thick borders, primary blocks.</p></a
+        >
+        <a class="card" href="04-minimal.html"
+          ><div class="num">04</div>
+          <h2>Modern minimalist</h2>
+          <p>Generous whitespace, one accent, quiet.</p></a
+        >
+        <a class="card" href="05-dark-neon.html"
+          ><div class="num">05</div>
+          <h2>Dark tech / neon</h2>
+          <p>Deep navy, neon glow, glassy cards.</p></a
+        >
+        <a class="card" href="06-warm-community.html"
+          ><div class="num">06</div>
+          <h2>Warm community</h2>
+          <p>Friendly palette, rounded shapes, humane tone.</p></a
+        >
+        <a class="card" href="07-zine.html"
+          ><div class="num">07</div>
+          <h2>Zine / indie web</h2>
+          <p>Mixed fonts, paper texture, handcrafted.</p></a
+        >
+        <a class="card" href="08-glass.html"
+          ><div class="num">08</div>
+          <h2>Glassmorphism gradient</h2>
+          <p>Soft gradients, frosted glass panels.</p></a
+        >
+        <a class="card" href="09-bauhaus.html"
+          ><div class="num">09</div>
+          <h2>Bauhaus / geometric</h2>
+          <p>Circles, squares, primary colors, strong grid.</p></a
+        >
+        <a class="card" href="10-swiss.html"
+          ><div class="num">10</div>
+          <h2>Swiss / typographic</h2>
+          <p>Helvetica, asymmetric grid, red accent.</p></a
+        >
+        <a class="card" href="11-bbs.html"
+          ><div class="num">11</div>
+          <h2>BBS / amber monitor</h2>
+          <p>ANSI art, CRT scanlines, dial-up nostalgia.</p></a
+        >
+        <a class="card" href="12-riso.html"
+          ><div class="num">12</div>
+          <h2>Risograph print</h2>
+          <p>Pink + blue overprint, paper grain, reg marks.</p></a
+        >
+        <a class="card" href="13-arcade.html"
+          ><div class="num">13</div>
+          <h2>Arcade / pixel-art</h2>
+          <p>CRT cabinet, sprites, pixel typography.</p></a
+        >
+        <a class="card" href="14-schematic.html"
+          ><div class="num">14</div>
+          <h2>Engineering schematic</h2>
+          <p>Title block, BOM table, technical drawing.</p></a
+        >
+        <a class="card" href="15-newspaper.html"
+          ><div class="num">15</div>
+          <h2>Newspaper front page</h2>
+          <p>Masthead, drop caps, columns, classifieds.</p></a
+        >
+        <a class="card" href="16-ledger.html"
+          ><div class="num">16</div>
+          <h2>Ledger &amp; stamp</h2>
+          <p>Old ledger, notary stamps, blackletter mark.</p></a
+        >
+        <a class="card" href="17-comic.html"
+          ><div class="num">17</div>
+          <h2>Comic book / halftone</h2>
+          <p>Ben-Day dots, speech bubbles, action panels.</p></a
+        >
+        <a class="card" href="18-transit.html"
+          ><div class="num">18</div>
+          <h2>Transit wayfinding</h2>
+          <p>Vignelli-style signage, line roundels, ETA board.</p></a
+        >
+        <a class="card" href="19-punk.html"
+          ><div class="num">19</div>
+          <h2>Punk flyer / xerox</h2>
+          <p>High-contrast B&amp;W, stickered, photocopied.</p></a
+        >
+        <a class="card" href="21-norton.html"
+          ><div class="num">21</div>
+          <h2>Norton Commander / DOS TUI</h2>
+          <p>Blue + cyan panels, F-key bar, file-manager layout.</p></a
+        >
+        <a class="card" href="22-ansi-scene.html"
+          ><div class="num">22</div>
+          <h2>ANSI scene art</h2>
+          <p>CGA palette, block-art logo, warez-scene density.</p></a
+        >
+        <a class="card" href="23-teletext.html"
+          ><div class="num">23</div>
+          <h2>Teletext / Ceefax</h2>
+          <p>Chunky pixel cells, color blocks, page-number index.</p></a
+        >
+        <a class="card" href="24-vt100.html"
+          ><div class="num">24</div>
+          <h2>VT100 monochrome green</h2>
+          <p>Classic phosphor terminal, login banner, MOTD.</p></a
+        >
+        <a class="card" href="25-c64.html"
+          ><div class="num">25</div>
+          <h2>C64 boot screen</h2>
+          <p>Light-blue on blue, BASIC LIST, READY prompt.</p></a
+        >
+      </div>
+      <footer>All 25 live under <code>./mockups/</code>.</footer>
+    </div>
+  </body>
+</html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -297,8 +297,33 @@
           <h2>Brutalist · mono &amp; cobalt</h2>
           <p>Warm grayscale with a single cobalt accent.</p></a
         >
+        <a class="card" href="41-brutalist-stamped.html"
+          ><div class="num">41</div>
+          <h2>Brutalist · stamped</h2>
+          <p>Tilted panels, hard offset shadows, rubber-stamp overlays.</p></a
+        >
+        <a class="card" href="42-brutalist-graph.html"
+          ><div class="num">42</div>
+          <h2>Brutalist · graph paper</h2>
+          <p>Engineering grid, mono coordinate labels, teal + ochre.</p></a
+        >
+        <a class="card" href="43-brutalist-halftone.html"
+          ><div class="num">43</div>
+          <h2>Brutalist · halftone</h2>
+          <p>Dot-pattern fades, oversize ghost numerals, indigo + rust.</p></a
+        >
+        <a class="card" href="44-brutalist-collage.html"
+          ><div class="num">44</div>
+          <h2>Brutalist · tape collage</h2>
+          <p>Masking-tape strips, kraft cardboard ground, terracotta.</p></a
+        >
+        <a class="card" href="45-brutalist-carbon.html"
+          ><div class="num">45</div>
+          <h2>Brutalist · carbon copy</h2>
+          <p>Typewriter mono, ribbon-red ghost shadow, memo header.</p></a
+        >
       </div>
-      <footer>All 39 live under <code>./mockups/</code>.</footer>
+      <footer>All 44 live under <code>./mockups/</code>.</footer>
     </div>
   </body>
 </html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -222,8 +222,58 @@
           <h2>C64 boot screen</h2>
           <p>Light-blue on blue, BASIC LIST, READY prompt.</p></a
         >
+        <a class="card" href="26-brutalist-muted.html"
+          ><div class="num">26</div>
+          <h2>Muted brutalist</h2>
+          <p>Charcoal, cream, ochre &amp; olive. Quiet contrast.</p></a
+        >
+        <a class="card" href="27-brutalist-concrete.html"
+          ><div class="num">27</div>
+          <h2>Concrete brutalist</h2>
+          <p>Raw concrete grays, rust &amp; kraft. Architectural.</p></a
+        >
+        <a class="card" href="28-brutalist-stained.html"
+          ><div class="num">28</div>
+          <h2>Stained-glass brutalist</h2>
+          <p>Translucent overlapping panels, lead-line borders.</p></a
+        >
+        <a class="card" href="29-brutalist-forest.html"
+          ><div class="num">29</div>
+          <h2>Forest brutalist</h2>
+          <p>Deep moss, cream, tan. Trail-marker feel.</p></a
+        >
+        <a class="card" href="30-bbs-pcboard.html"
+          ><div class="num">30</div>
+          <h2>PCBoard BBS</h2>
+          <p>Deep blue, cyan @-codes, classic bulletin layout.</p></a
+        >
+        <a class="card" href="31-bbs-renegade.html"
+          ><div class="num">31</div>
+          <h2>Renegade BBS</h2>
+          <p>Orange/red palette, lightbar menus, login banner.</p></a
+        >
+        <a class="card" href="32-bbs-wwiv.html"
+          ><div class="num">32</div>
+          <h2>WWIV BBS</h2>
+          <p>Bright blue field, white/cyan menu, sub-board list.</p></a
+        >
+        <a class="card" href="33-modernist-museum.html"
+          ><div class="num">33</div>
+          <h2>Modernist museum</h2>
+          <p>Gallery whites, thin display type, plate-style works.</p></a
+        >
+        <a class="card" href="34-japanese-editorial.html"
+          ><div class="num">34</div>
+          <h2>Japanese editorial</h2>
+          <p>Warm paper, vermilion seal, italic serif, asymmetric.</p></a
+        >
+        <a class="card" href="35-field-guide.html"
+          ><div class="num">35</div>
+          <h2>Scientific field guide</h2>
+          <p>Paper texture, specimen plates, taxonomic tone.</p></a
+        >
       </div>
-      <footer>All 25 live under <code>./mockups/</code>.</footer>
+      <footer>All 34 live under <code>./mockups/</code>.</footer>
     </div>
   </body>
 </html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -272,8 +272,33 @@
           <h2>Scientific field guide</h2>
           <p>Paper texture, specimen plates, taxonomic tone.</p></a
         >
+        <a class="card" href="36-brutalist-rust.html"
+          ><div class="num">36</div>
+          <h2>Brutalist · rust &amp; walnut</h2>
+          <p>Warm cream, rust, walnut, warm slate.</p></a
+        >
+        <a class="card" href="37-brutalist-pastel-sky.html"
+          ><div class="num">37</div>
+          <h2>Brutalist · pastel sky</h2>
+          <p>Muted sky blue, lavender, dusty navy.</p></a
+        >
+        <a class="card" href="38-brutalist-pastel-clay.html"
+          ><div class="num">38</div>
+          <h2>Brutalist · pastel clay</h2>
+          <p>Warm clay terracotta, smoke blue, cream.</p></a
+        >
+        <a class="card" href="39-brutalist-navy-copper.html"
+          ><div class="num">39</div>
+          <h2>Brutalist · navy &amp; copper</h2>
+          <p>Deep navy ink, copper, steel blue on cream.</p></a
+        >
+        <a class="card" href="40-brutalist-mono-cobalt.html"
+          ><div class="num">40</div>
+          <h2>Brutalist · mono &amp; cobalt</h2>
+          <p>Warm grayscale with a single cobalt accent.</p></a
+        >
       </div>
-      <footer>All 34 live under <code>./mockups/</code>.</footer>
+      <footer>All 39 live under <code>./mockups/</code>.</footer>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary

This branch contains some experiments with a new design for the homepage — 24 standalone HTML/CSS mockups under `./mockups/` exploring different visual directions (terminal, editorial, brutalist, minimal, BBS, teletext, VT100, C64, etc.). No build step; open `mockups/index.html` to browse them.

Nothing here is intended to ship as-is. **Feedback and PRs with more experiments are welcome.**

## Try it locally

Check out the branch and open the index in a browser:

```sh
gh pr checkout 114
# or, without gh:
git fetch origin claude/elegant-austin-000d86
git checkout claude/elegant-austin-000d86

open mockups/index.html          # macOS
xdg-open mockups/index.html      # Linux
start mockups/index.html         # Windows
```

The mockups are pure HTML/CSS — no `bun install`, no dev server required. If you'd rather serve them over HTTP:

```sh
python3 -m http.server 8000 --directory mockups
# then visit http://localhost:8000/
```

## Test plan

- [ ] Open `mockups/index.html` locally and click through the directions
- [ ] Note which (if any) feel like a promising starting point for the real homepage