### PR TITLE
Add brutalist color variants and BBS phosphor variants

### DIFF
--- a/mockups/46-brutalist-coral.html
+++ b/mockups/46-brutalist-coral.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist · coral</title>
+    <style>
+      :root {
+        --bg: #fef6e4;
+        --ink: #0a0a0a;
+        --pink: #e87461;
+        --blue: #3a86ff;
+        --yellow: #ffd166;
+        --green: #06d6a0;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 600;
+        line-height: 1.45;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 24px;
+        border-bottom: 4px solid var(--ink);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 900;
+        font-size: 20px;
+        background: var(--ink);
+        color: var(--bg);
+        padding: 6px 10px;
+        border: 4px solid var(--ink);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 16px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        color: var(--ink);
+        padding: 4px 10px;
+        border: 3px solid var(--ink);
+        background: var(--bg);
+        transition: transform 0.1s;
+      }
+      nav a:hover {
+        background: var(--yellow);
+        transform: translate(-2px, -2px);
+        box-shadow: 4px 4px 0 var(--ink);
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 40px 24px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 24px;
+        align-items: stretch;
+      }
+      .hero > div {
+        border: 5px solid var(--ink);
+        box-shadow: 10px 10px 0 var(--ink);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--pink);
+      }
+      .hero .main h1 {
+        font-size: clamp(40px, 6vw, 88px);
+        line-height: 0.95;
+        margin: 0 0 16px;
+        font-weight: 900;
+        letter-spacing: -0.03em;
+      }
+      .hero .main p {
+        font-size: 18px;
+        margin: 0 0 20px;
+        max-width: 30ch;
+      }
+      .btn {
+        display: inline-block;
+        background: var(--ink);
+        color: var(--yellow);
+        padding: 14px 22px;
+        text-decoration: none;
+        font-weight: 900;
+        font-size: 18px;
+        border: 4px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--yellow);
+      }
+      .btn:hover {
+        transform: translate(-2px, -2px);
+        box-shadow: 10px 10px 0 var(--yellow);
+      }
+      .side {
+        background: var(--yellow);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .side h2 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        font-weight: 900;
+      }
+      .stat {
+        font-size: 72px;
+        font-weight: 900;
+        line-height: 1;
+        margin: 10px 0;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 48px;
+      }
+      .features > div {
+        border: 5px solid var(--ink);
+        padding: 24px;
+        box-shadow: 8px 8px 0 var(--ink);
+      }
+      .features > div:nth-child(1) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      .features > div:nth-child(2) {
+        background: var(--green);
+      }
+      .features > div:nth-child(3) {
+        background: var(--yellow);
+      }
+      .features h3 {
+        margin: 0 0 8px;
+        font-size: 28px;
+        font-weight: 900;
+      }
+      .features .num {
+        font-size: 64px;
+        font-weight: 900;
+        line-height: 1;
+        margin-bottom: 4px;
+      }
+      .big {
+        margin-top: 48px;
+        border: 5px solid var(--ink);
+        box-shadow: 12px 12px 0 var(--ink);
+        background: var(--bg);
+        padding: 32px;
+      }
+      .big h2 {
+        font-size: clamp(32px, 4vw, 56px);
+        margin: 0 0 12px;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+      .tag {
+        border: 3px solid var(--ink);
+        padding: 4px 10px;
+        background: var(--yellow);
+      }
+      .tag:nth-child(3n) {
+        background: var(--pink);
+      }
+      .tag:nth-child(3n + 1) {
+        background: var(--green);
+      }
+      .tag:nth-child(5n) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      footer {
+        padding: 32px 24px;
+        border-top: 5px solid var(--ink);
+        text-align: center;
+        font-weight: 900;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">CODE / SELF / STUDY</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the Community &rarr;</a
+          >
+        </div>
+        <div class="side">
+          <h2>Since 2014</h2>
+          <div class="stat">5,000+</div>
+          <p>programmers, all levels, all languages.</p>
+        </div>
+      </section>
+
+      <section class="features">
+        <div>
+          <div class="num">01</div>
+          <h3>Community</h3>
+          <p>
+            Get out of your room. Meet like-minded programmers who actually show
+            up.
+          </p>
+        </div>
+        <div>
+          <div class="num">02</div>
+          <h3>Get Help</h3>
+          <p>
+            Experienced members mentor beginners. Ask questions. Ask for a study
+            plan.
+          </p>
+        </div>
+        <div>
+          <div class="num">03</div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions and tips from the
+            group.
+          </p>
+        </div>
+      </section>
+
+      <section class="big">
+        <h2>All languages. All levels.</h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag">Python</span><span class="tag">JavaScript</span
+          ><span class="tag">TypeScript</span><span class="tag">Go</span
+          ><span class="tag">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag">SQL</span
+          ><span class="tag">&amp; more</span>
+        </div>
+      </section>
+    </div>
+    <footer>© Code Self Study &middot; Bay Area</footer>
+  </body>
+</html>

--- a/mockups/47-brutalist-butter.html
+++ b/mockups/47-brutalist-butter.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist · butter</title>
+    <style>
+      :root {
+        --bg: #faf5e8;
+        --ink: #1a1a1a;
+        --pink: #f0a89c;
+        --blue: #8fb0d4;
+        --yellow: #f2d897;
+        --green: #a8c9a5;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 600;
+        line-height: 1.45;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 24px;
+        border-bottom: 4px solid var(--ink);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 900;
+        font-size: 20px;
+        background: var(--ink);
+        color: var(--bg);
+        padding: 6px 10px;
+        border: 4px solid var(--ink);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 16px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        color: var(--ink);
+        padding: 4px 10px;
+        border: 3px solid var(--ink);
+        background: var(--bg);
+        transition: transform 0.1s;
+      }
+      nav a:hover {
+        background: var(--yellow);
+        transform: translate(-2px, -2px);
+        box-shadow: 4px 4px 0 var(--ink);
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 40px 24px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 24px;
+        align-items: stretch;
+      }
+      .hero > div {
+        border: 5px solid var(--ink);
+        box-shadow: 10px 10px 0 var(--ink);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--pink);
+      }
+      .hero .main h1 {
+        font-size: clamp(40px, 6vw, 88px);
+        line-height: 0.95;
+        margin: 0 0 16px;
+        font-weight: 900;
+        letter-spacing: -0.03em;
+      }
+      .hero .main p {
+        font-size: 18px;
+        margin: 0 0 20px;
+        max-width: 30ch;
+      }
+      .btn {
+        display: inline-block;
+        background: var(--ink);
+        color: var(--yellow);
+        padding: 14px 22px;
+        text-decoration: none;
+        font-weight: 900;
+        font-size: 18px;
+        border: 4px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--yellow);
+      }
+      .btn:hover {
+        transform: translate(-2px, -2px);
+        box-shadow: 10px 10px 0 var(--yellow);
+      }
+      .side {
+        background: var(--yellow);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .side h2 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        font-weight: 900;
+      }
+      .stat {
+        font-size: 72px;
+        font-weight: 900;
+        line-height: 1;
+        margin: 10px 0;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 48px;
+      }
+      .features > div {
+        border: 5px solid var(--ink);
+        padding: 24px;
+        box-shadow: 8px 8px 0 var(--ink);
+      }
+      .features > div:nth-child(1) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      .features > div:nth-child(2) {
+        background: var(--green);
+      }
+      .features > div:nth-child(3) {
+        background: var(--yellow);
+      }
+      .features h3 {
+        margin: 0 0 8px;
+        font-size: 28px;
+        font-weight: 900;
+      }
+      .features .num {
+        font-size: 64px;
+        font-weight: 900;
+        line-height: 1;
+        margin-bottom: 4px;
+      }
+      .big {
+        margin-top: 48px;
+        border: 5px solid var(--ink);
+        box-shadow: 12px 12px 0 var(--ink);
+        background: var(--bg);
+        padding: 32px;
+      }
+      .big h2 {
+        font-size: clamp(32px, 4vw, 56px);
+        margin: 0 0 12px;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+      .tag {
+        border: 3px solid var(--ink);
+        padding: 4px 10px;
+        background: var(--yellow);
+      }
+      .tag:nth-child(3n) {
+        background: var(--pink);
+      }
+      .tag:nth-child(3n + 1) {
+        background: var(--green);
+      }
+      .tag:nth-child(5n) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      footer {
+        padding: 32px 24px;
+        border-top: 5px solid var(--ink);
+        text-align: center;
+        font-weight: 900;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">CODE / SELF / STUDY</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the Community &rarr;</a
+          >
+        </div>
+        <div class="side">
+          <h2>Since 2014</h2>
+          <div class="stat">5,000+</div>
+          <p>programmers, all levels, all languages.</p>
+        </div>
+      </section>
+
+      <section class="features">
+        <div>
+          <div class="num">01</div>
+          <h3>Community</h3>
+          <p>
+            Get out of your room. Meet like-minded programmers who actually show
+            up.
+          </p>
+        </div>
+        <div>
+          <div class="num">02</div>
+          <h3>Get Help</h3>
+          <p>
+            Experienced members mentor beginners. Ask questions. Ask for a study
+            plan.
+          </p>
+        </div>
+        <div>
+          <div class="num">03</div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions and tips from the
+            group.
+          </p>
+        </div>
+      </section>
+
+      <section class="big">
+        <h2>All languages. All levels.</h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag">Python</span><span class="tag">JavaScript</span
+          ><span class="tag">TypeScript</span><span class="tag">Go</span
+          ><span class="tag">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag">SQL</span
+          ><span class="tag">&amp; more</span>
+        </div>
+      </section>
+    </div>
+    <footer>© Code Self Study &middot; Bay Area</footer>
+  </body>
+</html>

--- a/mockups/48-brutalist-dusk.html
+++ b/mockups/48-brutalist-dusk.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist · dusk</title>
+    <style>
+      :root {
+        --bg: #ebe8e0;
+        --ink: #1f1d22;
+        --pink: #b8a0c4;
+        --blue: #7f96b0;
+        --yellow: #d9c591;
+        --green: #8aab9c;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 600;
+        line-height: 1.45;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 24px;
+        border-bottom: 4px solid var(--ink);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 900;
+        font-size: 20px;
+        background: var(--ink);
+        color: var(--bg);
+        padding: 6px 10px;
+        border: 4px solid var(--ink);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 16px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        color: var(--ink);
+        padding: 4px 10px;
+        border: 3px solid var(--ink);
+        background: var(--bg);
+        transition: transform 0.1s;
+      }
+      nav a:hover {
+        background: var(--yellow);
+        transform: translate(-2px, -2px);
+        box-shadow: 4px 4px 0 var(--ink);
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 40px 24px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 24px;
+        align-items: stretch;
+      }
+      .hero > div {
+        border: 5px solid var(--ink);
+        box-shadow: 10px 10px 0 var(--ink);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--pink);
+      }
+      .hero .main h1 {
+        font-size: clamp(40px, 6vw, 88px);
+        line-height: 0.95;
+        margin: 0 0 16px;
+        font-weight: 900;
+        letter-spacing: -0.03em;
+      }
+      .hero .main p {
+        font-size: 18px;
+        margin: 0 0 20px;
+        max-width: 30ch;
+      }
+      .btn {
+        display: inline-block;
+        background: var(--ink);
+        color: var(--yellow);
+        padding: 14px 22px;
+        text-decoration: none;
+        font-weight: 900;
+        font-size: 18px;
+        border: 4px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--yellow);
+      }
+      .btn:hover {
+        transform: translate(-2px, -2px);
+        box-shadow: 10px 10px 0 var(--yellow);
+      }
+      .side {
+        background: var(--yellow);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .side h2 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        font-weight: 900;
+      }
+      .stat {
+        font-size: 72px;
+        font-weight: 900;
+        line-height: 1;
+        margin: 10px 0;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 48px;
+      }
+      .features > div {
+        border: 5px solid var(--ink);
+        padding: 24px;
+        box-shadow: 8px 8px 0 var(--ink);
+      }
+      .features > div:nth-child(1) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      .features > div:nth-child(2) {
+        background: var(--green);
+      }
+      .features > div:nth-child(3) {
+        background: var(--yellow);
+      }
+      .features h3 {
+        margin: 0 0 8px;
+        font-size: 28px;
+        font-weight: 900;
+      }
+      .features .num {
+        font-size: 64px;
+        font-weight: 900;
+        line-height: 1;
+        margin-bottom: 4px;
+      }
+      .big {
+        margin-top: 48px;
+        border: 5px solid var(--ink);
+        box-shadow: 12px 12px 0 var(--ink);
+        background: var(--bg);
+        padding: 32px;
+      }
+      .big h2 {
+        font-size: clamp(32px, 4vw, 56px);
+        margin: 0 0 12px;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+      .tag {
+        border: 3px solid var(--ink);
+        padding: 4px 10px;
+        background: var(--yellow);
+      }
+      .tag:nth-child(3n) {
+        background: var(--pink);
+      }
+      .tag:nth-child(3n + 1) {
+        background: var(--green);
+      }
+      .tag:nth-child(5n) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      footer {
+        padding: 32px 24px;
+        border-top: 5px solid var(--ink);
+        text-align: center;
+        font-weight: 900;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">CODE / SELF / STUDY</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the Community &rarr;</a
+          >
+        </div>
+        <div class="side">
+          <h2>Since 2014</h2>
+          <div class="stat">5,000+</div>
+          <p>programmers, all levels, all languages.</p>
+        </div>
+      </section>
+
+      <section class="features">
+        <div>
+          <div class="num">01</div>
+          <h3>Community</h3>
+          <p>
+            Get out of your room. Meet like-minded programmers who actually show
+            up.
+          </p>
+        </div>
+        <div>
+          <div class="num">02</div>
+          <h3>Get Help</h3>
+          <p>
+            Experienced members mentor beginners. Ask questions. Ask for a study
+            plan.
+          </p>
+        </div>
+        <div>
+          <div class="num">03</div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions and tips from the
+            group.
+          </p>
+        </div>
+      </section>
+
+      <section class="big">
+        <h2>All languages. All levels.</h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag">Python</span><span class="tag">JavaScript</span
+          ><span class="tag">TypeScript</span><span class="tag">Go</span
+          ><span class="tag">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag">SQL</span
+          ><span class="tag">&amp; more</span>
+        </div>
+      </section>
+    </div>
+    <footer>© Code Self Study &middot; Bay Area</footer>
+  </body>
+</html>

--- a/mockups/49-brutalist-mint.html
+++ b/mockups/49-brutalist-mint.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist · mint</title>
+    <style>
+      :root {
+        --bg: #f3f5ee;
+        --ink: #143028;
+        --pink: #e8a892;
+        --blue: #a8bfd4;
+        --yellow: #edd9a1;
+        --green: #a6c9a9;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 600;
+        line-height: 1.45;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 24px;
+        border-bottom: 4px solid var(--ink);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 900;
+        font-size: 20px;
+        background: var(--ink);
+        color: var(--bg);
+        padding: 6px 10px;
+        border: 4px solid var(--ink);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 16px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        color: var(--ink);
+        padding: 4px 10px;
+        border: 3px solid var(--ink);
+        background: var(--bg);
+        transition: transform 0.1s;
+      }
+      nav a:hover {
+        background: var(--yellow);
+        transform: translate(-2px, -2px);
+        box-shadow: 4px 4px 0 var(--ink);
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 40px 24px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 24px;
+        align-items: stretch;
+      }
+      .hero > div {
+        border: 5px solid var(--ink);
+        box-shadow: 10px 10px 0 var(--ink);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--pink);
+      }
+      .hero .main h1 {
+        font-size: clamp(40px, 6vw, 88px);
+        line-height: 0.95;
+        margin: 0 0 16px;
+        font-weight: 900;
+        letter-spacing: -0.03em;
+      }
+      .hero .main p {
+        font-size: 18px;
+        margin: 0 0 20px;
+        max-width: 30ch;
+      }
+      .btn {
+        display: inline-block;
+        background: var(--ink);
+        color: var(--yellow);
+        padding: 14px 22px;
+        text-decoration: none;
+        font-weight: 900;
+        font-size: 18px;
+        border: 4px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--yellow);
+      }
+      .btn:hover {
+        transform: translate(-2px, -2px);
+        box-shadow: 10px 10px 0 var(--yellow);
+      }
+      .side {
+        background: var(--yellow);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .side h2 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        font-weight: 900;
+      }
+      .stat {
+        font-size: 72px;
+        font-weight: 900;
+        line-height: 1;
+        margin: 10px 0;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 48px;
+      }
+      .features > div {
+        border: 5px solid var(--ink);
+        padding: 24px;
+        box-shadow: 8px 8px 0 var(--ink);
+      }
+      .features > div:nth-child(1) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      .features > div:nth-child(2) {
+        background: var(--green);
+      }
+      .features > div:nth-child(3) {
+        background: var(--yellow);
+      }
+      .features h3 {
+        margin: 0 0 8px;
+        font-size: 28px;
+        font-weight: 900;
+      }
+      .features .num {
+        font-size: 64px;
+        font-weight: 900;
+        line-height: 1;
+        margin-bottom: 4px;
+      }
+      .big {
+        margin-top: 48px;
+        border: 5px solid var(--ink);
+        box-shadow: 12px 12px 0 var(--ink);
+        background: var(--bg);
+        padding: 32px;
+      }
+      .big h2 {
+        font-size: clamp(32px, 4vw, 56px);
+        margin: 0 0 12px;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+      .tag {
+        border: 3px solid var(--ink);
+        padding: 4px 10px;
+        background: var(--yellow);
+      }
+      .tag:nth-child(3n) {
+        background: var(--pink);
+      }
+      .tag:nth-child(3n + 1) {
+        background: var(--green);
+      }
+      .tag:nth-child(5n) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      footer {
+        padding: 32px 24px;
+        border-top: 5px solid var(--ink);
+        text-align: center;
+        font-weight: 900;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">CODE / SELF / STUDY</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the Community &rarr;</a
+          >
+        </div>
+        <div class="side">
+          <h2>Since 2014</h2>
+          <div class="stat">5,000+</div>
+          <p>programmers, all levels, all languages.</p>
+        </div>
+      </section>
+
+      <section class="features">
+        <div>
+          <div class="num">01</div>
+          <h3>Community</h3>
+          <p>
+            Get out of your room. Meet like-minded programmers who actually show
+            up.
+          </p>
+        </div>
+        <div>
+          <div class="num">02</div>
+          <h3>Get Help</h3>
+          <p>
+            Experienced members mentor beginners. Ask questions. Ask for a study
+            plan.
+          </p>
+        </div>
+        <div>
+          <div class="num">03</div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions and tips from the
+            group.
+          </p>
+        </div>
+      </section>
+
+      <section class="big">
+        <h2>All languages. All levels.</h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag">Python</span><span class="tag">JavaScript</span
+          ><span class="tag">TypeScript</span><span class="tag">Go</span
+          ><span class="tag">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag">SQL</span
+          ><span class="tag">&amp; more</span>
+        </div>
+      </section>
+    </div>
+    <footer>© Code Self Study &middot; Bay Area</footer>
+  </body>
+</html>

--- a/mockups/50-brutalist-stone.html
+++ b/mockups/50-brutalist-stone.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist · stone</title>
+    <style>
+      :root {
+        --bg: #e5e0d6;
+        --ink: #24221e;
+        --pink: #b08676;
+        --blue: #8a9cac;
+        --yellow: #c4b597;
+        --green: #8ba095;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 600;
+        line-height: 1.45;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 24px;
+        border-bottom: 4px solid var(--ink);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 900;
+        font-size: 20px;
+        background: var(--ink);
+        color: var(--bg);
+        padding: 6px 10px;
+        border: 4px solid var(--ink);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 16px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        color: var(--ink);
+        padding: 4px 10px;
+        border: 3px solid var(--ink);
+        background: var(--bg);
+        transition: transform 0.1s;
+      }
+      nav a:hover {
+        background: var(--yellow);
+        transform: translate(-2px, -2px);
+        box-shadow: 4px 4px 0 var(--ink);
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 40px 24px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 24px;
+        align-items: stretch;
+      }
+      .hero > div {
+        border: 5px solid var(--ink);
+        box-shadow: 10px 10px 0 var(--ink);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--pink);
+      }
+      .hero .main h1 {
+        font-size: clamp(40px, 6vw, 88px);
+        line-height: 0.95;
+        margin: 0 0 16px;
+        font-weight: 900;
+        letter-spacing: -0.03em;
+      }
+      .hero .main p {
+        font-size: 18px;
+        margin: 0 0 20px;
+        max-width: 30ch;
+      }
+      .btn {
+        display: inline-block;
+        background: var(--ink);
+        color: var(--yellow);
+        padding: 14px 22px;
+        text-decoration: none;
+        font-weight: 900;
+        font-size: 18px;
+        border: 4px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--yellow);
+      }
+      .btn:hover {
+        transform: translate(-2px, -2px);
+        box-shadow: 10px 10px 0 var(--yellow);
+      }
+      .side {
+        background: var(--yellow);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .side h2 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        font-weight: 900;
+      }
+      .stat {
+        font-size: 72px;
+        font-weight: 900;
+        line-height: 1;
+        margin: 10px 0;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 48px;
+      }
+      .features > div {
+        border: 5px solid var(--ink);
+        padding: 24px;
+        box-shadow: 8px 8px 0 var(--ink);
+      }
+      .features > div:nth-child(1) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      .features > div:nth-child(2) {
+        background: var(--green);
+      }
+      .features > div:nth-child(3) {
+        background: var(--yellow);
+      }
+      .features h3 {
+        margin: 0 0 8px;
+        font-size: 28px;
+        font-weight: 900;
+      }
+      .features .num {
+        font-size: 64px;
+        font-weight: 900;
+        line-height: 1;
+        margin-bottom: 4px;
+      }
+      .big {
+        margin-top: 48px;
+        border: 5px solid var(--ink);
+        box-shadow: 12px 12px 0 var(--ink);
+        background: var(--bg);
+        padding: 32px;
+      }
+      .big h2 {
+        font-size: clamp(32px, 4vw, 56px);
+        margin: 0 0 12px;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+      .tag {
+        border: 3px solid var(--ink);
+        padding: 4px 10px;
+        background: var(--yellow);
+      }
+      .tag:nth-child(3n) {
+        background: var(--pink);
+      }
+      .tag:nth-child(3n + 1) {
+        background: var(--green);
+      }
+      .tag:nth-child(5n) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      footer {
+        padding: 32px 24px;
+        border-top: 5px solid var(--ink);
+        text-align: center;
+        font-weight: 900;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">CODE / SELF / STUDY</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the Community &rarr;</a
+          >
+        </div>
+        <div class="side">
+          <h2>Since 2014</h2>
+          <div class="stat">5,000+</div>
+          <p>programmers, all levels, all languages.</p>
+        </div>
+      </section>
+
+      <section class="features">
+        <div>
+          <div class="num">01</div>
+          <h3>Community</h3>
+          <p>
+            Get out of your room. Meet like-minded programmers who actually show
+            up.
+          </p>
+        </div>
+        <div>
+          <div class="num">02</div>
+          <h3>Get Help</h3>
+          <p>
+            Experienced members mentor beginners. Ask questions. Ask for a study
+            plan.
+          </p>
+        </div>
+        <div>
+          <div class="num">03</div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions and tips from the
+            group.
+          </p>
+        </div>
+      </section>
+
+      <section class="big">
+        <h2>All languages. All levels.</h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag">Python</span><span class="tag">JavaScript</span
+          ><span class="tag">TypeScript</span><span class="tag">Go</span
+          ><span class="tag">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag">SQL</span
+          ><span class="tag">&amp; more</span>
+        </div>
+      </section>
+    </div>
+    <footer>© Code Self Study &middot; Bay Area</footer>
+  </body>
+</html>

--- a/mockups/51-brutalist-lavender.html
+++ b/mockups/51-brutalist-lavender.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — Brutalist · lavender</title>
+    <style>
+      :root {
+        --bg: #fdf8f2;
+        --ink: #1e1a24;
+        --pink: #c9a4d9;
+        --blue: #8cb5d9;
+        --yellow: #f0d4a0;
+        --green: #9cc9a5;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+        font-weight: 600;
+        line-height: 1.45;
+      }
+      nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 24px;
+        border-bottom: 4px solid var(--ink);
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .logo {
+        font-weight: 900;
+        font-size: 20px;
+        background: var(--ink);
+        color: var(--bg);
+        padding: 6px 10px;
+        border: 4px solid var(--ink);
+      }
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: 16px;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      nav a {
+        text-decoration: none;
+        color: var(--ink);
+        padding: 4px 10px;
+        border: 3px solid var(--ink);
+        background: var(--bg);
+        transition: transform 0.1s;
+      }
+      nav a:hover {
+        background: var(--yellow);
+        transform: translate(-2px, -2px);
+        box-shadow: 4px 4px 0 var(--ink);
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 40px 24px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 24px;
+        align-items: stretch;
+      }
+      .hero > div {
+        border: 5px solid var(--ink);
+        box-shadow: 10px 10px 0 var(--ink);
+        padding: 28px;
+      }
+      .hero .main {
+        background: var(--pink);
+      }
+      .hero .main h1 {
+        font-size: clamp(40px, 6vw, 88px);
+        line-height: 0.95;
+        margin: 0 0 16px;
+        font-weight: 900;
+        letter-spacing: -0.03em;
+      }
+      .hero .main p {
+        font-size: 18px;
+        margin: 0 0 20px;
+        max-width: 30ch;
+      }
+      .btn {
+        display: inline-block;
+        background: var(--ink);
+        color: var(--yellow);
+        padding: 14px 22px;
+        text-decoration: none;
+        font-weight: 900;
+        font-size: 18px;
+        border: 4px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--yellow);
+      }
+      .btn:hover {
+        transform: translate(-2px, -2px);
+        box-shadow: 10px 10px 0 var(--yellow);
+      }
+      .side {
+        background: var(--yellow);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .side h2 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        font-weight: 900;
+      }
+      .stat {
+        font-size: 72px;
+        font-weight: 900;
+        line-height: 1;
+        margin: 10px 0;
+      }
+      .features {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 48px;
+      }
+      .features > div {
+        border: 5px solid var(--ink);
+        padding: 24px;
+        box-shadow: 8px 8px 0 var(--ink);
+      }
+      .features > div:nth-child(1) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      .features > div:nth-child(2) {
+        background: var(--green);
+      }
+      .features > div:nth-child(3) {
+        background: var(--yellow);
+      }
+      .features h3 {
+        margin: 0 0 8px;
+        font-size: 28px;
+        font-weight: 900;
+      }
+      .features .num {
+        font-size: 64px;
+        font-weight: 900;
+        line-height: 1;
+        margin-bottom: 4px;
+      }
+      .big {
+        margin-top: 48px;
+        border: 5px solid var(--ink);
+        box-shadow: 12px 12px 0 var(--ink);
+        background: var(--bg);
+        padding: 32px;
+      }
+      .big h2 {
+        font-size: clamp(32px, 4vw, 56px);
+        margin: 0 0 12px;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+      .tags {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+      .tag {
+        border: 3px solid var(--ink);
+        padding: 4px 10px;
+        background: var(--yellow);
+      }
+      .tag:nth-child(3n) {
+        background: var(--pink);
+      }
+      .tag:nth-child(3n + 1) {
+        background: var(--green);
+      }
+      .tag:nth-child(5n) {
+        background: var(--blue);
+        color: var(--bg);
+      }
+      footer {
+        padding: 32px 24px;
+        border-top: 5px solid var(--ink);
+        text-align: center;
+        font-weight: 900;
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="logo">CODE / SELF / STUDY</div>
+      <ul>
+        <li><a href="#">Events</a></li>
+        <li><a href="#">Learn</a></li>
+        <li><a href="#">Forum</a></li>
+        <li><a href="#">Jobs</a></li>
+        <li><a href="#">Puzzles</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+    </nav>
+    <div class="wrap">
+      <section class="hero">
+        <div class="main">
+          <h1>Study code. Together. In person.</h1>
+          <p>
+            A friendly programming community of 5,000+ people in Berkeley and
+            the San Francisco Bay Area. All languages welcome.
+          </p>
+          <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+            >Join the Community &rarr;</a
+          >
+        </div>
+        <div class="side">
+          <h2>Since 2014</h2>
+          <div class="stat">5,000+</div>
+          <p>programmers, all levels, all languages.</p>
+        </div>
+      </section>
+
+      <section class="features">
+        <div>
+          <div class="num">01</div>
+          <h3>Community</h3>
+          <p>
+            Get out of your room. Meet like-minded programmers who actually show
+            up.
+          </p>
+        </div>
+        <div>
+          <div class="num">02</div>
+          <h3>Get Help</h3>
+          <p>
+            Experienced members mentor beginners. Ask questions. Ask for a study
+            plan.
+          </p>
+        </div>
+        <div>
+          <div class="num">03</div>
+          <h3>Networking</h3>
+          <p>
+            Members have landed jobs through introductions and tips from the
+            group.
+          </p>
+        </div>
+      </section>
+
+      <section class="big">
+        <h2>All languages. All levels.</h2>
+        <p>
+          Dozens of groups teach you to code. We build a local community of
+          friendly, highly-motivated programmers instead. The format is
+          self-study with mentorship.
+        </p>
+        <div class="tags">
+          <span class="tag">Python</span><span class="tag">JavaScript</span
+          ><span class="tag">TypeScript</span><span class="tag">Go</span
+          ><span class="tag">Rust</span><span class="tag">Haskell</span
+          ><span class="tag">Clojure</span><span class="tag">Elixir</span
+          ><span class="tag">Racket</span><span class="tag">Ruby</span
+          ><span class="tag">Scala</span><span class="tag">C++</span
+          ><span class="tag">Lua</span><span class="tag">SQL</span
+          ><span class="tag">&amp; more</span>
+        </div>
+      </section>
+    </div>
+    <footer>© Code Self Study &middot; Bay Area</footer>
+  </body>
+</html>

--- a/mockups/52-bbs-amber.html
+++ b/mockups/52-bbs-amber.html
@@ -1,0 +1,381 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — BBS · amber</title>
+    <style>
+      :root {
+        --bg: #1a0f00;
+        --fg: #ffb000;
+        --fg-dim: #8a5a00;
+        --accent: #00d4ff;
+        --warn: #ff4444;
+        --ok: #7cff7c;
+        --glow-fg: rgba(255, 176, 0, 0.5);
+        --glow-ok: rgba(124, 255, 124, 0.6);
+        --glow-accent: rgba(0, 212, 255, 0.5);
+        --scanline: rgba(0, 0, 0, 0.25);
+        --vignette: rgba(255, 176, 0, 0.06);
+      }
+      [data-theme="light"] {
+        --bg: #f4ecd8;
+        --fg: #3a2200;
+        --fg-dim: #8a6a3a;
+        --accent: #145a7a;
+        --warn: #a02020;
+        --ok: #2a6a2a;
+        --glow-fg: rgba(58, 34, 0, 0.15);
+        --glow-ok: rgba(42, 106, 42, 0.2);
+        --glow-accent: rgba(20, 90, 122, 0.2);
+        --scanline: rgba(0, 0, 0, 0.08);
+        --vignette: rgba(58, 34, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "VT323", "Perfect DOS VGA 437", "Courier New", ui-monospace, monospace;
+        font-size: 18px;
+        line-height: 1.4;
+        min-height: 100vh;
+        background-image:
+          linear-gradient(
+            to bottom,
+            transparent 0,
+            transparent 2px,
+            var(--scanline) 2px,
+            var(--scanline) 3px
+          ),
+          radial-gradient(
+            ellipse at center,
+            var(--vignette) 0%,
+            transparent 70%
+          );
+        background-size:
+          100% 3px,
+          100% 100%;
+        text-shadow: 0 0 4px var(--glow-fg);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .screen {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .header {
+        border: 2px solid var(--fg);
+        padding: 14px 10px;
+        margin-bottom: 16px;
+        overflow-x: auto;
+      }
+      .logo {
+        white-space: pre;
+        font-size: 10px;
+        line-height: 1.1;
+        color: var(--fg);
+        margin: 0;
+      }
+      .menubar {
+        border: 2px solid var(--fg);
+        background: var(--fg);
+        color: var(--bg);
+        padding: 4px 10px;
+        margin-bottom: 16px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        align-items: center;
+        text-shadow: none;
+        font-size: 16px;
+      }
+      .menubar span {
+        white-space: nowrap;
+      }
+      .menubar span {
+        font-weight: 700;
+      }
+      .menubar .k {
+        color: var(--warn);
+      }
+      .menubar .toggle {
+        margin-left: auto;
+        cursor: pointer;
+        user-select: none;
+        border: 1px solid var(--bg);
+        padding: 0 8px;
+      }
+      .menubar .toggle:hover {
+        background: var(--bg);
+        color: var(--fg);
+      }
+      .welcome {
+        border: 2px solid var(--fg);
+        padding: 18px;
+        margin-bottom: 16px;
+      }
+      h1 {
+        font-family: inherit;
+        font-size: 48px;
+        letter-spacing: 4px;
+        margin: 4px 0 12px;
+        color: var(--ok);
+        text-shadow: 0 0 8px var(--glow-ok);
+      }
+      .blink {
+        animation: blink 1s steps(1) infinite;
+        color: var(--accent);
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cta {
+        display: inline-block;
+        border: 2px solid var(--accent);
+        color: var(--accent);
+        padding: 6px 14px;
+        margin-top: 12px;
+        text-shadow: 0 0 4px var(--glow-accent);
+      }
+      .cta:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .sep {
+        color: var(--fg-dim);
+        letter-spacing: -1px;
+      }
+      .cols {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        margin-bottom: 16px;
+      }
+      .box {
+        border: 2px solid var(--fg);
+        padding: 12px;
+      }
+      .box h3 {
+        margin: 0 0 6px;
+        color: var(--ok);
+        font-size: 22px;
+      }
+      .box p {
+        margin: 0;
+        color: var(--fg);
+      }
+      .log {
+        border: 2px solid var(--fg);
+        padding: 14px;
+        margin-bottom: 16px;
+      }
+      .log h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .log ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .log li {
+        padding: 2px 0;
+      }
+      .log li::before {
+        content: "> ";
+        color: var(--ok);
+      }
+      .langs {
+        border: 2px solid var(--fg);
+        padding: 14px;
+      }
+      .langs h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .lang-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 2px 14px;
+      }
+      .status {
+        margin-top: 12px;
+        color: var(--fg-dim);
+        font-size: 14px;
+        border-top: 1px solid var(--fg-dim);
+        padding-top: 6px;
+      }
+      @media (max-width: 700px) {
+        .cols {
+          grid-template-columns: 1fr;
+        }
+        .logo {
+          font-size: 8px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="screen">
+      <div class="header">
+        <pre class="logo">
+ ██████╗ ██████╗ ██████╗ ███████╗  ███████╗███████╗██╗     ███████╗  ███████╗████████╗██╗   ██╗██████╗ ██╗   ██╗
+██╔════╝██╔═══██╗██╔══██╗██╔════╝  ██╔════╝██╔════╝██║     ██╔════╝  ██╔════╝╚══██╔══╝██║   ██║██╔══██╗╚██╗ ██╔╝
+██║     ██║   ██║██║  ██║█████╗    ███████╗█████╗  ██║     █████╗    ███████╗   ██║   ██║   ██║██║  ██║ ╚████╔╝
+██║     ██║   ██║██║  ██║██╔══╝    ╚════██║██╔══╝  ██║     ██╔══╝    ╚════██║   ██║   ██║   ██║██║  ██║  ╚██╔╝
+╚██████╗╚██████╔╝██████╔╝███████╗  ███████║███████╗███████╗██║       ███████║   ██║   ╚██████╔╝██████╔╝   ██║
+ ╚═════╝ ╚═════╝ ╚═════╝ ╚══════╝  ╚══════╝╚══════╝╚══════╝╚═╝       ╚══════╝   ╚═╝    ╚═════╝ ╚═════╝    ╚═╝</pre
+        >
+      </div>
+
+      <div class="menubar">
+        <span><span class="k">[H]</span>OME</span>
+        <span><span class="k">[E]</span>VENTS</span>
+        <span><span class="k">[L]</span>EARN</span>
+        <span><span class="k">[F]</span>ORUM</span>
+        <span><span class="k">[J]</span>OBS</span>
+        <span><span class="k">[P]</span>UZZLES</span>
+        <span><span class="k">[T]</span>OOLS</span>
+        <span><span class="k">[A]</span>BOUT</span>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">DARK</span></span
+        >
+      </div>
+
+      <div class="welcome">
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <h1>WELCOME, USER</h1>
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <p>
+          YOU HAVE CONNECTED TO
+          <strong style="color: var(--ok)">CODE SELF STUDY</strong> &mdash; A
+          FRIENDLY PROGRAMMING COMMUNITY OF 5,000+ MEMBERS IN BERKELEY AND THE
+          SAN FRANCISCO BAY AREA.
+        </p>
+        <p>
+          ALL LANGUAGES, ALL LEVELS, ALL WELCOME.
+          <span class="blink">█</span>
+        </p>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >[ PRESS RETURN TO JOIN ]</a
+        >
+      </div>
+
+      <div class="cols">
+        <div class="box">
+          <h3>COMMUNITY</h3>
+          <p>
+            Connect to the meetup &mdash; meet 5,000+ programmers who actually
+            keep showing up.
+          </p>
+        </div>
+        <div class="box">
+          <h3>MENTORSHIP</h3>
+          <p>
+            SYSOP-approved mentorship. Ask for a study plan. Beginners welcome.
+          </p>
+        </div>
+        <div class="box">
+          <h3>NETWORKING</h3>
+          <p>
+            Members have landed jobs via intros in the forum and at meetups.
+          </p>
+        </div>
+      </div>
+
+      <div class="log">
+        <h2>▓▓▓ BULLETIN ▓▓▓</h2>
+        <ul>
+          <li>
+            DOZENS OF MEETUPS TEACH YOU TO CODE. WE BUILD A LOCAL COMMUNITY.
+          </li>
+          <li>OPEN TO EVERY LANGUAGE. EVERY LEVEL. EVERY KIND OF PROJECT.</li>
+          <li>
+            FORMAT IS SELF-STUDY WITH ADVICE FROM MORE EXPERIENCED MEMBERS.
+          </li>
+          <li>
+            COMES AS A BOOTCAMP SUPPLEMENT OR ALTERNATIVE &mdash; ASK IN FORUM.
+          </li>
+        </ul>
+      </div>
+
+      <div class="langs">
+        <h2>▓▓▓ SUPPORTED DIALECTS ▓▓▓</h2>
+        <div class="lang-grid">
+          <span>» PYTHON</span><span>» JS</span><span>» TYPESCRIPT</span
+          ><span>» GO</span><span>» RUST</span><span>» HASKELL</span
+          ><span>» CLOJURE</span><span>» ELIXIR</span><span>» RACKET</span
+          ><span>» SCHEME</span><span>» C</span><span>» C++</span
+          ><span>» RUBY</span><span>» SCALA</span><span>» ERLANG</span
+          ><span>» ELM</span><span>» LUA</span><span>» SQL</span
+          ><span>» JULIA</span><span>» R</span><span>» +MORE</span>
+        </div>
+        <div class="status">
+          <span class="sep">───</span> CARRIER: 2400 BAUD · ANSI ON · LOCAL ECHO
+          ON · PRESS ? FOR HELP <span class="sep">───</span>
+        </div>
+      </div>
+    </div>
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "bbs-theme";
+        function apply(theme) {
+          if (theme === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "LIGHT";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "DARK";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var next =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(next);
+          localStorage.setItem(KEY, next);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/53-bbs-green.html
+++ b/mockups/53-bbs-green.html
@@ -1,0 +1,381 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — BBS · green phosphor</title>
+    <style>
+      :root {
+        --bg: #001400;
+        --fg: #33ff66;
+        --fg-dim: #1a7a2a;
+        --accent: #ffee66;
+        --warn: #ff5555;
+        --ok: #ffffff;
+        --glow-fg: rgba(51, 255, 102, 0.45);
+        --glow-ok: rgba(255, 255, 255, 0.55);
+        --glow-accent: rgba(255, 238, 102, 0.5);
+        --scanline: rgba(0, 0, 0, 0.25);
+        --vignette: rgba(51, 255, 102, 0.06);
+      }
+      [data-theme="light"] {
+        --bg: #eef1e0;
+        --fg: #0f2a10;
+        --fg-dim: #5a7a5a;
+        --accent: #6a5a00;
+        --warn: #8a1a1a;
+        --ok: #1a5a1a;
+        --glow-fg: rgba(15, 42, 16, 0.15);
+        --glow-ok: rgba(26, 90, 26, 0.2);
+        --glow-accent: rgba(106, 90, 0, 0.2);
+        --scanline: rgba(0, 0, 0, 0.08);
+        --vignette: rgba(15, 42, 16, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "VT323", "Perfect DOS VGA 437", "Courier New", ui-monospace, monospace;
+        font-size: 18px;
+        line-height: 1.4;
+        min-height: 100vh;
+        background-image:
+          linear-gradient(
+            to bottom,
+            transparent 0,
+            transparent 2px,
+            var(--scanline) 2px,
+            var(--scanline) 3px
+          ),
+          radial-gradient(
+            ellipse at center,
+            var(--vignette) 0%,
+            transparent 70%
+          );
+        background-size:
+          100% 3px,
+          100% 100%;
+        text-shadow: 0 0 4px var(--glow-fg);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .screen {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .header {
+        border: 2px solid var(--fg);
+        padding: 14px 10px;
+        margin-bottom: 16px;
+        overflow-x: auto;
+      }
+      .logo {
+        white-space: pre;
+        font-size: 10px;
+        line-height: 1.1;
+        color: var(--fg);
+        margin: 0;
+      }
+      .menubar {
+        border: 2px solid var(--fg);
+        background: var(--fg);
+        color: var(--bg);
+        padding: 4px 10px;
+        margin-bottom: 16px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        align-items: center;
+        text-shadow: none;
+        font-size: 16px;
+      }
+      .menubar span {
+        white-space: nowrap;
+      }
+      .menubar span {
+        font-weight: 700;
+      }
+      .menubar .k {
+        color: var(--warn);
+      }
+      .menubar .toggle {
+        margin-left: auto;
+        cursor: pointer;
+        user-select: none;
+        border: 1px solid var(--bg);
+        padding: 0 8px;
+      }
+      .menubar .toggle:hover {
+        background: var(--bg);
+        color: var(--fg);
+      }
+      .welcome {
+        border: 2px solid var(--fg);
+        padding: 18px;
+        margin-bottom: 16px;
+      }
+      h1 {
+        font-family: inherit;
+        font-size: 48px;
+        letter-spacing: 4px;
+        margin: 4px 0 12px;
+        color: var(--ok);
+        text-shadow: 0 0 8px var(--glow-ok);
+      }
+      .blink {
+        animation: blink 1s steps(1) infinite;
+        color: var(--accent);
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cta {
+        display: inline-block;
+        border: 2px solid var(--accent);
+        color: var(--accent);
+        padding: 6px 14px;
+        margin-top: 12px;
+        text-shadow: 0 0 4px var(--glow-accent);
+      }
+      .cta:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .sep {
+        color: var(--fg-dim);
+        letter-spacing: -1px;
+      }
+      .cols {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        margin-bottom: 16px;
+      }
+      .box {
+        border: 2px solid var(--fg);
+        padding: 12px;
+      }
+      .box h3 {
+        margin: 0 0 6px;
+        color: var(--ok);
+        font-size: 22px;
+      }
+      .box p {
+        margin: 0;
+        color: var(--fg);
+      }
+      .log {
+        border: 2px solid var(--fg);
+        padding: 14px;
+        margin-bottom: 16px;
+      }
+      .log h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .log ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .log li {
+        padding: 2px 0;
+      }
+      .log li::before {
+        content: "> ";
+        color: var(--ok);
+      }
+      .langs {
+        border: 2px solid var(--fg);
+        padding: 14px;
+      }
+      .langs h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .lang-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 2px 14px;
+      }
+      .status {
+        margin-top: 12px;
+        color: var(--fg-dim);
+        font-size: 14px;
+        border-top: 1px solid var(--fg-dim);
+        padding-top: 6px;
+      }
+      @media (max-width: 700px) {
+        .cols {
+          grid-template-columns: 1fr;
+        }
+        .logo {
+          font-size: 8px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="screen">
+      <div class="header">
+        <pre class="logo">
+ ██████╗ ██████╗ ██████╗ ███████╗  ███████╗███████╗██╗     ███████╗  ███████╗████████╗██╗   ██╗██████╗ ██╗   ██╗
+██╔════╝██╔═══██╗██╔══██╗██╔════╝  ██╔════╝██╔════╝██║     ██╔════╝  ██╔════╝╚══██╔══╝██║   ██║██╔══██╗╚██╗ ██╔╝
+██║     ██║   ██║██║  ██║█████╗    ███████╗█████╗  ██║     █████╗    ███████╗   ██║   ██║   ██║██║  ██║ ╚████╔╝
+██║     ██║   ██║██║  ██║██╔══╝    ╚════██║██╔══╝  ██║     ██╔══╝    ╚════██║   ██║   ██║   ██║██║  ██║  ╚██╔╝
+╚██████╗╚██████╔╝██████╔╝███████╗  ███████║███████╗███████╗██║       ███████║   ██║   ╚██████╔╝██████╔╝   ██║
+ ╚═════╝ ╚═════╝ ╚═════╝ ╚══════╝  ╚══════╝╚══════╝╚══════╝╚═╝       ╚══════╝   ╚═╝    ╚═════╝ ╚═════╝    ╚═╝</pre
+        >
+      </div>
+
+      <div class="menubar">
+        <span><span class="k">[H]</span>OME</span>
+        <span><span class="k">[E]</span>VENTS</span>
+        <span><span class="k">[L]</span>EARN</span>
+        <span><span class="k">[F]</span>ORUM</span>
+        <span><span class="k">[J]</span>OBS</span>
+        <span><span class="k">[P]</span>UZZLES</span>
+        <span><span class="k">[T]</span>OOLS</span>
+        <span><span class="k">[A]</span>BOUT</span>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">DARK</span></span
+        >
+      </div>
+
+      <div class="welcome">
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <h1>WELCOME, USER</h1>
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <p>
+          YOU HAVE CONNECTED TO
+          <strong style="color: var(--ok)">CODE SELF STUDY</strong> &mdash; A
+          FRIENDLY PROGRAMMING COMMUNITY OF 5,000+ MEMBERS IN BERKELEY AND THE
+          SAN FRANCISCO BAY AREA.
+        </p>
+        <p>
+          ALL LANGUAGES, ALL LEVELS, ALL WELCOME.
+          <span class="blink">█</span>
+        </p>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >[ PRESS RETURN TO JOIN ]</a
+        >
+      </div>
+
+      <div class="cols">
+        <div class="box">
+          <h3>COMMUNITY</h3>
+          <p>
+            Connect to the meetup &mdash; meet 5,000+ programmers who actually
+            keep showing up.
+          </p>
+        </div>
+        <div class="box">
+          <h3>MENTORSHIP</h3>
+          <p>
+            SYSOP-approved mentorship. Ask for a study plan. Beginners welcome.
+          </p>
+        </div>
+        <div class="box">
+          <h3>NETWORKING</h3>
+          <p>
+            Members have landed jobs via intros in the forum and at meetups.
+          </p>
+        </div>
+      </div>
+
+      <div class="log">
+        <h2>▓▓▓ BULLETIN ▓▓▓</h2>
+        <ul>
+          <li>
+            DOZENS OF MEETUPS TEACH YOU TO CODE. WE BUILD A LOCAL COMMUNITY.
+          </li>
+          <li>OPEN TO EVERY LANGUAGE. EVERY LEVEL. EVERY KIND OF PROJECT.</li>
+          <li>
+            FORMAT IS SELF-STUDY WITH ADVICE FROM MORE EXPERIENCED MEMBERS.
+          </li>
+          <li>
+            COMES AS A BOOTCAMP SUPPLEMENT OR ALTERNATIVE &mdash; ASK IN FORUM.
+          </li>
+        </ul>
+      </div>
+
+      <div class="langs">
+        <h2>▓▓▓ SUPPORTED DIALECTS ▓▓▓</h2>
+        <div class="lang-grid">
+          <span>» PYTHON</span><span>» JS</span><span>» TYPESCRIPT</span
+          ><span>» GO</span><span>» RUST</span><span>» HASKELL</span
+          ><span>» CLOJURE</span><span>» ELIXIR</span><span>» RACKET</span
+          ><span>» SCHEME</span><span>» C</span><span>» C++</span
+          ><span>» RUBY</span><span>» SCALA</span><span>» ERLANG</span
+          ><span>» ELM</span><span>» LUA</span><span>» SQL</span
+          ><span>» JULIA</span><span>» R</span><span>» +MORE</span>
+        </div>
+        <div class="status">
+          <span class="sep">───</span> CARRIER: 2400 BAUD · ANSI ON · LOCAL ECHO
+          ON · PRESS ? FOR HELP <span class="sep">───</span>
+        </div>
+      </div>
+    </div>
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "bbs-theme";
+        function apply(theme) {
+          if (theme === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "LIGHT";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "DARK";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var next =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(next);
+          localStorage.setItem(KEY, next);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/54-bbs-paperwhite.html
+++ b/mockups/54-bbs-paperwhite.html
@@ -1,0 +1,381 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — BBS · paper-white</title>
+    <style>
+      :root {
+        --bg: #0a0a0a;
+        --fg: #ebe8dc;
+        --fg-dim: #6a6860;
+        --accent: #8cc9ff;
+        --warn: #ff7a7a;
+        --ok: #a6ffb0;
+        --glow-fg: rgba(235, 232, 220, 0.35);
+        --glow-ok: rgba(166, 255, 176, 0.45);
+        --glow-accent: rgba(140, 201, 255, 0.45);
+        --scanline: rgba(0, 0, 0, 0.25);
+        --vignette: rgba(235, 232, 220, 0.04);
+      }
+      [data-theme="light"] {
+        --bg: #f4f1e6;
+        --fg: #1a1a14;
+        --fg-dim: #5a5850;
+        --accent: #1a4a8a;
+        --warn: #8a1a2a;
+        --ok: #1a5a2a;
+        --glow-fg: rgba(26, 26, 20, 0.15);
+        --glow-ok: rgba(26, 90, 42, 0.2);
+        --glow-accent: rgba(26, 74, 138, 0.2);
+        --scanline: rgba(0, 0, 0, 0.06);
+        --vignette: rgba(26, 26, 20, 0.03);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "VT323", "Perfect DOS VGA 437", "Courier New", ui-monospace, monospace;
+        font-size: 18px;
+        line-height: 1.4;
+        min-height: 100vh;
+        background-image:
+          linear-gradient(
+            to bottom,
+            transparent 0,
+            transparent 2px,
+            var(--scanline) 2px,
+            var(--scanline) 3px
+          ),
+          radial-gradient(
+            ellipse at center,
+            var(--vignette) 0%,
+            transparent 70%
+          );
+        background-size:
+          100% 3px,
+          100% 100%;
+        text-shadow: 0 0 4px var(--glow-fg);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .screen {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .header {
+        border: 2px solid var(--fg);
+        padding: 14px 10px;
+        margin-bottom: 16px;
+        overflow-x: auto;
+      }
+      .logo {
+        white-space: pre;
+        font-size: 10px;
+        line-height: 1.1;
+        color: var(--fg);
+        margin: 0;
+      }
+      .menubar {
+        border: 2px solid var(--fg);
+        background: var(--fg);
+        color: var(--bg);
+        padding: 4px 10px;
+        margin-bottom: 16px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        align-items: center;
+        text-shadow: none;
+        font-size: 16px;
+      }
+      .menubar span {
+        white-space: nowrap;
+      }
+      .menubar span {
+        font-weight: 700;
+      }
+      .menubar .k {
+        color: var(--warn);
+      }
+      .menubar .toggle {
+        margin-left: auto;
+        cursor: pointer;
+        user-select: none;
+        border: 1px solid var(--bg);
+        padding: 0 8px;
+      }
+      .menubar .toggle:hover {
+        background: var(--bg);
+        color: var(--fg);
+      }
+      .welcome {
+        border: 2px solid var(--fg);
+        padding: 18px;
+        margin-bottom: 16px;
+      }
+      h1 {
+        font-family: inherit;
+        font-size: 48px;
+        letter-spacing: 4px;
+        margin: 4px 0 12px;
+        color: var(--ok);
+        text-shadow: 0 0 8px var(--glow-ok);
+      }
+      .blink {
+        animation: blink 1s steps(1) infinite;
+        color: var(--accent);
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cta {
+        display: inline-block;
+        border: 2px solid var(--accent);
+        color: var(--accent);
+        padding: 6px 14px;
+        margin-top: 12px;
+        text-shadow: 0 0 4px var(--glow-accent);
+      }
+      .cta:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .sep {
+        color: var(--fg-dim);
+        letter-spacing: -1px;
+      }
+      .cols {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        margin-bottom: 16px;
+      }
+      .box {
+        border: 2px solid var(--fg);
+        padding: 12px;
+      }
+      .box h3 {
+        margin: 0 0 6px;
+        color: var(--ok);
+        font-size: 22px;
+      }
+      .box p {
+        margin: 0;
+        color: var(--fg);
+      }
+      .log {
+        border: 2px solid var(--fg);
+        padding: 14px;
+        margin-bottom: 16px;
+      }
+      .log h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .log ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .log li {
+        padding: 2px 0;
+      }
+      .log li::before {
+        content: "> ";
+        color: var(--ok);
+      }
+      .langs {
+        border: 2px solid var(--fg);
+        padding: 14px;
+      }
+      .langs h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .lang-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 2px 14px;
+      }
+      .status {
+        margin-top: 12px;
+        color: var(--fg-dim);
+        font-size: 14px;
+        border-top: 1px solid var(--fg-dim);
+        padding-top: 6px;
+      }
+      @media (max-width: 700px) {
+        .cols {
+          grid-template-columns: 1fr;
+        }
+        .logo {
+          font-size: 8px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="screen">
+      <div class="header">
+        <pre class="logo">
+ ██████╗ ██████╗ ██████╗ ███████╗  ███████╗███████╗██╗     ███████╗  ███████╗████████╗██╗   ██╗██████╗ ██╗   ██╗
+██╔════╝██╔═══██╗██╔══██╗██╔════╝  ██╔════╝██╔════╝██║     ██╔════╝  ██╔════╝╚══██╔══╝██║   ██║██╔══██╗╚██╗ ██╔╝
+██║     ██║   ██║██║  ██║█████╗    ███████╗█████╗  ██║     █████╗    ███████╗   ██║   ██║   ██║██║  ██║ ╚████╔╝
+██║     ██║   ██║██║  ██║██╔══╝    ╚════██║██╔══╝  ██║     ██╔══╝    ╚════██║   ██║   ██║   ██║██║  ██║  ╚██╔╝
+╚██████╗╚██████╔╝██████╔╝███████╗  ███████║███████╗███████╗██║       ███████║   ██║   ╚██████╔╝██████╔╝   ██║
+ ╚═════╝ ╚═════╝ ╚═════╝ ╚══════╝  ╚══════╝╚══════╝╚══════╝╚═╝       ╚══════╝   ╚═╝    ╚═════╝ ╚═════╝    ╚═╝</pre
+        >
+      </div>
+
+      <div class="menubar">
+        <span><span class="k">[H]</span>OME</span>
+        <span><span class="k">[E]</span>VENTS</span>
+        <span><span class="k">[L]</span>EARN</span>
+        <span><span class="k">[F]</span>ORUM</span>
+        <span><span class="k">[J]</span>OBS</span>
+        <span><span class="k">[P]</span>UZZLES</span>
+        <span><span class="k">[T]</span>OOLS</span>
+        <span><span class="k">[A]</span>BOUT</span>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">DARK</span></span
+        >
+      </div>
+
+      <div class="welcome">
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <h1>WELCOME, USER</h1>
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <p>
+          YOU HAVE CONNECTED TO
+          <strong style="color: var(--ok)">CODE SELF STUDY</strong> &mdash; A
+          FRIENDLY PROGRAMMING COMMUNITY OF 5,000+ MEMBERS IN BERKELEY AND THE
+          SAN FRANCISCO BAY AREA.
+        </p>
+        <p>
+          ALL LANGUAGES, ALL LEVELS, ALL WELCOME.
+          <span class="blink">█</span>
+        </p>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >[ PRESS RETURN TO JOIN ]</a
+        >
+      </div>
+
+      <div class="cols">
+        <div class="box">
+          <h3>COMMUNITY</h3>
+          <p>
+            Connect to the meetup &mdash; meet 5,000+ programmers who actually
+            keep showing up.
+          </p>
+        </div>
+        <div class="box">
+          <h3>MENTORSHIP</h3>
+          <p>
+            SYSOP-approved mentorship. Ask for a study plan. Beginners welcome.
+          </p>
+        </div>
+        <div class="box">
+          <h3>NETWORKING</h3>
+          <p>
+            Members have landed jobs via intros in the forum and at meetups.
+          </p>
+        </div>
+      </div>
+
+      <div class="log">
+        <h2>▓▓▓ BULLETIN ▓▓▓</h2>
+        <ul>
+          <li>
+            DOZENS OF MEETUPS TEACH YOU TO CODE. WE BUILD A LOCAL COMMUNITY.
+          </li>
+          <li>OPEN TO EVERY LANGUAGE. EVERY LEVEL. EVERY KIND OF PROJECT.</li>
+          <li>
+            FORMAT IS SELF-STUDY WITH ADVICE FROM MORE EXPERIENCED MEMBERS.
+          </li>
+          <li>
+            COMES AS A BOOTCAMP SUPPLEMENT OR ALTERNATIVE &mdash; ASK IN FORUM.
+          </li>
+        </ul>
+      </div>
+
+      <div class="langs">
+        <h2>▓▓▓ SUPPORTED DIALECTS ▓▓▓</h2>
+        <div class="lang-grid">
+          <span>» PYTHON</span><span>» JS</span><span>» TYPESCRIPT</span
+          ><span>» GO</span><span>» RUST</span><span>» HASKELL</span
+          ><span>» CLOJURE</span><span>» ELIXIR</span><span>» RACKET</span
+          ><span>» SCHEME</span><span>» C</span><span>» C++</span
+          ><span>» RUBY</span><span>» SCALA</span><span>» ERLANG</span
+          ><span>» ELM</span><span>» LUA</span><span>» SQL</span
+          ><span>» JULIA</span><span>» R</span><span>» +MORE</span>
+        </div>
+        <div class="status">
+          <span class="sep">───</span> CARRIER: 2400 BAUD · ANSI ON · LOCAL ECHO
+          ON · PRESS ? FOR HELP <span class="sep">───</span>
+        </div>
+      </div>
+    </div>
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "bbs-theme";
+        function apply(theme) {
+          if (theme === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "LIGHT";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "DARK";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var next =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(next);
+          localStorage.setItem(KEY, next);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/55-bbs-vtblue.html
+++ b/mockups/55-bbs-vtblue.html
@@ -1,0 +1,381 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — BBS · VT blue</title>
+    <style>
+      :root {
+        --bg: #000814;
+        --fg: #7fc9ff;
+        --fg-dim: #3a6a94;
+        --accent: #ffffff;
+        --warn: #ff8a6a;
+        --ok: #9cffd1;
+        --glow-fg: rgba(127, 201, 255, 0.45);
+        --glow-ok: rgba(156, 255, 209, 0.5);
+        --glow-accent: rgba(255, 255, 255, 0.55);
+        --scanline: rgba(0, 0, 0, 0.25);
+        --vignette: rgba(127, 201, 255, 0.06);
+      }
+      [data-theme="light"] {
+        --bg: #eaf0f6;
+        --fg: #0a2238;
+        --fg-dim: #4a6680;
+        --accent: #1a3a5a;
+        --warn: #8a1a2a;
+        --ok: #1a5a4a;
+        --glow-fg: rgba(10, 34, 56, 0.15);
+        --glow-ok: rgba(26, 90, 74, 0.2);
+        --glow-accent: rgba(26, 58, 90, 0.2);
+        --scanline: rgba(0, 0, 0, 0.06);
+        --vignette: rgba(10, 34, 56, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "VT323", "Perfect DOS VGA 437", "Courier New", ui-monospace, monospace;
+        font-size: 18px;
+        line-height: 1.4;
+        min-height: 100vh;
+        background-image:
+          linear-gradient(
+            to bottom,
+            transparent 0,
+            transparent 2px,
+            var(--scanline) 2px,
+            var(--scanline) 3px
+          ),
+          radial-gradient(
+            ellipse at center,
+            var(--vignette) 0%,
+            transparent 70%
+          );
+        background-size:
+          100% 3px,
+          100% 100%;
+        text-shadow: 0 0 4px var(--glow-fg);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .screen {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .header {
+        border: 2px solid var(--fg);
+        padding: 14px 10px;
+        margin-bottom: 16px;
+        overflow-x: auto;
+      }
+      .logo {
+        white-space: pre;
+        font-size: 10px;
+        line-height: 1.1;
+        color: var(--fg);
+        margin: 0;
+      }
+      .menubar {
+        border: 2px solid var(--fg);
+        background: var(--fg);
+        color: var(--bg);
+        padding: 4px 10px;
+        margin-bottom: 16px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        align-items: center;
+        text-shadow: none;
+        font-size: 16px;
+      }
+      .menubar span {
+        white-space: nowrap;
+      }
+      .menubar span {
+        font-weight: 700;
+      }
+      .menubar .k {
+        color: var(--warn);
+      }
+      .menubar .toggle {
+        margin-left: auto;
+        cursor: pointer;
+        user-select: none;
+        border: 1px solid var(--bg);
+        padding: 0 8px;
+      }
+      .menubar .toggle:hover {
+        background: var(--bg);
+        color: var(--fg);
+      }
+      .welcome {
+        border: 2px solid var(--fg);
+        padding: 18px;
+        margin-bottom: 16px;
+      }
+      h1 {
+        font-family: inherit;
+        font-size: 48px;
+        letter-spacing: 4px;
+        margin: 4px 0 12px;
+        color: var(--ok);
+        text-shadow: 0 0 8px var(--glow-ok);
+      }
+      .blink {
+        animation: blink 1s steps(1) infinite;
+        color: var(--accent);
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cta {
+        display: inline-block;
+        border: 2px solid var(--accent);
+        color: var(--accent);
+        padding: 6px 14px;
+        margin-top: 12px;
+        text-shadow: 0 0 4px var(--glow-accent);
+      }
+      .cta:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .sep {
+        color: var(--fg-dim);
+        letter-spacing: -1px;
+      }
+      .cols {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        margin-bottom: 16px;
+      }
+      .box {
+        border: 2px solid var(--fg);
+        padding: 12px;
+      }
+      .box h3 {
+        margin: 0 0 6px;
+        color: var(--ok);
+        font-size: 22px;
+      }
+      .box p {
+        margin: 0;
+        color: var(--fg);
+      }
+      .log {
+        border: 2px solid var(--fg);
+        padding: 14px;
+        margin-bottom: 16px;
+      }
+      .log h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .log ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .log li {
+        padding: 2px 0;
+      }
+      .log li::before {
+        content: "> ";
+        color: var(--ok);
+      }
+      .langs {
+        border: 2px solid var(--fg);
+        padding: 14px;
+      }
+      .langs h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .lang-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 2px 14px;
+      }
+      .status {
+        margin-top: 12px;
+        color: var(--fg-dim);
+        font-size: 14px;
+        border-top: 1px solid var(--fg-dim);
+        padding-top: 6px;
+      }
+      @media (max-width: 700px) {
+        .cols {
+          grid-template-columns: 1fr;
+        }
+        .logo {
+          font-size: 8px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="screen">
+      <div class="header">
+        <pre class="logo">
+ ██████╗ ██████╗ ██████╗ ███████╗  ███████╗███████╗██╗     ███████╗  ███████╗████████╗██╗   ██╗██████╗ ██╗   ██╗
+██╔════╝██╔═══██╗██╔══██╗██╔════╝  ██╔════╝██╔════╝██║     ██╔════╝  ██╔════╝╚══██╔══╝██║   ██║██╔══██╗╚██╗ ██╔╝
+██║     ██║   ██║██║  ██║█████╗    ███████╗█████╗  ██║     █████╗    ███████╗   ██║   ██║   ██║██║  ██║ ╚████╔╝
+██║     ██║   ██║██║  ██║██╔══╝    ╚════██║██╔══╝  ██║     ██╔══╝    ╚════██║   ██║   ██║   ██║██║  ██║  ╚██╔╝
+╚██████╗╚██████╔╝██████╔╝███████╗  ███████║███████╗███████╗██║       ███████║   ██║   ╚██████╔╝██████╔╝   ██║
+ ╚═════╝ ╚═════╝ ╚═════╝ ╚══════╝  ╚══════╝╚══════╝╚══════╝╚═╝       ╚══════╝   ╚═╝    ╚═════╝ ╚═════╝    ╚═╝</pre
+        >
+      </div>
+
+      <div class="menubar">
+        <span><span class="k">[H]</span>OME</span>
+        <span><span class="k">[E]</span>VENTS</span>
+        <span><span class="k">[L]</span>EARN</span>
+        <span><span class="k">[F]</span>ORUM</span>
+        <span><span class="k">[J]</span>OBS</span>
+        <span><span class="k">[P]</span>UZZLES</span>
+        <span><span class="k">[T]</span>OOLS</span>
+        <span><span class="k">[A]</span>BOUT</span>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">DARK</span></span
+        >
+      </div>
+
+      <div class="welcome">
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <h1>WELCOME, USER</h1>
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <p>
+          YOU HAVE CONNECTED TO
+          <strong style="color: var(--ok)">CODE SELF STUDY</strong> &mdash; A
+          FRIENDLY PROGRAMMING COMMUNITY OF 5,000+ MEMBERS IN BERKELEY AND THE
+          SAN FRANCISCO BAY AREA.
+        </p>
+        <p>
+          ALL LANGUAGES, ALL LEVELS, ALL WELCOME.
+          <span class="blink">█</span>
+        </p>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >[ PRESS RETURN TO JOIN ]</a
+        >
+      </div>
+
+      <div class="cols">
+        <div class="box">
+          <h3>COMMUNITY</h3>
+          <p>
+            Connect to the meetup &mdash; meet 5,000+ programmers who actually
+            keep showing up.
+          </p>
+        </div>
+        <div class="box">
+          <h3>MENTORSHIP</h3>
+          <p>
+            SYSOP-approved mentorship. Ask for a study plan. Beginners welcome.
+          </p>
+        </div>
+        <div class="box">
+          <h3>NETWORKING</h3>
+          <p>
+            Members have landed jobs via intros in the forum and at meetups.
+          </p>
+        </div>
+      </div>
+
+      <div class="log">
+        <h2>▓▓▓ BULLETIN ▓▓▓</h2>
+        <ul>
+          <li>
+            DOZENS OF MEETUPS TEACH YOU TO CODE. WE BUILD A LOCAL COMMUNITY.
+          </li>
+          <li>OPEN TO EVERY LANGUAGE. EVERY LEVEL. EVERY KIND OF PROJECT.</li>
+          <li>
+            FORMAT IS SELF-STUDY WITH ADVICE FROM MORE EXPERIENCED MEMBERS.
+          </li>
+          <li>
+            COMES AS A BOOTCAMP SUPPLEMENT OR ALTERNATIVE &mdash; ASK IN FORUM.
+          </li>
+        </ul>
+      </div>
+
+      <div class="langs">
+        <h2>▓▓▓ SUPPORTED DIALECTS ▓▓▓</h2>
+        <div class="lang-grid">
+          <span>» PYTHON</span><span>» JS</span><span>» TYPESCRIPT</span
+          ><span>» GO</span><span>» RUST</span><span>» HASKELL</span
+          ><span>» CLOJURE</span><span>» ELIXIR</span><span>» RACKET</span
+          ><span>» SCHEME</span><span>» C</span><span>» C++</span
+          ><span>» RUBY</span><span>» SCALA</span><span>» ERLANG</span
+          ><span>» ELM</span><span>» LUA</span><span>» SQL</span
+          ><span>» JULIA</span><span>» R</span><span>» +MORE</span>
+        </div>
+        <div class="status">
+          <span class="sep">───</span> CARRIER: 2400 BAUD · ANSI ON · LOCAL ECHO
+          ON · PRESS ? FOR HELP <span class="sep">───</span>
+        </div>
+      </div>
+    </div>
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "bbs-theme";
+        function apply(theme) {
+          if (theme === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "LIGHT";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "DARK";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var next =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(next);
+          localStorage.setItem(KEY, next);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/56-bbs-plasma.html
+++ b/mockups/56-bbs-plasma.html
@@ -1,0 +1,381 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — BBS · plasma</title>
+    <style>
+      :root {
+        --bg: #140400;
+        --fg: #ff6a1a;
+        --fg-dim: #8a3a10;
+        --accent: #ffcc33;
+        --warn: #ff2222;
+        --ok: #ffaa66;
+        --glow-fg: rgba(255, 106, 26, 0.5);
+        --glow-ok: rgba(255, 170, 102, 0.55);
+        --glow-accent: rgba(255, 204, 51, 0.5);
+        --scanline: rgba(0, 0, 0, 0.25);
+        --vignette: rgba(255, 106, 26, 0.06);
+      }
+      [data-theme="light"] {
+        --bg: #f4e4d8;
+        --fg: #3a1a08;
+        --fg-dim: #7a4a2a;
+        --accent: #8a4a10;
+        --warn: #9a2020;
+        --ok: #7a3a10;
+        --glow-fg: rgba(58, 26, 8, 0.15);
+        --glow-ok: rgba(122, 58, 16, 0.2);
+        --glow-accent: rgba(138, 74, 16, 0.2);
+        --scanline: rgba(0, 0, 0, 0.08);
+        --vignette: rgba(58, 26, 8, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "VT323", "Perfect DOS VGA 437", "Courier New", ui-monospace, monospace;
+        font-size: 18px;
+        line-height: 1.4;
+        min-height: 100vh;
+        background-image:
+          linear-gradient(
+            to bottom,
+            transparent 0,
+            transparent 2px,
+            var(--scanline) 2px,
+            var(--scanline) 3px
+          ),
+          radial-gradient(
+            ellipse at center,
+            var(--vignette) 0%,
+            transparent 70%
+          );
+        background-size:
+          100% 3px,
+          100% 100%;
+        text-shadow: 0 0 4px var(--glow-fg);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .screen {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .header {
+        border: 2px solid var(--fg);
+        padding: 14px 10px;
+        margin-bottom: 16px;
+        overflow-x: auto;
+      }
+      .logo {
+        white-space: pre;
+        font-size: 10px;
+        line-height: 1.1;
+        color: var(--fg);
+        margin: 0;
+      }
+      .menubar {
+        border: 2px solid var(--fg);
+        background: var(--fg);
+        color: var(--bg);
+        padding: 4px 10px;
+        margin-bottom: 16px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        align-items: center;
+        text-shadow: none;
+        font-size: 16px;
+      }
+      .menubar span {
+        white-space: nowrap;
+      }
+      .menubar span {
+        font-weight: 700;
+      }
+      .menubar .k {
+        color: var(--warn);
+      }
+      .menubar .toggle {
+        margin-left: auto;
+        cursor: pointer;
+        user-select: none;
+        border: 1px solid var(--bg);
+        padding: 0 8px;
+      }
+      .menubar .toggle:hover {
+        background: var(--bg);
+        color: var(--fg);
+      }
+      .welcome {
+        border: 2px solid var(--fg);
+        padding: 18px;
+        margin-bottom: 16px;
+      }
+      h1 {
+        font-family: inherit;
+        font-size: 48px;
+        letter-spacing: 4px;
+        margin: 4px 0 12px;
+        color: var(--ok);
+        text-shadow: 0 0 8px var(--glow-ok);
+      }
+      .blink {
+        animation: blink 1s steps(1) infinite;
+        color: var(--accent);
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .cta {
+        display: inline-block;
+        border: 2px solid var(--accent);
+        color: var(--accent);
+        padding: 6px 14px;
+        margin-top: 12px;
+        text-shadow: 0 0 4px var(--glow-accent);
+      }
+      .cta:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      .sep {
+        color: var(--fg-dim);
+        letter-spacing: -1px;
+      }
+      .cols {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        margin-bottom: 16px;
+      }
+      .box {
+        border: 2px solid var(--fg);
+        padding: 12px;
+      }
+      .box h3 {
+        margin: 0 0 6px;
+        color: var(--ok);
+        font-size: 22px;
+      }
+      .box p {
+        margin: 0;
+        color: var(--fg);
+      }
+      .log {
+        border: 2px solid var(--fg);
+        padding: 14px;
+        margin-bottom: 16px;
+      }
+      .log h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .log ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .log li {
+        padding: 2px 0;
+      }
+      .log li::before {
+        content: "> ";
+        color: var(--ok);
+      }
+      .langs {
+        border: 2px solid var(--fg);
+        padding: 14px;
+      }
+      .langs h2 {
+        color: var(--accent);
+        margin: 0 0 8px;
+        font-size: 24px;
+        letter-spacing: 2px;
+      }
+      .lang-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 2px 14px;
+      }
+      .status {
+        margin-top: 12px;
+        color: var(--fg-dim);
+        font-size: 14px;
+        border-top: 1px solid var(--fg-dim);
+        padding-top: 6px;
+      }
+      @media (max-width: 700px) {
+        .cols {
+          grid-template-columns: 1fr;
+        }
+        .logo {
+          font-size: 8px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="screen">
+      <div class="header">
+        <pre class="logo">
+ ██████╗ ██████╗ ██████╗ ███████╗  ███████╗███████╗██╗     ███████╗  ███████╗████████╗██╗   ██╗██████╗ ██╗   ██╗
+██╔════╝██╔═══██╗██╔══██╗██╔════╝  ██╔════╝██╔════╝██║     ██╔════╝  ██╔════╝╚══██╔══╝██║   ██║██╔══██╗╚██╗ ██╔╝
+██║     ██║   ██║██║  ██║█████╗    ███████╗█████╗  ██║     █████╗    ███████╗   ██║   ██║   ██║██║  ██║ ╚████╔╝
+██║     ██║   ██║██║  ██║██╔══╝    ╚════██║██╔══╝  ██║     ██╔══╝    ╚════██║   ██║   ██║   ██║██║  ██║  ╚██╔╝
+╚██████╗╚██████╔╝██████╔╝███████╗  ███████║███████╗███████╗██║       ███████║   ██║   ╚██████╔╝██████╔╝   ██║
+ ╚═════╝ ╚═════╝ ╚═════╝ ╚══════╝  ╚══════╝╚══════╝╚══════╝╚═╝       ╚══════╝   ╚═╝    ╚═════╝ ╚═════╝    ╚═╝</pre
+        >
+      </div>
+
+      <div class="menubar">
+        <span><span class="k">[H]</span>OME</span>
+        <span><span class="k">[E]</span>VENTS</span>
+        <span><span class="k">[L]</span>EARN</span>
+        <span><span class="k">[F]</span>ORUM</span>
+        <span><span class="k">[J]</span>OBS</span>
+        <span><span class="k">[P]</span>UZZLES</span>
+        <span><span class="k">[T]</span>OOLS</span>
+        <span><span class="k">[A]</span>BOUT</span>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">DARK</span></span
+        >
+      </div>
+
+      <div class="welcome">
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <h1>WELCOME, USER</h1>
+        <div class="sep">
+          ═══════════════════════════════════════════════════════════
+        </div>
+        <p>
+          YOU HAVE CONNECTED TO
+          <strong style="color: var(--ok)">CODE SELF STUDY</strong> &mdash; A
+          FRIENDLY PROGRAMMING COMMUNITY OF 5,000+ MEMBERS IN BERKELEY AND THE
+          SAN FRANCISCO BAY AREA.
+        </p>
+        <p>
+          ALL LANGUAGES, ALL LEVELS, ALL WELCOME.
+          <span class="blink">█</span>
+        </p>
+        <a class="cta" href="https://www.meetup.com/codeselfstudy/"
+          >[ PRESS RETURN TO JOIN ]</a
+        >
+      </div>
+
+      <div class="cols">
+        <div class="box">
+          <h3>COMMUNITY</h3>
+          <p>
+            Connect to the meetup &mdash; meet 5,000+ programmers who actually
+            keep showing up.
+          </p>
+        </div>
+        <div class="box">
+          <h3>MENTORSHIP</h3>
+          <p>
+            SYSOP-approved mentorship. Ask for a study plan. Beginners welcome.
+          </p>
+        </div>
+        <div class="box">
+          <h3>NETWORKING</h3>
+          <p>
+            Members have landed jobs via intros in the forum and at meetups.
+          </p>
+        </div>
+      </div>
+
+      <div class="log">
+        <h2>▓▓▓ BULLETIN ▓▓▓</h2>
+        <ul>
+          <li>
+            DOZENS OF MEETUPS TEACH YOU TO CODE. WE BUILD A LOCAL COMMUNITY.
+          </li>
+          <li>OPEN TO EVERY LANGUAGE. EVERY LEVEL. EVERY KIND OF PROJECT.</li>
+          <li>
+            FORMAT IS SELF-STUDY WITH ADVICE FROM MORE EXPERIENCED MEMBERS.
+          </li>
+          <li>
+            COMES AS A BOOTCAMP SUPPLEMENT OR ALTERNATIVE &mdash; ASK IN FORUM.
+          </li>
+        </ul>
+      </div>
+
+      <div class="langs">
+        <h2>▓▓▓ SUPPORTED DIALECTS ▓▓▓</h2>
+        <div class="lang-grid">
+          <span>» PYTHON</span><span>» JS</span><span>» TYPESCRIPT</span
+          ><span>» GO</span><span>» RUST</span><span>» HASKELL</span
+          ><span>» CLOJURE</span><span>» ELIXIR</span><span>» RACKET</span
+          ><span>» SCHEME</span><span>» C</span><span>» C++</span
+          ><span>» RUBY</span><span>» SCALA</span><span>» ERLANG</span
+          ><span>» ELM</span><span>» LUA</span><span>» SQL</span
+          ><span>» JULIA</span><span>» R</span><span>» +MORE</span>
+        </div>
+        <div class="status">
+          <span class="sep">───</span> CARRIER: 2400 BAUD · ANSI ON · LOCAL ECHO
+          ON · PRESS ? FOR HELP <span class="sep">───</span>
+        </div>
+      </div>
+    </div>
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "bbs-theme";
+        function apply(theme) {
+          if (theme === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "LIGHT";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "DARK";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var next =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(next);
+          localStorage.setItem(KEY, next);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -322,8 +322,63 @@
           <h2>Brutalist · carbon copy</h2>
           <p>Typewriter mono, ribbon-red ghost shadow, memo header.</p></a
         >
+        <a class="card" href="46-brutalist-coral.html"
+          ><div class="num">46</div>
+          <h2>Brutalist · coral</h2>
+          <p>Original palette with the pink swapped for muted coral.</p></a
+        >
+        <a class="card" href="47-brutalist-butter.html"
+          ><div class="num">47</div>
+          <h2>Brutalist · butter</h2>
+          <p>Soft butter, sage, dusty blue &amp; coral pastels.</p></a
+        >
+        <a class="card" href="48-brutalist-dusk.html"
+          ><div class="num">48</div>
+          <h2>Brutalist · dusk</h2>
+          <p>Muted lavender, steel blue, ochre &amp; sage teal.</p></a
+        >
+        <a class="card" href="49-brutalist-mint.html"
+          ><div class="num">49</div>
+          <h2>Brutalist · mint</h2>
+          <p>Pastel mint, pale sky, peach &amp; soft butter.</p></a
+        >
+        <a class="card" href="50-brutalist-stone.html"
+          ><div class="num">50</div>
+          <h2>Brutalist · stone</h2>
+          <p>Desaturated rose stone, dove, sand &amp; stone teal.</p></a
+        >
+        <a class="card" href="51-brutalist-lavender.html"
+          ><div class="num">51</div>
+          <h2>Brutalist · lavender</h2>
+          <p>Lavender, muted sky, cream yellow &amp; soft mint.</p></a
+        >
+        <a class="card" href="52-bbs-amber.html"
+          ><div class="num">52</div>
+          <h2>BBS · amber phosphor</h2>
+          <p>Classic amber CRT with light/dark toggle.</p></a
+        >
+        <a class="card" href="53-bbs-green.html"
+          ><div class="num">53</div>
+          <h2>BBS · green phosphor</h2>
+          <p>P1 green on black; paper light mode.</p></a
+        >
+        <a class="card" href="54-bbs-paperwhite.html"
+          ><div class="num">54</div>
+          <h2>BBS · paper-white</h2>
+          <p>Mac Plus feel, cream on ink &amp; ink on cream.</p></a
+        >
+        <a class="card" href="55-bbs-vtblue.html"
+          ><div class="num">55</div>
+          <h2>BBS · VT blue</h2>
+          <p>DEC-style blue phosphor with navy light mode.</p></a
+        >
+        <a class="card" href="56-bbs-plasma.html"
+          ><div class="num">56</div>
+          <h2>BBS · plasma</h2>
+          <p>Orange plasma panel; rust-on-oat light mode.</p></a
+        >
       </div>
-      <footer>All 44 live under <code>./mockups/</code>.</footer>
+      <footer>All 55 live under <code>./mockups/</code>.</footer>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- **46–51**: six brutalist variants replacing the pink accent with muted/pastel palettes (coral, butter, dusk, mint, stone, lavender)
- **52–56**: five BBS variants (amber, green, paper-white, VT blue, plasma) with a new "CODE SELF STUDY" ASCII header, a light/dark toggle in the menubar persisted via localStorage, and the old NODE tags / right-side stats panel removed
- index.html updated with cards for all 11 new mockups

## Test plan
- [ ] Open each new mockup from the index; confirm styling loads
- [ ] On 52–56, toggle light/dark via the menubar chip; confirm state persists across reload
- [ ] Narrow the viewport to ~400px on 52–56; confirm the header scrolls horizontally rather than clipping and the menubar wraps cleanly