### PR TITLE
Add tmux/TUI green-terminal mockups (57–62)

### DIFF
--- a/mockups/57-tmux-btop.html
+++ b/mockups/57-tmux-btop.html
@@ -1,0 +1,758 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — tmux · btop</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --border-hi: #5cd65c;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --red: #ff7a7a;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --status-active: #ffe066;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.18);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --border-hi: #1a1a14;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --red: #8a1a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --status-active: #ffe066;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.45;
+        min-height: 100vh;
+        padding: 24px;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .term {
+        max-width: 1180px;
+        margin: 0 auto;
+        background: var(--pane);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.3),
+          0 18px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+        box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: auto auto auto;
+        gap: 0;
+      }
+      .pane {
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        padding: 0;
+        background: var(--pane);
+      }
+      .pane.full {
+        grid-column: 1 / -1;
+        border-right: none;
+      }
+      .pane.last {
+        border-right: none;
+      }
+      .pane-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        color: var(--fg-dim);
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border);
+        background: var(--pane-2);
+      }
+      .pane-bar .lab {
+        color: var(--accent);
+      }
+      .pane-bar .lab.cyan {
+        color: var(--cyan);
+      }
+      .pane-bar .lab.mag {
+        color: var(--magenta);
+      }
+      .pane-bar .lab.yel {
+        color: var(--yellow);
+      }
+      .pane-bar .fill {
+        flex: 1;
+        border-bottom: 1px dashed var(--fg-mute);
+        margin: 0 4px;
+        height: 0;
+        transform: translateY(2px);
+      }
+      .pane-bar .keys {
+        color: var(--fg-mute);
+      }
+      .pane-body {
+        padding: 12px 14px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 90px 1fr 60px;
+        gap: 10px;
+        align-items: center;
+        padding: 1px 0;
+      }
+      .row .name {
+        color: var(--fg);
+      }
+      .row .pct {
+        text-align: right;
+        color: var(--accent);
+      }
+      .bar {
+        font-family: inherit;
+        color: var(--accent);
+        white-space: pre;
+        overflow: hidden;
+        letter-spacing: -1px;
+      }
+      .bar.cyan {
+        color: var(--cyan);
+      }
+      .bar.yel {
+        color: var(--yellow);
+      }
+      .bar.mag {
+        color: var(--magenta);
+      }
+      .meter-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        padding: 2px 0;
+      }
+      .meter-row .lbl {
+        width: 70px;
+        color: var(--fg-dim);
+      }
+      .meter-row .val {
+        margin-left: auto;
+        color: var(--accent);
+      }
+      .meter {
+        flex: 1;
+        height: 10px;
+        border: 1px solid var(--border);
+        background: var(--pane-2);
+        position: relative;
+      }
+      .meter > i {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        box-shadow: 0 0 6px var(--accent);
+      }
+      .meter.cyan > i {
+        background: var(--cyan);
+        box-shadow: 0 0 6px var(--cyan);
+      }
+      .meter.mag > i {
+        background: var(--magenta);
+        box-shadow: 0 0 6px var(--magenta);
+      }
+      .ascii {
+        white-space: pre;
+        color: var(--fg-dim);
+        margin: 0;
+        font-size: 11px;
+        line-height: 1.05;
+      }
+      .ascii .hi {
+        color: var(--accent);
+      }
+      .lead {
+        margin: 8px 0 4px;
+        color: var(--fg);
+      }
+      .lead b {
+        color: var(--yellow);
+      }
+      .ctas {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 4px 12px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .btn.ghost {
+        border-color: var(--fg-dim);
+        color: var(--fg-dim);
+      }
+      .btn.ghost:hover {
+        background: var(--fg-dim);
+        color: var(--pane);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 2px 8px 2px 0;
+        white-space: nowrap;
+      }
+      thead th {
+        color: var(--fg-dim);
+        border-bottom: 1px dashed var(--border);
+        font-weight: normal;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 11px;
+      }
+      tbody tr:hover {
+        background: var(--pane-2);
+      }
+      td.user {
+        color: var(--cyan);
+      }
+      td.pid {
+        color: var(--fg-dim);
+      }
+      td.cmd {
+        color: var(--fg);
+        white-space: normal;
+        width: 100%;
+      }
+      td.cpu,
+      td.mem {
+        color: var(--accent);
+        text-align: right;
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        margin-top: 6px;
+      }
+      .langs span {
+        color: var(--fg);
+      }
+      .langs span::before {
+        content: "▸ ";
+        color: var(--fg-mute);
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--status-active);
+        color: var(--status-bg);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      @media (max-width: 820px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .pane {
+          border-right: none;
+        }
+        .ttitle {
+          font-size: 11px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <div class="titlebar">
+        <div class="dots">
+          <span class="dot"></span><span class="dot y"></span
+          ><span class="dot g"></span>
+        </div>
+        <div class="ttitle">
+          <b>codeselfstudy</b>@neo: ~/community — tmux: btop · 1180×640
+        </div>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </div>
+
+      <div class="grid">
+        <!-- pane 0 : btop CPU (languages) -->
+        <div class="pane">
+          <div class="pane-bar">
+            <span>0</span><span class="lab">btop</span>
+            <span class="fill"></span>
+            <span class="keys">q quit · h help</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── cpu · languages in use ─────────────────────────
+            </div>
+            <div class="row">
+              <span class="name">python</span>
+              <span class="bar"
+                >█████████████████████████████████████████░░░░░</span
+              >
+              <span class="pct">62%</span>
+            </div>
+            <div class="row">
+              <span class="name">javascript</span>
+              <span class="bar cyan"
+                >██████████████████████████████████░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">54%</span>
+            </div>
+            <div class="row">
+              <span class="name">typescript</span>
+              <span class="bar cyan"
+                >███████████████████████████████░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">48%</span>
+            </div>
+            <div class="row">
+              <span class="name">go</span>
+              <span class="bar yel"
+                >████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">35%</span>
+            </div>
+            <div class="row">
+              <span class="name">rust</span>
+              <span class="bar yel"
+                >██████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">31%</span>
+            </div>
+            <div class="row">
+              <span class="name">haskell</span>
+              <span class="bar mag"
+                >██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">22%</span>
+            </div>
+            <div class="row">
+              <span class="name">clojure</span>
+              <span class="bar mag"
+                >████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">19%</span>
+            </div>
+            <div class="row">
+              <span class="name">elixir</span>
+              <span class="bar mag"
+                >███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">17%</span>
+            </div>
+            <div class="row">
+              <span class="name">racket</span>
+              <span class="bar"
+                >█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct">14%</span>
+            </div>
+            <div class="row">
+              <span class="name">+ 12 more</span>
+              <span class="bar" style="color: var(--fg-mute)"
+                >░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--fg-dim)">··</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 1 : MEM/NET (community) -->
+        <div class="pane last">
+          <div class="pane-bar">
+            <span>1</span><span class="lab cyan">mem · net</span>
+            <span class="fill"></span><span class="keys">e expand</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── community pool ─────────────────
+            </div>
+            <div class="meter-row">
+              <span class="lbl">members</span>
+              <span class="meter"><i style="width: 92%"></i></span>
+              <span class="val">5,000+</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">years up</span>
+              <span class="meter cyan"><i style="width: 82%"></i></span>
+              <span class="val" style="color: var(--cyan)">11</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">langs</span>
+              <span class="meter mag"><i style="width: 70%"></i></span>
+              <span class="val" style="color: var(--magenta)">20+</span>
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 6px">
+              ── net · this week ────────────────
+            </div>
+            <div style="color: var(--fg)">
+              ↓ <span style="color: var(--accent)">12</span> meetups / month
+            </div>
+            <div style="color: var(--fg)">
+              ↑ <span style="color: var(--cyan)">234</span> forum posts
+            </div>
+            <div style="color: var(--fg)">
+              ⇄ <span style="color: var(--yellow)">38</span> intros & jobs
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 4px">
+              ── load avg ───────────────────────
+            </div>
+            <pre
+              class="ascii"
+            ><span class="hi">▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅</span>
+12mo · steady &amp; rising</pre>
+          </div>
+        </div>
+
+        <!-- pane 2 : welcome / CTA -->
+        <div class="pane full">
+          <div class="pane-bar">
+            <span>2</span><span class="lab yel">★ codeselfstudy --intro</span>
+            <span class="fill"></span>
+            <span class="keys">prefix + ? help</span>
+          </div>
+          <div class="pane-body">
+            <pre class="ascii">
+  <span class="hi">code self study</span> · a friendly programming community in the san francisco bay area
+  <span class="hi">────────────────</span>   est. 2014 · all languages, all levels, in person + online</pre>
+            <p class="lead">
+              Self-study computer programming alongside <b>5,000+</b> members in
+              Berkeley and the SF Bay Area. Bring a project, bring a question,
+              or just show up. We meet in person and online.<span class="blink"
+                >▮</span
+              >
+            </p>
+            <div class="ctas">
+              <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+                >$ meetup --join</a
+              >
+              <a class="btn ghost" href="#">$ forum</a>
+              <a class="btn ghost" href="#">$ events --upcoming</a>
+              <a class="btn ghost" href="#">$ puzzles</a>
+            </div>
+            <div style="margin-top: 14px; color: var(--fg-dim)">
+              what we do ::
+            </div>
+            <div class="langs">
+              <span>build a local community of motivated programmers</span>
+              <span>open to every language &amp; level</span>
+              <span>self-study with mentorship from experienced members</span>
+              <span>bootcamp supplement or alternative</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 3 : process list (recent activity) -->
+        <div class="pane full" style="border-bottom: none">
+          <div class="pane-bar">
+            <span>3</span><span class="lab mag">proc · recent activity</span>
+            <span class="fill"></span>
+            <span class="keys">/ filter · k kill</span>
+          </div>
+          <div class="pane-body">
+            <table>
+              <thead>
+                <tr>
+                  <th>pid</th>
+                  <th>user</th>
+                  <th>cpu</th>
+                  <th>mem</th>
+                  <th>uptime</th>
+                  <th>cmd</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="pid">1284</td>
+                  <td class="user">alice</td>
+                  <td class="cpu">12.4</td>
+                  <td class="mem">8.2</td>
+                  <td class="pid">02:14</td>
+                  <td class="cmd">
+                    rustc puzzles/day-7.rs &nbsp;<span
+                      style="color: var(--fg-dim)"
+                      >· asked for review in #rust</span
+                    >
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1391</td>
+                  <td class="user">bob</td>
+                  <td class="cpu">24.1</td>
+                  <td class="mem">3.4</td>
+                  <td class="pid">00:42</td>
+                  <td class="cmd">
+                    meetup --where berkeley --in 3d &nbsp;<span
+                      style="color: var(--fg-dim)"
+                      >· 18 RSVPs</span
+                    >
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1432</td>
+                  <td class="user">carol</td>
+                  <td class="cpu">7.0</td>
+                  <td class="mem">4.1</td>
+                  <td class="pid">11:08</td>
+                  <td class="cmd">
+                    hs-projects/parser
+                    <span style="color: var(--accent)">← merged</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1518</td>
+                  <td class="user">dan</td>
+                  <td class="cpu">3.2</td>
+                  <td class="mem">2.0</td>
+                  <td class="pid">04:31</td>
+                  <td class="cmd">
+                    forum reply: "study plan for going from JS → systems"
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1607</td>
+                  <td class="user">eve</td>
+                  <td class="cpu">15.7</td>
+                  <td class="mem">6.8</td>
+                  <td class="pid">00:09</td>
+                  <td class="cmd">
+                    intro &nbsp;<span style="color: var(--yellow)"
+                      >job referral · backend role</span
+                    >
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1684</td>
+                  <td class="user">frank</td>
+                  <td class="cpu">9.3</td>
+                  <td class="mem">2.7</td>
+                  <td class="pid">06:55</td>
+                  <td class="cmd">
+                    tools/regex-trainer
+                    <span style="color: var(--cyan)">+ new contributor</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1711</td>
+                  <td class="user">grace</td>
+                  <td class="cpu">5.5</td>
+                  <td class="mem">1.9</td>
+                  <td class="pid">13:20</td>
+                  <td class="cmd">elixir/phoenix study group · weds 7pm</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win active">0:btop*</span>
+        <span class="win">1:nvim</span>
+        <span class="win">2:lazygit</span>
+        <span class="win">3:weechat</span>
+        <span class="win">4:yazi</span>
+        <span class="right"
+          >"neo" load 1.42 · ↑11y · <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/58-tmux-neovim.html
+++ b/mockups/58-tmux-neovim.html
@@ -1,0 +1,767 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — tmux · neovim</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --orange: #ffb86b;
+        --red: #ff7a7a;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --mode-bg: #c4ff5e;
+        --mode-fg: #050805;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.16);
+        --scanline: rgba(0, 0, 0, 0.18);
+        --selection: rgba(196, 255, 94, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --orange: #8a4a14;
+        --red: #8a1a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --mode-bg: #1a1a14;
+        --mode-fg: #efe9d6;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+        --selection: rgba(26, 74, 138, 0.14);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.5;
+        min-height: 100vh;
+        padding: 24px;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      .term {
+        max-width: 1180px;
+        margin: 0 auto;
+        background: var(--pane);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.3),
+          0 18px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+
+      /* tabline (bufferline) */
+      .tabline {
+        display: flex;
+        background: var(--pane-2);
+        border-bottom: 1px solid var(--border);
+        font-size: 12px;
+      }
+      .tab {
+        padding: 4px 14px;
+        color: var(--fg-dim);
+        border-right: 1px solid var(--border);
+        cursor: pointer;
+      }
+      .tab .ic {
+        color: var(--orange);
+        margin-right: 6px;
+      }
+      .tab.active {
+        background: var(--pane);
+        color: var(--fg);
+      }
+      .tab.active .ic {
+        color: var(--accent);
+      }
+      .tab .mod {
+        color: var(--accent);
+        margin-left: 6px;
+      }
+      .tabline .spacer {
+        flex: 1;
+      }
+      .tabline .right {
+        padding: 4px 14px;
+        color: var(--fg-mute);
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: 240px 1fr;
+        min-height: 540px;
+      }
+
+      .tree {
+        border-right: 1px solid var(--border);
+        background: var(--pane-2);
+        padding: 10px 12px;
+      }
+      .tree h4 {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--fg-dim);
+        margin: 0 0 8px;
+        font-weight: 500;
+      }
+      .tree ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        font-size: 13px;
+      }
+      .tree li {
+        padding: 1px 0;
+        color: var(--fg);
+        cursor: pointer;
+      }
+      .tree li:hover {
+        background: var(--selection);
+      }
+      .tree li .ind {
+        color: var(--fg-mute);
+      }
+      .tree li.dir {
+        color: var(--cyan);
+      }
+      .tree li.dir.open::before {
+        content: " ";
+      }
+      .tree li.dir.closed::before {
+        content: " ";
+      }
+      .tree li.file::before {
+        content: " ";
+        color: var(--orange);
+      }
+      .tree li.file.md::before {
+        content: " ";
+        color: var(--cyan);
+      }
+      .tree li.file.ts::before {
+        content: " ";
+        color: var(--cyan);
+      }
+      .tree li.file.rs::before {
+        content: " ";
+        color: var(--orange);
+      }
+      .tree li.cur {
+        background: var(--selection);
+        color: var(--accent);
+      }
+
+      .editor {
+        display: grid;
+        grid-template-columns: 1fr;
+        position: relative;
+      }
+      .buffer {
+        padding: 8px 0;
+        font-size: 13.5px;
+        line-height: 1.55;
+      }
+      .ln {
+        display: grid;
+        grid-template-columns: 56px 1fr;
+        gap: 0;
+      }
+      .ln:hover {
+        background: rgba(196, 255, 94, 0.04);
+      }
+      .ln .n {
+        text-align: right;
+        padding-right: 14px;
+        color: var(--fg-mute);
+        user-select: none;
+      }
+      .ln.cur .n {
+        color: var(--accent);
+      }
+      .ln.cur {
+        background: var(--selection);
+      }
+      .ln .l {
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      /* markdown highlighting */
+      .h1 {
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .h2 {
+        color: var(--yellow);
+      }
+      .h3 {
+        color: var(--magenta);
+      }
+      .punct {
+        color: var(--fg-mute);
+      }
+      .str {
+        color: var(--orange);
+      }
+      .kw {
+        color: var(--magenta);
+      }
+      .ln-link {
+        color: var(--cyan);
+        text-decoration: underline;
+      }
+      .com {
+        color: var(--fg-dim);
+        font-style: italic;
+      }
+      .bullet {
+        color: var(--accent);
+      }
+      .cur-ch {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .blink {
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+
+      /* lualine */
+      .lualine {
+        display: flex;
+        align-items: stretch;
+        font-size: 12px;
+        background: var(--pane-2);
+        border-top: 1px solid var(--border);
+      }
+      .lualine .seg {
+        padding: 3px 10px;
+        background: var(--pane-2);
+        color: var(--fg-dim);
+      }
+      .lualine .mode {
+        background: var(--mode-bg);
+        color: var(--mode-fg);
+        font-weight: 700;
+        letter-spacing: 0.1em;
+      }
+      .lualine .branch {
+        color: var(--magenta);
+      }
+      .lualine .branch::before {
+        content: " ";
+      }
+      .lualine .file {
+        color: var(--fg);
+      }
+      .lualine .diag {
+        color: var(--red);
+      }
+      .lualine .diag.warn {
+        color: var(--yellow);
+      }
+      .lualine .diag.info {
+        color: var(--cyan);
+      }
+      .lualine .grow {
+        flex: 1;
+      }
+      .lualine .pos {
+        color: var(--accent);
+      }
+
+      /* tmux */
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--mode-bg);
+        color: var(--mode-fg);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+
+      .btn {
+        display: inline-block;
+        padding: 2px 10px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+
+      @media (max-width: 780px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .tree {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <div class="titlebar">
+        <div class="dots">
+          <span class="dot"></span><span class="dot y"></span
+          ><span class="dot g"></span>
+        </div>
+        <div class="ttitle">
+          <b>codeselfstudy</b>@neo: ~/community — tmux: nvim · 1180×640
+        </div>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </div>
+
+      <div class="tabline">
+        <div class="tab"><span class="ic">●</span>NvimTree</div>
+        <div class="tab active">
+          <span class="ic">●</span>welcome.md<span class="mod">●</span>
+        </div>
+        <div class="tab"><span class="ic">●</span>events.ts</div>
+        <div class="tab"><span class="ic">●</span>languages.toml</div>
+        <div class="spacer"></div>
+        <div class="right">main · 4 buffers</div>
+      </div>
+
+      <div class="grid">
+        <aside class="tree">
+          <h4>~/codeselfstudy</h4>
+          <ul>
+            <li class="dir open">community/</li>
+            <li>
+              <span class="ind"> </span><span class="file md">welcome.md</span>
+            </li>
+            <li>
+              <span class="ind"> </span><span class="file md">join.md</span>
+            </li>
+            <li>
+              <span class="ind"> </span
+              ><span class="file md">code-of-conduct.md</span>
+            </li>
+            <li class="dir closed"><span class="ind"> </span>events/</li>
+            <li class="dir closed"><span class="ind"> </span>jobs/</li>
+            <li class="dir closed"><span class="ind"> </span>forum/</li>
+            <li class="dir open"><span class="ind"> </span>learn/</li>
+            <li>
+              <span class="ind"> </span
+              ><span class="file md">study-plans.md</span>
+            </li>
+            <li>
+              <span class="ind"> </span
+              ><span class="file md">mentorship.md</span>
+            </li>
+            <li class="dir closed"><span class="ind"> </span>puzzles/</li>
+            <li class="dir open"><span class="ind"> </span>languages/</li>
+            <li class="cur">
+              <span class="ind"> </span
+              ><span class="file ts">supported.ts</span>
+            </li>
+            <li>
+              <span class="ind"> </span><span class="file rs">examples.rs</span>
+            </li>
+            <li class="dir closed"><span class="ind"> </span>tools/</li>
+            <li>
+              <span class="ind"> </span><span class="file md">about.md</span>
+            </li>
+            <li>
+              <span class="ind"> </span><span class="file md">README.md</span>
+            </li>
+          </ul>
+          <h4 style="margin-top: 14px">git status</h4>
+          <ul style="font-size: 12px">
+            <li style="color: var(--accent)">M welcome.md</li>
+            <li style="color: var(--cyan)">A events/2026-04-30.md</li>
+            <li style="color: var(--yellow)">?? notes/draft.md</li>
+          </ul>
+        </aside>
+
+        <section class="editor">
+          <div class="buffer">
+            <div class="ln">
+              <span class="n">1</span
+              ><span class="l"><span class="h1"># Code Self Study</span></span>
+            </div>
+            <div class="ln">
+              <span class="n">2</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">3</span
+              ><span class="l"
+                ><span class="com"
+                  >> A friendly programming community in the SF Bay Area &mdash;
+                  est. 2014</span
+                ></span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">4</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">5</span
+              ><span class="l"><span class="h2">## hello, world</span></span>
+            </div>
+            <div class="ln">
+              <span class="n">6</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">7</span
+              ><span class="l"
+                >Self-study computer programming alongside
+                <span class="kw">5,000+</span> programmers in</span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">8</span
+              ><span class="l"
+                >Berkeley and the Bay Area.
+                <span class="kw">All</span> languages,
+                <span class="kw">all</span> levels, all welcome.</span
+              >
+            </div>
+            <div class="ln cur">
+              <span class="n">9</span
+              ><span class="l"
+                >We meet in person and online.<span class="cur-ch blink"
+                  >▮</span
+                ></span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">10</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">11</span
+              ><span class="l"><span class="h2">## what we do</span></span>
+            </div>
+            <div class="ln">
+              <span class="n">12</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">13</span
+              ><span class="l"
+                ><span class="bullet">-</span> build a local community of
+                motivated programmers</span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">14</span
+              ><span class="l"
+                ><span class="bullet">-</span> open to every language &amp;
+                level &mdash; bring a project</span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">15</span
+              ><span class="l"
+                ><span class="bullet">-</span> self-study with mentorship from
+                experienced members</span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">16</span
+              ><span class="l"
+                ><span class="bullet">-</span> bootcamp
+                <span class="str">"supplement"</span> or
+                <span class="str">"alternative"</span></span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">17</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">18</span
+              ><span class="l"
+                ><span class="h2">## supported languages</span></span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">19</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">20</span
+              ><span class="l"
+                ><span class="punct">`</span><span class="str">python</span
+                ><span class="punct">`</span> <span class="punct">`</span
+                ><span class="str">javascript</span><span class="punct">`</span>
+                <span class="punct">`</span><span class="str">typescript</span
+                ><span class="punct">`</span> <span class="punct">`</span
+                ><span class="str">go</span><span class="punct">`</span>
+                <span class="punct">`</span><span class="str">rust</span
+                ><span class="punct">`</span> <span class="punct">`</span
+                ><span class="str">haskell</span><span class="punct">`</span>
+                <span class="punct">`</span><span class="str">clojure</span
+                ><span class="punct">`</span></span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">21</span
+              ><span class="l"
+                ><span class="punct">`</span><span class="str">elixir</span
+                ><span class="punct">`</span> <span class="punct">`</span
+                ><span class="str">racket</span><span class="punct">`</span>
+                <span class="punct">`</span><span class="str">scheme</span
+                ><span class="punct">`</span> <span class="punct">`</span
+                ><span class="str">c</span><span class="punct">`</span>
+                <span class="punct">`</span><span class="str">c++</span
+                ><span class="punct">`</span> <span class="punct">`</span
+                ><span class="str">ruby</span><span class="punct">`</span>
+                <span class="punct">`</span><span class="str">scala</span
+                ><span class="punct">`</span> <span class="punct">`</span
+                ><span class="str">erlang</span><span class="punct">`</span>
+                <span class="punct">`</span><span class="str">elm</span
+                ><span class="punct">`</span> <span class="punct">`</span
+                ><span class="str">sql</span><span class="punct">`</span>
+                <span class="punct">`</span><span class="str">+more</span
+                ><span class="punct">`</span></span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">22</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">23</span
+              ><span class="l"><span class="h2">## join us</span></span>
+            </div>
+            <div class="ln">
+              <span class="n">24</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">25</span
+              ><span class="l"
+                ><span class="punct">[</span
+                ><span class="ln-link">meetup &raquo;</span
+                ><span class="punct">](</span
+                ><a class="ln-link" href="https://www.meetup.com/codeselfstudy/"
+                  >https://www.meetup.com/codeselfstudy/</a
+                ><span class="punct">)</span></span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">26</span
+              ><span class="l"
+                ><span class="punct">[</span
+                ><span class="ln-link">forum &raquo;</span
+                ><span class="punct">](</span><span class="str">/forum</span
+                ><span class="punct">)</span> <span class="punct">[</span
+                ><span class="ln-link">events &raquo;</span
+                ><span class="punct">](</span><span class="str">/events</span
+                ><span class="punct">)</span> <span class="punct">[</span
+                ><span class="ln-link">puzzles &raquo;</span
+                ><span class="punct">](</span><span class="str">/puzzles</span
+                ><span class="punct">)</span></span
+              >
+            </div>
+            <div class="ln">
+              <span class="n">27</span><span class="l"></span>
+            </div>
+            <div class="ln">
+              <span class="n">28</span
+              ><span class="l"
+                ><span class="com">&lt;!-- :wq to ship --&gt;</span></span
+              >
+            </div>
+          </div>
+
+          <div class="lualine">
+            <span class="seg mode">NORMAL</span>
+            <span class="seg branch">main</span>
+            <span class="seg file">welcome.md</span>
+            <span class="seg diag info">●0</span>
+            <span class="seg diag warn">●0</span>
+            <span class="seg diag">●0</span>
+            <span class="grow"></span>
+            <span class="seg">utf-8</span>
+            <span class="seg">markdown</span>
+            <span class="seg pos">9:34</span>
+            <span class="seg mode">100%</span>
+          </div>
+        </section>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win">0:btop</span>
+        <span class="win active">1:nvim*</span>
+        <span class="win">2:lazygit</span>
+        <span class="win">3:weechat</span>
+        <span class="win">4:yazi</span>
+        <span class="right"
+          >"neo" &nbsp;<a
+            href="https://www.meetup.com/codeselfstudy/"
+            class="btn"
+            >join meetup</a
+          >&nbsp; <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/59-tmux-lazygit.html
+++ b/mockups/59-tmux-lazygit.html
@@ -1,0 +1,747 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — tmux · lazygit</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --border-active: #c4ff5e;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --orange: #ffb86b;
+        --red: #ff7a7a;
+        --green: #6ce46c;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --diff-add-bg: rgba(108, 228, 108, 0.14);
+        --diff-add-fg: #b8ffb8;
+        --diff-del-bg: rgba(255, 122, 122, 0.14);
+        --diff-del-fg: #ffb0b0;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.16);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --border-active: #1a1a14;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --orange: #8a4a14;
+        --red: #8a1a2a;
+        --green: #1a5a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --diff-add-bg: rgba(26, 90, 42, 0.12);
+        --diff-add-fg: #1a5a2a;
+        --diff-del-bg: rgba(138, 26, 42, 0.1);
+        --diff-del-fg: #8a1a2a;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.5;
+        min-height: 100vh;
+        padding: 24px;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      .term {
+        max-width: 1180px;
+        margin: 0 auto;
+        background: var(--pane);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.3),
+          0 18px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: 320px 1fr;
+        min-height: 600px;
+      }
+      .col {
+        display: flex;
+        flex-direction: column;
+        border-right: 1px solid var(--border);
+      }
+      .col.last {
+        border-right: none;
+      }
+      .panel {
+        border-bottom: 1px solid var(--border);
+      }
+      .panel.active {
+        border: 1px solid var(--border-active);
+        margin: -1px;
+        position: relative;
+        z-index: 1;
+      }
+      .panel.last {
+        border-bottom: none;
+        flex: 1;
+      }
+      .pbar {
+        padding: 3px 10px;
+        font-size: 12px;
+        color: var(--fg-dim);
+        background: var(--pane-2);
+        border-bottom: 1px dashed var(--border);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .pbar .num {
+        color: var(--accent);
+      }
+      .pbar .keys {
+        margin-left: auto;
+        color: var(--fg-mute);
+      }
+      .panel.active .pbar {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .panel.active .pbar .num,
+      .panel.active .pbar .keys {
+        color: var(--pane);
+      }
+      .pbody {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      .pbody.no-pad {
+        padding: 0;
+      }
+
+      .file-row,
+      .branch-row,
+      .commit-row {
+        padding: 1px 6px;
+        display: flex;
+        gap: 8px;
+        align-items: baseline;
+      }
+      .file-row:hover,
+      .branch-row:hover,
+      .commit-row:hover {
+        background: var(--pane-2);
+      }
+      .file-row.cur,
+      .branch-row.cur,
+      .commit-row.cur {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .file-row.cur .add,
+      .file-row.cur .del,
+      .file-row.cur .un,
+      .branch-row.cur .ahead,
+      .branch-row.cur .name,
+      .commit-row.cur .hash,
+      .commit-row.cur .who {
+        color: var(--pane);
+      }
+      .add {
+        color: var(--green);
+      }
+      .del {
+        color: var(--red);
+      }
+      .un {
+        color: var(--yellow);
+      }
+      .name {
+        color: var(--fg);
+      }
+      .ahead {
+        color: var(--cyan);
+        font-size: 11px;
+      }
+      .who {
+        color: var(--magenta);
+      }
+      .hash {
+        color: var(--yellow);
+      }
+      .commit-row .msg {
+        color: var(--fg);
+      }
+      .head {
+        color: var(--accent);
+      }
+      .head::before {
+        content: "* ";
+      }
+
+      /* diff pane */
+      .diff {
+        font-size: 13px;
+        font-family: inherit;
+      }
+      .diff-head {
+        background: var(--pane-2);
+        padding: 6px 12px;
+        color: var(--fg-dim);
+        border-bottom: 1px dashed var(--border);
+      }
+      .diff-head b {
+        color: var(--cyan);
+      }
+      .hunk {
+        color: var(--magenta);
+        background: rgba(255, 122, 198, 0.05);
+        padding: 2px 12px;
+      }
+      .dline {
+        display: grid;
+        grid-template-columns: 50px 1fr;
+        padding: 0;
+        white-space: pre;
+        line-height: 1.5;
+      }
+      .dline .gutter {
+        text-align: right;
+        padding-right: 12px;
+        color: var(--fg-mute);
+        user-select: none;
+        background: var(--pane-2);
+        border-right: 1px dashed var(--fg-mute);
+      }
+      .dline .l {
+        padding: 0 12px;
+        white-space: pre-wrap;
+      }
+      .dline.add {
+        background: var(--diff-add-bg);
+      }
+      .dline.add .l {
+        color: var(--diff-add-fg);
+      }
+      .dline.add .gutter::after {
+        content: " +";
+        color: var(--green);
+      }
+      .dline.del {
+        background: var(--diff-del-bg);
+      }
+      .dline.del .l {
+        color: var(--diff-del-fg);
+      }
+      .dline.del .gutter::after {
+        content: " -";
+        color: var(--red);
+      }
+      .dline.ctx .gutter::after {
+        content: "  ";
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+
+      .cmdbar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 12px;
+        background: var(--pane-2);
+        border-top: 1px solid var(--border);
+        font-size: 12px;
+        color: var(--fg-dim);
+        flex-wrap: wrap;
+      }
+      .cmdbar .key {
+        background: var(--accent);
+        color: var(--pane);
+        padding: 0 6px;
+        margin-right: 2px;
+      }
+
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--accent);
+        color: var(--pane);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      .btn {
+        display: inline-block;
+        padding: 1px 8px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+
+      @media (max-width: 820px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .col {
+          border-right: none;
+          border-bottom: 1px solid var(--border);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <div class="titlebar">
+        <div class="dots">
+          <span class="dot"></span><span class="dot y"></span
+          ><span class="dot g"></span>
+        </div>
+        <div class="ttitle">
+          <b>codeselfstudy</b>@neo: ~/community — tmux: lazygit · 1180×640
+        </div>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </div>
+
+      <div class="grid">
+        <div class="col">
+          <div class="panel">
+            <div class="pbar">
+              <span class="num">1</span>Status
+              <span class="keys">↑↓ · ?</span>
+            </div>
+            <div class="pbody">
+              <div>↓0 ↑3 <span style="color: var(--accent)">main</span></div>
+              <div style="color: var(--fg-dim); font-size: 12px">
+                codeselfstudy/community
+              </div>
+            </div>
+          </div>
+
+          <div class="panel">
+            <div class="pbar">
+              <span class="num">2</span>Files
+              <span class="keys">space stage · c commit</span>
+            </div>
+            <div class="pbody no-pad">
+              <div class="file-row">
+                <span class="add">M</span><span class="un">M</span
+                ><span class="name">community/welcome.md</span>
+              </div>
+              <div class="file-row">
+                <span class="add">A</span><span> </span
+                ><span class="name">events/2026-04-30-berkeley.md</span>
+              </div>
+              <div class="file-row">
+                <span> </span><span class="add">A</span
+                ><span class="name">events/2026-05-07-online.md</span>
+              </div>
+              <div class="file-row">
+                <span class="add">M</span><span> </span
+                ><span class="name">languages/supported.ts</span>
+              </div>
+              <div class="file-row">
+                <span> </span><span class="un">?</span
+                ><span class="name">notes/draft.md</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="panel active">
+            <div class="pbar">
+              <span class="num">3</span>Local branches
+              <span class="keys">n new · space switch</span>
+            </div>
+            <div class="pbody no-pad">
+              <div class="branch-row cur">
+                <span class="head name">main</span><span class="ahead">↑3</span>
+              </div>
+              <div class="branch-row">
+                <span class="name">events/2026-spring</span
+                ><span class="ahead">↑1</span>
+              </div>
+              <div class="branch-row">
+                <span class="name">learn/study-plans</span
+                ><span class="ahead">↑5 ↓2</span>
+              </div>
+              <div class="branch-row">
+                <span class="name">jobs/intros</span>
+              </div>
+              <div class="branch-row">
+                <span class="name">tools/regex-trainer</span>
+              </div>
+              <div class="branch-row">
+                <span class="name">forum/digest</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="panel last">
+            <div class="pbar">
+              <span class="num">4</span>Commits
+              <span class="keys">enter view · r rebase</span>
+            </div>
+            <div class="pbody no-pad">
+              <div class="commit-row">
+                <span class="hash">a91c4e2</span
+                ><span class="msg">welcome: 5,000+ members</span>
+              </div>
+              <div class="commit-row">
+                <span class="hash">7d3a118</span
+                ><span class="msg">events: april + may meetups</span>
+              </div>
+              <div class="commit-row">
+                <span class="hash">f24b8a9</span
+                ><span class="msg">add elixir + julia to supported langs</span>
+              </div>
+              <div class="commit-row">
+                <span class="hash">3e9c0d1</span
+                ><span class="msg">forum: weekly digest template</span>
+              </div>
+              <div class="commit-row">
+                <span class="hash">2b8f5c7</span
+                ><span class="msg">puzzles: day 7 solutions</span>
+              </div>
+              <div class="commit-row">
+                <span class="hash">88a112d</span
+                ><span class="msg">mentorship: study plan template</span>
+              </div>
+              <div class="commit-row">
+                <span class="hash">11b2e5a</span
+                ><span class="msg">init: code self study repo</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col last">
+          <div class="diff" style="flex: 1">
+            <div class="diff-head">
+              <b>community/welcome.md</b> &nbsp;<span
+                style="color: var(--fg-mute)"
+                >·</span
+              >&nbsp;
+              <span style="color: var(--accent)">+18</span>
+              <span style="color: var(--red)">−4</span>
+              &nbsp;<span style="color: var(--fg-mute)">·</span>&nbsp; ↑3 ahead
+              of origin/main
+            </div>
+            <div class="hunk">@@ -1,6 +1,20 @@ welcome page</div>
+            <div class="dline ctx">
+              <span class="gutter">1</span
+              ><span class="l"># Code Self Study</span>
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">2</span><span class="l"></span>
+            </div>
+            <div class="dline del">
+              <span class="gutter">3</span
+              ><span class="l"
+                >A programming community in the SF Bay Area.</span
+              >
+            </div>
+            <div class="dline add">
+              <span class="gutter">3</span
+              ><span class="l"
+                >A friendly programming community in the SF Bay Area &mdash;
+                est. 2014.</span
+              >
+            </div>
+            <div class="dline add">
+              <span class="gutter">4</span
+              ><span class="l"
+                >5,000+ members. All languages, all levels. In person +
+                online.</span
+              >
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">5</span><span class="l"></span>
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">6</span><span class="l">## what we do</span>
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">7</span><span class="l"></span>
+            </div>
+            <div class="dline del">
+              <span class="gutter">8</span><span class="l">- meetups</span>
+            </div>
+            <div class="dline del">
+              <span class="gutter">9</span><span class="l">- mentorship</span>
+            </div>
+            <div class="dline add">
+              <span class="gutter">8</span
+              ><span class="l"
+                >- build a local community of motivated programmers</span
+              >
+            </div>
+            <div class="dline add">
+              <span class="gutter">9</span
+              ><span class="l"
+                >- open to every language &amp; level &mdash; bring a
+                project</span
+              >
+            </div>
+            <div class="dline add">
+              <span class="gutter">10</span
+              ><span class="l"
+                >- self-study with mentorship from experienced members</span
+              >
+            </div>
+            <div class="dline add">
+              <span class="gutter">11</span
+              ><span class="l"
+                >- works as a bootcamp supplement &mdash; or alternative</span
+              >
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">12</span><span class="l"></span>
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">13</span><span class="l">## languages</span>
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">14</span><span class="l"></span>
+            </div>
+            <div class="dline del">
+              <span class="gutter">15</span
+              ><span class="l">python, js, go, rust, haskell, ...</span>
+            </div>
+            <div class="dline add">
+              <span class="gutter">15</span
+              ><span class="l"
+                >python · javascript · typescript · go · rust · haskell</span
+              >
+            </div>
+            <div class="dline add">
+              <span class="gutter">16</span
+              ><span class="l"
+                >clojure · elixir · racket · scheme · c · c++ · ruby</span
+              >
+            </div>
+            <div class="dline add">
+              <span class="gutter">17</span
+              ><span class="l"
+                >scala · erlang · elm · lua · sql · julia · r · + more</span
+              >
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">18</span><span class="l"></span>
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">19</span><span class="l">## join</span>
+            </div>
+            <div class="dline ctx">
+              <span class="gutter">20</span><span class="l"></span>
+            </div>
+            <div class="dline add">
+              <span class="gutter">21</span
+              ><span class="l"
+                >[meetup &raquo;](https://www.meetup.com/codeselfstudy/) ·
+                [forum](/forum) · [events](/events)<span class="blink"
+                  >▮</span
+                ></span
+              >
+            </div>
+          </div>
+
+          <div class="cmdbar">
+            <span><span class="key">␣</span>stage</span>
+            <span><span class="key">c</span>commit</span>
+            <span><span class="key">P</span>push</span>
+            <span><span class="key">p</span>pull</span>
+            <span><span class="key">b</span>branch</span>
+            <span><span class="key">r</span>rebase</span>
+            <span><span class="key">?</span>help</span>
+            <span style="margin-left: auto; color: var(--fg-dim)"
+              >ready to commit · 5 changes</span
+            >
+          </div>
+        </div>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win">0:btop</span>
+        <span class="win">1:nvim</span>
+        <span class="win active">2:lazygit*</span>
+        <span class="win">3:weechat</span>
+        <span class="win">4:yazi</span>
+        <span class="right"
+          >"neo" &nbsp;<a
+            class="btn"
+            href="https://www.meetup.com/codeselfstudy/"
+            >join meetup</a
+          >&nbsp; <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/60-tmux-irc.html
+++ b/mockups/60-tmux-irc.html
@@ -1,0 +1,741 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — tmux · weechat</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --orange: #ffb86b;
+        --red: #ff7a7a;
+        --green: #6ce46c;
+        --blue: #82b0ff;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --bar-bg: #1f4a1f;
+        --bar-fg: #c4ff5e;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.16);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --orange: #8a4a14;
+        --red: #8a1a2a;
+        --green: #1a5a2a;
+        --blue: #1a3a8a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --bar-bg: #1a1a14;
+        --bar-fg: #efe9d6;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.5;
+        min-height: 100vh;
+        padding: 24px;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      .term {
+        max-width: 1180px;
+        margin: 0 auto;
+        background: var(--pane);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.3),
+          0 18px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+
+      .titletop {
+        background: var(--bar-bg);
+        color: var(--bar-fg);
+        padding: 3px 12px;
+        font-size: 12px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        gap: 14px;
+      }
+      .titletop .info {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: 200px 1fr 200px;
+        min-height: 540px;
+      }
+      .col {
+        border-right: 1px solid var(--border);
+        background: var(--pane);
+        overflow: hidden;
+      }
+      .col.last {
+        border-right: none;
+      }
+      .col h4 {
+        margin: 0;
+        padding: 6px 10px;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--fg-dim);
+        font-weight: 500;
+        background: var(--pane-2);
+        border-bottom: 1px dashed var(--border);
+      }
+
+      .buflist ul,
+      .nicks ul {
+        list-style: none;
+        padding: 4px 0;
+        margin: 0;
+        font-size: 13px;
+      }
+      .buflist li,
+      .nicks li {
+        padding: 1px 12px;
+        cursor: pointer;
+      }
+      .buflist li:hover,
+      .nicks li:hover {
+        background: var(--pane-2);
+      }
+      .buflist li.cur {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .buflist li.cur .num,
+      .buflist li.cur .nm {
+        color: var(--pane);
+      }
+      .buflist li .num {
+        color: var(--fg-mute);
+        margin-right: 4px;
+      }
+      .buflist li .nm {
+        color: var(--fg);
+      }
+      .buflist .net {
+        color: var(--magenta);
+        padding: 6px 10px 2px;
+        font-size: 12px;
+      }
+      .buflist .badge {
+        float: right;
+        background: var(--red);
+        color: var(--pane);
+        font-size: 11px;
+        padding: 0 5px;
+        border-radius: 8px;
+      }
+      .buflist .badge.hl {
+        background: var(--accent);
+      }
+
+      .chat {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+      .topic {
+        padding: 4px 12px;
+        background: var(--bar-bg);
+        color: var(--bar-fg);
+        font-size: 12px;
+        border-bottom: 1px solid var(--border);
+      }
+      .topic b {
+        color: var(--yellow);
+      }
+      .log {
+        flex: 1;
+        padding: 6px 12px;
+        font-size: 13px;
+        line-height: 1.6;
+      }
+      .msg {
+        display: grid;
+        grid-template-columns: 60px 110px 1fr;
+        gap: 8px;
+        padding: 1px 0;
+      }
+      .msg .t {
+        color: var(--fg-mute);
+        font-size: 12px;
+      }
+      .msg .who {
+        text-align: right;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .msg .body {
+        color: var(--fg);
+        word-break: break-word;
+      }
+      .nick-1 {
+        color: var(--cyan);
+      }
+      .nick-2 {
+        color: var(--magenta);
+      }
+      .nick-3 {
+        color: var(--yellow);
+      }
+      .nick-4 {
+        color: var(--orange);
+      }
+      .nick-5 {
+        color: var(--green);
+      }
+      .nick-6 {
+        color: var(--blue);
+      }
+      .msg.sys .who {
+        color: var(--fg-mute);
+      }
+      .msg.sys .body {
+        color: var(--fg-dim);
+        font-style: italic;
+      }
+      .msg.bot .who {
+        color: var(--accent);
+      }
+      .msg.bot .body {
+        color: var(--fg);
+      }
+      .msg.bot .body b {
+        color: var(--accent);
+      }
+      .msg.act .who::before {
+        content: "* ";
+      }
+      .msg.act .who,
+      .msg.act .body {
+        color: var(--magenta);
+      }
+      .msg.hl {
+        background: rgba(196, 255, 94, 0.06);
+      }
+      .msg.hl .body {
+        color: var(--accent);
+      }
+      a.url {
+        color: var(--cyan);
+        text-decoration: underline;
+      }
+      .pill {
+        background: var(--accent);
+        color: var(--pane);
+        padding: 0 4px;
+      }
+
+      .statusbar {
+        display: flex;
+        gap: 14px;
+        background: var(--bar-bg);
+        color: var(--bar-fg);
+        font-size: 12px;
+        padding: 3px 12px;
+        border-top: 1px solid var(--border);
+      }
+      .statusbar .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      .input {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 5px 12px;
+        font-size: 13px;
+        background: var(--pane);
+      }
+      .input .nick {
+        color: var(--accent);
+      }
+      .input .pmt {
+        color: var(--fg-dim);
+      }
+      .input .typed {
+        flex: 1;
+        color: var(--fg);
+      }
+      .input .cur {
+        display: inline-block;
+        width: 8px;
+        height: 14px;
+        background: var(--accent);
+        vertical-align: -2px;
+        margin-left: 2px;
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+
+      .nicks li::before {
+        margin-right: 4px;
+        color: var(--fg-mute);
+      }
+      .nicks li.op::before {
+        content: "@";
+        color: var(--accent);
+      }
+      .nicks li.voice::before {
+        content: "+";
+        color: var(--cyan);
+      }
+      .nicks li.away {
+        color: var(--fg-mute);
+      }
+      .nicks li.away::before {
+        content: "·";
+      }
+      .nicks .count {
+        font-size: 11px;
+        color: var(--fg-dim);
+        padding: 2px 12px;
+      }
+
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--accent);
+        color: var(--pane);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      .btn {
+        display: inline-block;
+        padding: 1px 8px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+
+      @media (max-width: 860px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 160px 1fr;
+        }
+        .col.last {
+          display: none;
+        }
+      }
+      @media (max-width: 600px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .col.first {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <div class="titlebar">
+        <div class="dots">
+          <span class="dot"></span><span class="dot y"></span
+          ><span class="dot g"></span>
+        </div>
+        <div class="ttitle">
+          <b>codeselfstudy</b>@neo: ~/community — tmux: weechat · 1180×640
+        </div>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </div>
+
+      <div class="titletop">
+        <span>weechat 4.4.0</span>
+        <span>11 buffers</span>
+        <span class="info">codeselfstudy.chat · TLS · since 2014-04-09</span>
+      </div>
+
+      <div class="grid">
+        <aside class="col first buflist">
+          <h4>buffers</h4>
+          <div class="net">codeselfstudy</div>
+          <ul>
+            <li class="cur">
+              <span class="num">1.</span><span class="nm">#welcome</span>
+            </li>
+            <li>
+              <span class="num">2.</span><span class="nm">#beginners</span>
+              <span class="badge hl">3</span>
+            </li>
+            <li>
+              <span class="num">3.</span><span class="nm">#python</span>
+              <span class="badge">12</span>
+            </li>
+            <li>
+              <span class="num">4.</span><span class="nm">#javascript</span>
+            </li>
+            <li>
+              <span class="num">5.</span><span class="nm">#rust</span>
+              <span class="badge">2</span>
+            </li>
+            <li><span class="num">6.</span><span class="nm">#haskell</span></li>
+            <li><span class="num">7.</span><span class="nm">#clojure</span></li>
+            <li><span class="num">8.</span><span class="nm">#elixir</span></li>
+            <li>
+              <span class="num">9.</span><span class="nm">#jobs</span>
+              <span class="badge hl">1</span>
+            </li>
+            <li><span class="num">10.</span><span class="nm">#events</span></li>
+            <li>
+              <span class="num">11.</span><span class="nm">#puzzles</span>
+            </li>
+          </ul>
+          <div class="net">queries</div>
+          <ul>
+            <li>
+              <span class="num">12.</span><span class="nm">@mentor-bot</span>
+            </li>
+          </ul>
+        </aside>
+
+        <main class="chat">
+          <div class="topic">
+            <b>#welcome</b> · topic: a friendly programming community in the SF
+            Bay Area · est. 2014 · all langs, all levels · /join #beginners to
+            start
+          </div>
+
+          <div class="log">
+            <div class="msg sys">
+              <span class="t">17:54</span><span class="who">--</span
+              ><span class="body"
+                >You joined <b style="color: var(--accent)">#welcome</b> · 217
+                users · topic set by <span class="nick-1">sysop</span></span
+              >
+            </div>
+            <div class="msg bot">
+              <span class="t">17:54</span><span class="who">mentor-bot</span
+              ><span class="body"
+                >Hello! Code Self Study is <b>5,000+</b> programmers in Berkeley
+                and the SF Bay Area. We meet in person and online, weekly.
+                <b>All</b> languages, <b>all</b> levels.</span
+              >
+            </div>
+            <div class="msg bot">
+              <span class="t">17:54</span><span class="who">mentor-bot</span
+              ><span class="body"
+                >Type <span class="pill">/help</span> &mdash; or
+                <a class="url" href="https://www.meetup.com/codeselfstudy/"
+                  >https://www.meetup.com/codeselfstudy/</a
+                >
+                to RSVP for the next meetup.</span
+              >
+            </div>
+            <div class="msg">
+              <span class="t">18:02</span><span class="who nick-2">alice</span
+              ><span class="body"
+                >hi! first time here. been writing python for a year, want to
+                learn rust without burning out.</span
+              >
+            </div>
+            <div class="msg">
+              <span class="t">18:02</span><span class="who nick-3">bob</span
+              ><span class="body"
+                >welcome! /join #rust &mdash; we have a study group most
+                wednesdays at 7pm</span
+              >
+            </div>
+            <div class="msg">
+              <span class="t">18:03</span><span class="who nick-4">carol</span
+              ><span class="body"
+                >also #beginners is great even if you're not a beginner anymore
+                &mdash; lots of rubber-ducking</span
+              >
+            </div>
+            <div class="msg act">
+              <span class="t">18:04</span><span class="who nick-5">dan</span
+              ><span class="body"
+                >is updating the puzzle of the day &mdash; today: implement a
+                tiny json parser, any language</span
+              >
+            </div>
+            <div class="msg">
+              <span class="t">18:05</span><span class="who nick-6">eve</span
+              ><span class="body"
+                >btw the in-person meetup at the berkeley library is this
+                saturday 1pm. bring a laptop. or don't.</span
+              >
+            </div>
+            <div class="msg sys">
+              <span class="t">18:06</span><span class="who">--</span
+              ><span class="body"
+                ><span class="nick-1">frank</span> joined #welcome</span
+              >
+            </div>
+            <div class="msg">
+              <span class="t">18:06</span><span class="who nick-1">frank</span
+              ><span class="body"
+                >hey all &mdash; bootcamp grad, looking for project ideas /
+                accountability</span
+              >
+            </div>
+            <div class="msg">
+              <span class="t">18:07</span><span class="who nick-3">bob</span
+              ><span class="body"
+                >we run as a self-study group with mentorship. you bring the
+                project, we'll help with the plan. ask in #beginners and someone
+                will pair up.</span
+              >
+            </div>
+            <div class="msg hl">
+              <span class="t">18:08</span><span class="who nick-2">alice</span
+              ><span class="body">this is great. how do i join properly?</span>
+            </div>
+            <div class="msg bot">
+              <span class="t">18:08</span><span class="who">mentor-bot</span
+              ><span class="body"
+                >→ rsvp on meetup:
+                <a class="url" href="https://www.meetup.com/codeselfstudy/"
+                  >meetup.com/codeselfstudy</a
+                >
+                · /msg me <b>plan</b> for a study plan template ·
+                <span class="pill">all welcome</span></span
+              >
+            </div>
+            <div class="msg">
+              <span class="t">18:09</span><span class="who nick-5">dan</span
+              ><span class="body"
+                >languages we actively use here: python, js, ts, go, rust,
+                haskell, clojure, elixir, racket, scheme, ruby, c++, scala,
+                erlang, elm, lua, sql &mdash; and more in #other-langs</span
+              >
+            </div>
+          </div>
+
+          <div class="statusbar">
+            <span>[<span style="color: var(--accent)">18:11</span>]</span>
+            <span>[codeselfstudy] 1:#welcome(+nt)</span>
+            <span>217 nicks</span>
+            <span>(0/0/0)</span>
+            <span class="right">[H: 2:#beginners(3,hl), 9:#jobs(1,hl)]</span>
+          </div>
+          <div class="input">
+            <span class="nick">[you]</span><span class="pmt">›</span>
+            <span class="typed">/join #beginners<span class="cur"></span></span>
+          </div>
+        </main>
+
+        <aside class="col last nicks">
+          <h4>#welcome · 217</h4>
+          <ul>
+            <li class="op nick-1">sysop</li>
+            <li class="op nick-3">bob</li>
+            <li class="op nick-5">dan</li>
+            <li class="voice nick-2">alice</li>
+            <li class="voice nick-4">carol</li>
+            <li class="voice nick-6">eve</li>
+            <li class="nick-1">frank</li>
+            <li class="nick-2">grace</li>
+            <li class="nick-3">heng</li>
+            <li class="nick-4">irene</li>
+            <li class="nick-5">jess</li>
+            <li class="nick-6">kai</li>
+            <li class="away">leo</li>
+            <li class="away">mira</li>
+            <li class="away">nico</li>
+            <li class="away">otto</li>
+            <li class="away">priya</li>
+            <li class="count">… +200 more</li>
+          </ul>
+        </aside>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win">0:btop</span>
+        <span class="win">1:nvim</span>
+        <span class="win">2:lazygit</span>
+        <span class="win active">3:weechat*</span>
+        <span class="win">4:yazi</span>
+        <span class="right"
+          >"neo" &nbsp;<a
+            class="btn"
+            href="https://www.meetup.com/codeselfstudy/"
+            >join meetup</a
+          >&nbsp; <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/61-tmux-yazi.html
+++ b/mockups/61-tmux-yazi.html
@@ -1,0 +1,671 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — tmux · yazi</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --orange: #ffb86b;
+        --red: #ff7a7a;
+        --green: #6ce46c;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.16);
+        --scanline: rgba(0, 0, 0, 0.18);
+        --select: rgba(196, 255, 94, 0.16);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --orange: #8a4a14;
+        --red: #8a1a2a;
+        --green: #1a5a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+        --select: rgba(26, 74, 138, 0.14);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.5;
+        min-height: 100vh;
+        padding: 24px;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      .term {
+        max-width: 1180px;
+        margin: 0 auto;
+        background: var(--pane);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.3),
+          0 18px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+
+      .topbar {
+        display: flex;
+        gap: 14px;
+        padding: 5px 12px;
+        background: var(--pane-2);
+        border-bottom: 1px solid var(--border);
+        font-size: 12px;
+      }
+      .topbar .crumb {
+        color: var(--fg-dim);
+      }
+      .topbar .crumb b {
+        color: var(--accent);
+      }
+      .topbar .right {
+        margin-left: auto;
+        color: var(--fg-mute);
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: 1fr 1.4fr 2fr;
+        min-height: 560px;
+      }
+      .col {
+        border-right: 1px solid var(--border);
+        overflow: hidden;
+      }
+      .col.last {
+        border-right: none;
+      }
+      .col h4 {
+        margin: 0;
+        padding: 4px 12px;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--fg-dim);
+        font-weight: 500;
+        background: var(--pane-2);
+        border-bottom: 1px dashed var(--border);
+      }
+      ul.entries {
+        list-style: none;
+        padding: 4px 0;
+        margin: 0;
+        font-size: 13px;
+      }
+      ul.entries li {
+        padding: 1px 12px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      ul.entries li:hover {
+        background: var(--pane-2);
+      }
+      ul.entries li.cur {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      ul.entries li.cur .ic,
+      ul.entries li.cur .meta {
+        color: var(--pane);
+      }
+      ul.entries li.parent.cur {
+        background: var(--pane-2);
+        color: var(--accent);
+      }
+      ul.entries li.parent.cur .ic {
+        color: var(--accent);
+      }
+      ul.entries li.dir .ic {
+        color: var(--cyan);
+      }
+      ul.entries li.dir.cur .ic {
+        color: var(--pane);
+      }
+      ul.entries li.md .ic {
+        color: var(--magenta);
+      }
+      ul.entries li.code .ic {
+        color: var(--orange);
+      }
+      ul.entries li.toml .ic {
+        color: var(--yellow);
+      }
+      ul.entries li.exec .ic {
+        color: var(--green);
+      }
+      ul.entries li .ic {
+        margin-right: 6px;
+        color: var(--fg-dim);
+      }
+      ul.entries li .meta {
+        float: right;
+        color: var(--fg-mute);
+        font-size: 11px;
+      }
+      ul.entries li.sel {
+        color: var(--yellow);
+      }
+      ul.entries li.sel::before {
+        content: "✓ ";
+        color: var(--yellow);
+      }
+
+      /* preview pane */
+      .preview {
+        padding: 12px 16px;
+        font-size: 13.5px;
+        line-height: 1.55;
+      }
+      .preview h1 {
+        margin: 0 0 6px;
+        font-size: 20px;
+        color: var(--accent);
+      }
+      .preview h1::before {
+        content: "# ";
+        color: var(--fg-mute);
+      }
+      .preview h2 {
+        margin: 14px 0 4px;
+        font-size: 15px;
+        color: var(--yellow);
+      }
+      .preview h2::before {
+        content: "## ";
+        color: var(--fg-mute);
+      }
+      .preview p {
+        margin: 6px 0;
+        color: var(--fg);
+      }
+      .preview ul {
+        margin: 4px 0;
+        padding-left: 20px;
+      }
+      .preview ul li::marker {
+        color: var(--accent);
+      }
+      .preview .quote {
+        border-left: 2px solid var(--magenta);
+        padding-left: 10px;
+        color: var(--fg-dim);
+        font-style: italic;
+        margin: 8px 0;
+      }
+      .preview code {
+        background: var(--pane-2);
+        color: var(--orange);
+        padding: 0 4px;
+      }
+      .preview .codeblock {
+        background: var(--pane-2);
+        border: 1px dashed var(--border);
+        padding: 8px 12px;
+        white-space: pre;
+        font-size: 12.5px;
+        line-height: 1.5;
+        color: var(--fg);
+        overflow-x: auto;
+        margin: 8px 0;
+      }
+      .preview .codeblock .com {
+        color: var(--fg-dim);
+      }
+      .preview .codeblock .kw {
+        color: var(--magenta);
+      }
+      .preview .codeblock .str {
+        color: var(--orange);
+      }
+      .preview .codeblock .num {
+        color: var(--yellow);
+      }
+      .preview .codeblock .fn {
+        color: var(--cyan);
+      }
+      .preview a {
+        color: var(--cyan);
+        text-decoration: underline;
+      }
+      .preview .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+      }
+      .preview .langs span {
+        background: var(--pane-2);
+        color: var(--fg);
+        padding: 1px 8px;
+        border: 1px solid var(--border);
+      }
+      .preview .ctas {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 3px 12px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .btn.ghost {
+        border-color: var(--fg-dim);
+        color: var(--fg-dim);
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+
+      .statusbar {
+        display: flex;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--pane-2);
+        border-top: 1px solid var(--border);
+        font-size: 12px;
+        color: var(--fg-dim);
+        flex-wrap: wrap;
+      }
+      .statusbar .perm {
+        color: var(--accent);
+      }
+      .statusbar .who {
+        color: var(--cyan);
+      }
+      .statusbar .right {
+        margin-left: auto;
+      }
+
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--accent);
+        color: var(--pane);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+
+      @media (max-width: 860px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr 1fr;
+        }
+        .col.first {
+          display: none;
+        }
+      }
+      @media (max-width: 560px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .col.first,
+        .col.middle {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <div class="titlebar">
+        <div class="dots">
+          <span class="dot"></span><span class="dot y"></span
+          ><span class="dot g"></span>
+        </div>
+        <div class="ttitle">
+          <b>codeselfstudy</b>@neo: ~/community — tmux: yazi · 1180×640
+        </div>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </div>
+
+      <div class="topbar">
+        <span class="crumb">~/codeselfstudy/<b>community</b>/welcome.md</span>
+        <span class="right"
+          >24 items · 1 selected · sort: name · hidden: off</span
+        >
+      </div>
+
+      <div class="grid">
+        <aside class="col first">
+          <h4>~/codeselfstudy</h4>
+          <ul class="entries">
+            <li class="dir parent"><span class="ic"></span>..</li>
+            <li class="dir parent cur">
+              <span class="ic"></span>community<span class="meta"> </span>
+            </li>
+            <li class="dir parent"><span class="ic"></span>events</li>
+            <li class="dir parent"><span class="ic"></span>forum</li>
+            <li class="dir parent"><span class="ic"></span>jobs</li>
+            <li class="dir parent"><span class="ic"></span>languages</li>
+            <li class="dir parent"><span class="ic"></span>learn</li>
+            <li class="dir parent"><span class="ic"></span>puzzles</li>
+            <li class="dir parent"><span class="ic"></span>tools</li>
+            <li class="md parent"><span class="ic"></span>README.md</li>
+            <li class="exec parent"><span class="ic"></span>justfile</li>
+            <li class="toml parent"><span class="ic"></span>config.toml</li>
+          </ul>
+        </aside>
+
+        <main class="col middle">
+          <h4>community/</h4>
+          <ul class="entries">
+            <li class="dir">
+              <span class="ic"></span>..<span class="meta"> </span>
+            </li>
+            <li class="md">
+              <span class="ic"></span>about.md<span class="meta"> 1.2K</span>
+            </li>
+            <li class="md">
+              <span class="ic"></span>code-of-conduct.md<span class="meta">
+                3.8K</span
+              >
+            </li>
+            <li class="md">
+              <span class="ic"></span>history.md<span class="meta"> 4.1K</span>
+            </li>
+            <li class="md">
+              <span class="ic"></span>join.md<span class="meta"> 2.0K</span>
+            </li>
+            <li class="md">
+              <span class="ic"></span>mentorship.md<span class="meta">
+                1.8K</span
+              >
+            </li>
+            <li class="md">
+              <span class="ic"></span>networking.md<span class="meta">
+                0.9K</span
+              >
+            </li>
+            <li class="md sel">
+              <span class="ic"></span>study-plan.md<span class="meta">
+                2.6K</span
+              >
+            </li>
+            <li class="md cur">
+              <span class="ic"></span>welcome.md<span class="meta"> 3.4K</span>
+            </li>
+            <li class="md">
+              <span class="ic"></span>what-we-do.md<span class="meta">
+                1.5K</span
+              >
+            </li>
+            <li class="dir">
+              <span class="ic"></span>media/<span class="meta"> 18 items</span>
+            </li>
+            <li class="dir">
+              <span class="ic"></span>archive/<span class="meta">
+                92 items</span
+              >
+            </li>
+          </ul>
+        </main>
+
+        <aside class="col last">
+          <h4>· welcome.md · markdown · 3.4 KB</h4>
+          <div class="preview">
+            <h1>Code Self Study</h1>
+            <div class="quote">
+              A friendly programming community in the SF Bay Area &mdash; est.
+              2014. <b style="color: var(--yellow)">5,000+</b> members. All
+              languages, all levels. In person and online.
+            </div>
+
+            <h2>what we do</h2>
+            <ul>
+              <li>build a local community of motivated programmers</li>
+              <li>
+                open to every language &amp; level &mdash; bring a project
+              </li>
+              <li>self-study with mentorship from experienced members</li>
+              <li>works as a bootcamp supplement &mdash; or alternative</li>
+            </ul>
+
+            <h2>languages</h2>
+            <div class="langs">
+              <span>python</span><span>javascript</span><span>typescript</span
+              ><span>go</span><span>rust</span><span>haskell</span
+              ><span>clojure</span><span>elixir</span><span>racket</span
+              ><span>scheme</span><span>c</span><span>c++</span><span>ruby</span
+              ><span>scala</span><span>erlang</span><span>elm</span
+              ><span>lua</span><span>sql</span><span>+ more</span>
+            </div>
+
+            <h2>example</h2>
+            <pre
+              class="codeblock"
+            ><span class="com"># anybody can show up — bring a project, or borrow ours</span>
+<span class="kw">def</span> <span class="fn">join</span>(you):
+    you.languages = [<span class="str">"any"</span>]
+    you.level     = <span class="str">"any"</span>
+    <span class="kw">return</span> meet(you, <span class="num">5000</span>)
+</pre>
+
+            <h2>join</h2>
+            <p>
+              <a href="https://www.meetup.com/codeselfstudy/"
+                >https://www.meetup.com/codeselfstudy/</a
+              >
+            </p>
+            <div class="ctas">
+              <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+                >meetup ›</a
+              >
+              <a class="btn ghost" href="#">forum</a>
+              <a class="btn ghost" href="#">events</a>
+              <a class="btn ghost" href="#">puzzles</a>
+            </div>
+            <p style="color: var(--fg-mute); margin-top: 14px">
+              <span class="blink">▮</span> press <code>enter</code> to open ·
+              <code>q</code> to quit
+            </p>
+          </div>
+        </aside>
+      </div>
+
+      <div class="statusbar">
+        <span class="perm">-rw-r--r--</span>
+        <span class="who">user</span>
+        <span class="who" style="color: var(--magenta)">staff</span>
+        <span>3.4K</span>
+        <span>2026-04-26 18:42</span>
+        <span>welcome.md</span>
+        <span class="right">8/24 · 33%</span>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win">0:btop</span>
+        <span class="win">1:nvim</span>
+        <span class="win">2:lazygit</span>
+        <span class="win">3:weechat</span>
+        <span class="win active">4:yazi*</span>
+        <span class="right"
+          >"neo" &nbsp;<a
+            class="btn"
+            href="https://www.meetup.com/codeselfstudy/"
+            >join meetup</a
+          >&nbsp; <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/62-tmux-btop-v2.html
+++ b/mockups/62-tmux-btop-v2.html
@@ -1,0 +1,803 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — tmux · btop · v2</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --border-hi: #5cd65c;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --red: #ff7a7a;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --status-active: #ffe066;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.18);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --border-hi: #1a1a14;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --red: #8a1a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --status-active: #ffe066;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.45;
+        min-height: 100vh;
+        padding: 24px;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .term {
+        max-width: 1180px;
+        margin: 0 auto;
+        background: var(--pane);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.3),
+          0 18px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+        box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .navboxes {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        padding: 10px 12px;
+        background: var(--pane);
+        border-bottom: 1px solid var(--border);
+      }
+      .navboxes a {
+        font-size: 12px;
+        color: var(--fg-dim);
+        padding: 2px 10px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        text-decoration: none;
+        letter-spacing: 0.04em;
+      }
+      .navboxes a:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+        background: transparent;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: auto auto auto;
+        gap: 0;
+      }
+      .o1 {
+        order: 1;
+      }
+      .o2 {
+        order: 2;
+      }
+      .o3 {
+        order: 3;
+        border-bottom: none;
+      }
+      .o4 {
+        order: 4;
+        border-bottom: none;
+      }
+      .pane {
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        padding: 0;
+        background: var(--pane);
+      }
+      .pane.full {
+        grid-column: 1 / -1;
+        border-right: none;
+      }
+      .pane.last {
+        border-right: none;
+      }
+      .pane-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        color: var(--fg-dim);
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border);
+        background: var(--pane-2);
+      }
+      .pane-bar .lab {
+        color: var(--accent);
+      }
+      .pane-bar .lab.cyan {
+        color: var(--cyan);
+      }
+      .pane-bar .lab.mag {
+        color: var(--magenta);
+      }
+      .pane-bar .lab.yel {
+        color: var(--yellow);
+      }
+      .pane-bar .fill {
+        flex: 1;
+        border-bottom: 1px dashed var(--fg-mute);
+        margin: 0 4px;
+        height: 0;
+        transform: translateY(2px);
+      }
+      .pane-bar .keys {
+        color: var(--fg-mute);
+      }
+      .pane-body {
+        padding: 12px 14px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 90px 1fr 60px;
+        gap: 10px;
+        align-items: center;
+        padding: 1px 0;
+      }
+      .row .name {
+        color: var(--fg);
+      }
+      .row .pct {
+        text-align: right;
+        color: var(--accent);
+      }
+      .bar {
+        font-family: inherit;
+        color: var(--accent);
+        white-space: pre;
+        overflow: hidden;
+        letter-spacing: -1px;
+      }
+      .bar.cyan {
+        color: var(--cyan);
+      }
+      .bar.yel {
+        color: var(--yellow);
+      }
+      .bar.mag {
+        color: var(--magenta);
+      }
+      .meter-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        padding: 2px 0;
+      }
+      .meter-row .lbl {
+        width: 70px;
+        color: var(--fg-dim);
+      }
+      .meter-row .val {
+        margin-left: auto;
+        color: var(--accent);
+      }
+      .meter {
+        flex: 1;
+        height: 10px;
+        border: 1px solid var(--border);
+        background: var(--pane-2);
+        position: relative;
+      }
+      .meter > i {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        box-shadow: 0 0 6px var(--accent);
+      }
+      .meter.cyan > i {
+        background: var(--cyan);
+        box-shadow: 0 0 6px var(--cyan);
+      }
+      .meter.mag > i {
+        background: var(--magenta);
+        box-shadow: 0 0 6px var(--magenta);
+      }
+      .ascii {
+        white-space: pre;
+        color: var(--fg-dim);
+        margin: 0;
+        font-size: 11px;
+        line-height: 1.05;
+      }
+      .ascii .hi {
+        color: var(--accent);
+      }
+      .lead {
+        margin: 8px 0 4px;
+        color: var(--fg);
+      }
+      .lead b {
+        color: var(--yellow);
+      }
+      .ctas {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 4px 12px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .btn.ghost {
+        border-color: var(--fg-dim);
+        color: var(--fg-dim);
+      }
+      .btn.ghost:hover {
+        background: var(--fg-dim);
+        color: var(--pane);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 2px 8px 2px 0;
+        white-space: nowrap;
+      }
+      thead th {
+        color: var(--fg-dim);
+        border-bottom: 1px dashed var(--border);
+        font-weight: normal;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 11px;
+      }
+      tbody tr:hover {
+        background: var(--pane-2);
+      }
+      td.user {
+        color: var(--cyan);
+      }
+      td.pid {
+        color: var(--fg-dim);
+      }
+      td.cmd {
+        color: var(--fg);
+        white-space: normal;
+        width: 100%;
+      }
+      td.cpu,
+      td.mem {
+        color: var(--accent);
+        text-align: right;
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        margin-top: 6px;
+      }
+      .langs span {
+        color: var(--fg);
+      }
+      .langs span::before {
+        content: "▸ ";
+        color: var(--fg-mute);
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--status-active);
+        color: var(--status-bg);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      @media (max-width: 820px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .pane {
+          border-right: none;
+        }
+        .ttitle {
+          font-size: 11px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <div class="titlebar">
+        <div class="dots">
+          <span class="dot"></span><span class="dot y"></span
+          ><span class="dot g"></span>
+        </div>
+        <div class="ttitle"><b>codeselfstudy</b></div>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </div>
+
+      <nav class="navboxes" aria-label="primary">
+        <a href="#">home</a>
+        <a href="#">events</a>
+        <a href="#">learn</a>
+        <a href="#">forum</a>
+        <a href="#">jobs</a>
+        <a href="#">puzzles</a>
+        <a href="#">tools</a>
+        <a href="#">about</a>
+      </nav>
+
+      <div class="grid">
+        <!-- pane 0 : btop CPU (languages) -->
+        <div class="pane o3">
+          <div class="pane-bar">
+            <span>0</span><span class="lab">btop</span>
+            <span class="fill"></span>
+            <span class="keys">q quit · h help</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── cpu · languages in use ─────────────────────────
+            </div>
+            <div class="row">
+              <span class="name">python</span>
+              <span class="bar"
+                >█████████████████████████████████████████░░░░░</span
+              >
+              <span class="pct">62%</span>
+            </div>
+            <div class="row">
+              <span class="name">javascript</span>
+              <span class="bar cyan"
+                >██████████████████████████████████░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">54%</span>
+            </div>
+            <div class="row">
+              <span class="name">typescript</span>
+              <span class="bar cyan"
+                >███████████████████████████████░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">48%</span>
+            </div>
+            <div class="row">
+              <span class="name">go</span>
+              <span class="bar yel"
+                >████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">35%</span>
+            </div>
+            <div class="row">
+              <span class="name">rust</span>
+              <span class="bar yel"
+                >██████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">31%</span>
+            </div>
+            <div class="row">
+              <span class="name">haskell</span>
+              <span class="bar mag"
+                >██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">22%</span>
+            </div>
+            <div class="row">
+              <span class="name">clojure</span>
+              <span class="bar mag"
+                >████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">19%</span>
+            </div>
+            <div class="row">
+              <span class="name">elixir</span>
+              <span class="bar mag"
+                >███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">17%</span>
+            </div>
+            <div class="row">
+              <span class="name">racket</span>
+              <span class="bar"
+                >█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct">14%</span>
+            </div>
+            <div class="row">
+              <span class="name">+ 12 more</span>
+              <span class="bar" style="color: var(--fg-mute)"
+                >░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--fg-dim)">··</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 1 : MEM/NET (community) -->
+        <div class="pane last o4">
+          <div class="pane-bar">
+            <span>1</span><span class="lab cyan">mem · net</span>
+            <span class="fill"></span><span class="keys">e expand</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── community pool ─────────────────
+            </div>
+            <div class="meter-row">
+              <span class="lbl">members</span>
+              <span class="meter"><i style="width: 92%"></i></span>
+              <span class="val">5,000+</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">years up</span>
+              <span class="meter cyan"><i style="width: 82%"></i></span>
+              <span class="val" style="color: var(--cyan)">11</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">langs</span>
+              <span class="meter mag"><i style="width: 70%"></i></span>
+              <span class="val" style="color: var(--magenta)">20+</span>
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 6px">
+              ── net · this week ────────────────
+            </div>
+            <div style="color: var(--fg)">
+              ↓ <span style="color: var(--accent)">12</span> meetups / month
+            </div>
+            <div style="color: var(--fg)">
+              ↑ <span style="color: var(--cyan)">234</span> forum posts
+            </div>
+            <div style="color: var(--fg)">
+              ⇄ <span style="color: var(--yellow)">38</span> intros & jobs
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 4px">
+              ── load avg ───────────────────────
+            </div>
+            <pre
+              class="ascii"
+            ><span class="hi">▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅</span>
+12mo · steady &amp; rising</pre>
+          </div>
+        </div>
+
+        <!-- pane 2 : welcome / CTA -->
+        <div class="pane full o1">
+          <div class="pane-bar">
+            <span>2</span><span class="lab yel">★ codeselfstudy --intro</span>
+            <span class="fill"></span>
+            <span class="keys">prefix + ? help</span>
+          </div>
+          <div class="pane-body">
+            <pre class="ascii">
+  <span class="hi">code self study</span> · a friendly programming community in the san francisco bay area
+  <span class="hi">────────────────</span>   est. 2014 · all languages, all levels, in person + online</pre>
+            <p class="lead">
+              Self-study computer programming alongside <b>5,000+</b> members in
+              Berkeley and the SF Bay Area. Bring a project, bring a question,
+              or just show up. We meet in person and online.<span class="blink"
+                >▮</span
+              >
+            </p>
+            <div class="ctas">
+              <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+                >$ meetup --join</a
+              >
+              <a class="btn ghost" href="#">$ forum</a>
+              <a class="btn ghost" href="#">$ events --upcoming</a>
+              <a class="btn ghost" href="#">$ puzzles</a>
+            </div>
+            <div style="margin-top: 14px; color: var(--fg-dim)">
+              what we do ::
+            </div>
+            <div class="langs">
+              <span>build a local community of motivated programmers</span>
+              <span>open to every language &amp; level</span>
+              <span>self-study with mentorship from experienced members</span>
+              <span>bootcamp supplement or alternative</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 3 : process list (recent activity) -->
+        <div class="pane full o2">
+          <div class="pane-bar">
+            <span>3</span><span class="lab mag">proc · recent activity</span>
+            <span class="fill"></span>
+            <span class="keys">/ filter · k kill</span>
+          </div>
+          <div class="pane-body">
+            <table>
+              <thead>
+                <tr>
+                  <th>pid</th>
+                  <th>user</th>
+                  <th>cpu</th>
+                  <th>mem</th>
+                  <th>uptime</th>
+                  <th>cmd</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="pid">1284</td>
+                  <td class="user">alice</td>
+                  <td class="cpu">12.4</td>
+                  <td class="mem">8.2</td>
+                  <td class="pid">02:14</td>
+                  <td class="cmd">
+                    rustc puzzles/day-7.rs &nbsp;<span
+                      style="color: var(--fg-dim)"
+                      >· asked for review in #rust</span
+                    >
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1391</td>
+                  <td class="user">bob</td>
+                  <td class="cpu">24.1</td>
+                  <td class="mem">3.4</td>
+                  <td class="pid">00:42</td>
+                  <td class="cmd">
+                    meetup --where berkeley --in 3d &nbsp;<span
+                      style="color: var(--fg-dim)"
+                      >· 18 RSVPs</span
+                    >
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1432</td>
+                  <td class="user">carol</td>
+                  <td class="cpu">7.0</td>
+                  <td class="mem">4.1</td>
+                  <td class="pid">11:08</td>
+                  <td class="cmd">
+                    hs-projects/parser
+                    <span style="color: var(--accent)">← merged</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1518</td>
+                  <td class="user">dan</td>
+                  <td class="cpu">3.2</td>
+                  <td class="mem">2.0</td>
+                  <td class="pid">04:31</td>
+                  <td class="cmd">
+                    forum reply: "study plan for going from JS → systems"
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1607</td>
+                  <td class="user">eve</td>
+                  <td class="cpu">15.7</td>
+                  <td class="mem">6.8</td>
+                  <td class="pid">00:09</td>
+                  <td class="cmd">
+                    intro &nbsp;<span style="color: var(--yellow)"
+                      >job referral · backend role</span
+                    >
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1684</td>
+                  <td class="user">frank</td>
+                  <td class="cpu">9.3</td>
+                  <td class="mem">2.7</td>
+                  <td class="pid">06:55</td>
+                  <td class="cmd">
+                    tools/regex-trainer
+                    <span style="color: var(--cyan)">+ new contributor</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="pid">1711</td>
+                  <td class="user">grace</td>
+                  <td class="cpu">5.5</td>
+                  <td class="mem">1.9</td>
+                  <td class="pid">13:20</td>
+                  <td class="cmd">elixir/phoenix study group · weds 7pm</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win active">0:btop*</span>
+        <span class="win">1:nvim</span>
+        <span class="win">2:lazygit</span>
+        <span class="win">3:weechat</span>
+        <span class="win">4:yazi</span>
+        <span class="right"
+          >"neo" load 1.42 · ↑11y · <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/63-tmux-home.html
+++ b/mockups/63-tmux-home.html
@@ -1,0 +1,792 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — terminal home</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --border-hi: #5cd65c;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --red: #ff7a7a;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --status-active: #ffe066;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.18);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --border-hi: #1a1a14;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --red: #8a1a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --status-active: #ffe066;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.45;
+        min-height: 100vh;
+        padding: 24px;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .term {
+        max-width: 1180px;
+        margin: 0 auto;
+        background: var(--pane);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.3),
+          0 18px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+        box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .navboxes {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        padding: 10px 12px;
+        background: var(--pane);
+        border-bottom: 1px solid var(--border);
+      }
+      .navboxes a {
+        font-size: 12px;
+        color: var(--fg-dim);
+        padding: 2px 10px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        text-decoration: none;
+        letter-spacing: 0.04em;
+      }
+      .navboxes a:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+        background: transparent;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: auto auto auto;
+        gap: 0;
+      }
+      .o1 {
+        order: 1;
+      }
+      .o2 {
+        order: 2;
+      }
+      .o3 {
+        order: 3;
+        border-bottom: none;
+      }
+      .o4 {
+        order: 4;
+        border-bottom: none;
+      }
+      .pane {
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        padding: 0;
+        background: var(--pane);
+      }
+      .pane.full {
+        grid-column: 1 / -1;
+        border-right: none;
+      }
+      .pane.last {
+        border-right: none;
+      }
+      .pane-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        color: var(--fg-dim);
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border);
+        background: var(--pane-2);
+      }
+      .pane-bar .lab {
+        color: var(--accent);
+      }
+      .pane-bar .lab.cyan {
+        color: var(--cyan);
+      }
+      .pane-bar .lab.mag {
+        color: var(--magenta);
+      }
+      .pane-bar .lab.yel {
+        color: var(--yellow);
+      }
+      .pane-bar .fill {
+        flex: 1;
+        border-bottom: 1px dashed var(--fg-mute);
+        margin: 0 4px;
+        height: 0;
+        transform: translateY(2px);
+      }
+      .pane-bar .keys {
+        color: var(--fg-mute);
+      }
+      .pane-body {
+        padding: 12px 14px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 90px 1fr 60px;
+        gap: 10px;
+        align-items: center;
+        padding: 1px 0;
+      }
+      .row .name {
+        color: var(--fg);
+      }
+      .row .pct {
+        text-align: right;
+        color: var(--accent);
+      }
+      .bar {
+        font-family: inherit;
+        color: var(--accent);
+        white-space: pre;
+        overflow: hidden;
+        letter-spacing: -1px;
+      }
+      .bar.cyan {
+        color: var(--cyan);
+      }
+      .bar.yel {
+        color: var(--yellow);
+      }
+      .bar.mag {
+        color: var(--magenta);
+      }
+      .meter-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        padding: 2px 0;
+      }
+      .meter-row .lbl {
+        width: 70px;
+        color: var(--fg-dim);
+      }
+      .meter-row .val {
+        margin-left: auto;
+        color: var(--accent);
+      }
+      .meter {
+        flex: 1;
+        height: 10px;
+        border: 1px solid var(--border);
+        background: var(--pane-2);
+        position: relative;
+      }
+      .meter > i {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        box-shadow: 0 0 6px var(--accent);
+      }
+      .meter.cyan > i {
+        background: var(--cyan);
+        box-shadow: 0 0 6px var(--cyan);
+      }
+      .meter.mag > i {
+        background: var(--magenta);
+        box-shadow: 0 0 6px var(--magenta);
+      }
+      .ascii {
+        white-space: pre;
+        color: var(--fg-dim);
+        margin: 0;
+        font-size: 11px;
+        line-height: 1.05;
+      }
+      .ascii .hi {
+        color: var(--accent);
+      }
+      .lead {
+        margin: 8px 0 4px;
+        color: var(--fg);
+      }
+      .lead b {
+        color: var(--yellow);
+      }
+      .ctas {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 4px 12px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .btn.ghost {
+        border-color: var(--fg-dim);
+        color: var(--fg-dim);
+      }
+      .btn.ghost:hover {
+        background: var(--fg-dim);
+        color: var(--pane);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 2px 8px 2px 0;
+        white-space: nowrap;
+      }
+      thead th {
+        color: var(--fg-dim);
+        border-bottom: 1px dashed var(--border);
+        font-weight: normal;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 11px;
+      }
+      tbody tr:hover {
+        background: var(--pane-2);
+      }
+      td.user {
+        color: var(--cyan);
+      }
+      td.pid {
+        color: var(--fg-dim);
+      }
+      td.cmd {
+        color: var(--fg);
+        white-space: normal;
+        width: 100%;
+      }
+      td.cpu,
+      td.mem {
+        color: var(--accent);
+        text-align: right;
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        margin-top: 6px;
+      }
+      .langs span {
+        color: var(--fg);
+      }
+      .langs span::before {
+        content: "▸ ";
+        color: var(--fg-mute);
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--status-active);
+        color: var(--status-bg);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      @media (max-width: 820px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .pane {
+          border-right: none;
+        }
+        .ttitle {
+          font-size: 11px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <div class="titlebar">
+        <div class="dots">
+          <span class="dot"></span><span class="dot y"></span
+          ><span class="dot g"></span>
+        </div>
+        <div class="ttitle"><b>codeselfstudy</b></div>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </div>
+
+      <nav class="navboxes" aria-label="primary">
+        <a href="#">home</a>
+        <a href="#">events</a>
+        <a href="#">learn</a>
+        <a href="#">forum</a>
+        <a href="#">jobs</a>
+        <a href="#">puzzles</a>
+        <a href="#">tools</a>
+        <a href="#">about</a>
+      </nav>
+
+      <div class="grid">
+        <!-- pane 0 : languages -->
+        <div class="pane o3">
+          <div class="pane-bar">
+            <span>0</span><span class="lab">~/languages</span>
+            <span class="fill"></span>
+            <span class="keys">↑↓ scroll · / filter</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── languages used by members ──────────────────────
+            </div>
+            <div class="row">
+              <span class="name">python</span>
+              <span class="bar"
+                >█████████████████████████████████████████░░░░░</span
+              >
+              <span class="pct">62%</span>
+            </div>
+            <div class="row">
+              <span class="name">javascript</span>
+              <span class="bar cyan"
+                >██████████████████████████████████░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">54%</span>
+            </div>
+            <div class="row">
+              <span class="name">typescript</span>
+              <span class="bar cyan"
+                >███████████████████████████████░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">48%</span>
+            </div>
+            <div class="row">
+              <span class="name">go</span>
+              <span class="bar yel"
+                >████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">35%</span>
+            </div>
+            <div class="row">
+              <span class="name">rust</span>
+              <span class="bar yel"
+                >██████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">31%</span>
+            </div>
+            <div class="row">
+              <span class="name">haskell</span>
+              <span class="bar mag"
+                >██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">22%</span>
+            </div>
+            <div class="row">
+              <span class="name">clojure</span>
+              <span class="bar mag"
+                >████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">19%</span>
+            </div>
+            <div class="row">
+              <span class="name">elixir</span>
+              <span class="bar mag"
+                >███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">17%</span>
+            </div>
+            <div class="row">
+              <span class="name">racket</span>
+              <span class="bar"
+                >█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct">14%</span>
+            </div>
+            <div class="row">
+              <span class="name">+ 12 more</span>
+              <span class="bar" style="color: var(--fg-mute)"
+                >░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--fg-dim)">··</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 1 : stats -->
+        <div class="pane last o4">
+          <div class="pane-bar">
+            <span>1</span><span class="lab cyan">~/stats</span>
+            <span class="fill"></span><span class="keys">e expand</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── community ──────────────────────
+            </div>
+            <div class="meter-row">
+              <span class="lbl">members</span>
+              <span class="meter"><i style="width: 92%"></i></span>
+              <span class="val">5,000+</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">years up</span>
+              <span class="meter cyan"><i style="width: 82%"></i></span>
+              <span class="val" style="color: var(--cyan)">11</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">langs</span>
+              <span class="meter mag"><i style="width: 70%"></i></span>
+              <span class="val" style="color: var(--magenta)">20+</span>
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 6px">
+              ── net · this week ────────────────
+            </div>
+            <div style="color: var(--fg)">
+              ↓ <span style="color: var(--accent)">12</span> meetups / month
+            </div>
+            <div style="color: var(--fg)">
+              ↑ <span style="color: var(--cyan)">234</span> forum posts
+            </div>
+            <div style="color: var(--fg)">
+              ⇄ <span style="color: var(--yellow)">38</span> intros & jobs
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 4px">
+              ── load avg ───────────────────────
+            </div>
+            <pre
+              class="ascii"
+            ><span class="hi">▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅</span>
+12mo · steady &amp; rising</pre>
+          </div>
+        </div>
+
+        <!-- pane 2 : welcome / CTA -->
+        <div class="pane full o1">
+          <div class="pane-bar">
+            <span>2</span><span class="lab yel">~/welcome</span>
+            <span class="fill"></span>
+            <span class="keys">prefix + ? help</span>
+          </div>
+          <div class="pane-body">
+            <pre class="ascii">
+  <span class="hi">code self study</span> · a friendly programming community in the san francisco bay area
+  <span class="hi">────────────────</span>   est. 2014 · all languages, all levels, in person + online</pre>
+            <p class="lead">
+              Self-study computer programming alongside <b>5,000+</b> members in
+              Berkeley and the SF Bay Area. Bring a project, bring a question,
+              or just show up. We meet in person and online.<span class="blink"
+                >▮</span
+              >
+            </p>
+            <div class="ctas">
+              <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+                >$ meetup --join</a
+              >
+              <a class="btn ghost" href="#">$ forum</a>
+              <a class="btn ghost" href="#">$ events --upcoming</a>
+              <a class="btn ghost" href="#">$ puzzles</a>
+            </div>
+            <div style="margin-top: 14px; color: var(--fg-dim)">
+              what we do ::
+            </div>
+            <div class="langs">
+              <span>build a local community of motivated programmers</span>
+              <span>open to every language &amp; level</span>
+              <span>self-study with mentorship from experienced members</span>
+              <span>bootcamp supplement or alternative</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 3 : recent activity (forum) -->
+        <div class="pane full o2">
+          <div class="pane-bar">
+            <span>3</span><span class="lab mag">recent activity · forum</span>
+            <span class="fill"></span>
+            <span class="keys">↻ live · enter open</span>
+          </div>
+          <div class="pane-body">
+            <table>
+              <thead>
+                <tr>
+                  <th>when</th>
+                  <th>by</th>
+                  <th>category</th>
+                  <th>topic</th>
+                  <th style="text-align: right">replies</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="pid">2m</td>
+                  <td class="user">alice</td>
+                  <td><span style="color: var(--yellow)">#rust</span></td>
+                  <td class="cmd">
+                    code review on a tiny json parser &mdash; got it down to 180
+                    lines, can it be smaller?
+                  </td>
+                  <td class="cpu">8</td>
+                </tr>
+                <tr>
+                  <td class="pid">14m</td>
+                  <td class="user">bob</td>
+                  <td><span style="color: var(--cyan)">#events</span></td>
+                  <td class="cmd">
+                    in-person meetup · Berkeley library · sat 1pm
+                    <span style="color: var(--fg-dim)">· 18 RSVPs</span>
+                  </td>
+                  <td class="cpu">3</td>
+                </tr>
+                <tr>
+                  <td class="pid">42m</td>
+                  <td class="user">carol</td>
+                  <td><span style="color: var(--magenta)">#haskell</span></td>
+                  <td class="cmd">
+                    finally got <code>traverse</code> to click &mdash; short
+                    writeup with the aha moment
+                  </td>
+                  <td class="cpu">12</td>
+                </tr>
+                <tr>
+                  <td class="pid">1h</td>
+                  <td class="user">dan</td>
+                  <td>
+                    <span style="color: var(--accent)">#beginners</span>
+                  </td>
+                  <td class="cmd">
+                    study plan for going from JS → systems programming?
+                  </td>
+                  <td class="cpu">21</td>
+                </tr>
+                <tr>
+                  <td class="pid">3h</td>
+                  <td class="user">eve</td>
+                  <td><span style="color: #ffb86b">#jobs</span></td>
+                  <td class="cmd">
+                    backend role at a small SF startup &mdash; intros welcome
+                  </td>
+                  <td class="cpu">5</td>
+                </tr>
+                <tr>
+                  <td class="pid">5h</td>
+                  <td class="user">frank</td>
+                  <td><span style="color: var(--cyan)">#tools</span></td>
+                  <td class="cmd">
+                    regex-trainer · new contributor · added lookahead exercises
+                  </td>
+                  <td class="cpu">2</td>
+                </tr>
+                <tr>
+                  <td class="pid">8h</td>
+                  <td class="user">grace</td>
+                  <td><span style="color: var(--magenta)">#elixir</span></td>
+                  <td class="cmd">
+                    phoenix study group · weds 7pm · open to all levels
+                  </td>
+                  <td class="cpu">7</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win active">0:home*</span>
+        <span class="win">1:forum</span>
+        <span class="win">2:events</span>
+        <span class="win">3:learn</span>
+        <span class="win">4:jobs</span>
+        <span class="right"
+          >members 5,000+ · est. 2014 · <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/64-tmux-home-tracks.html
+++ b/mockups/64-tmux-home-tracks.html
@@ -1,0 +1,792 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — terminal home · tracks</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --border-hi: #5cd65c;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --red: #ff7a7a;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --status-active: #ffe066;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.18);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --border-hi: #1a1a14;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --red: #8a1a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --status-active: #ffe066;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.45;
+        min-height: 100vh;
+        padding: 24px;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .term {
+        max-width: 1180px;
+        margin: 0 auto;
+        background: var(--pane);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.3),
+          0 18px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+        box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .navboxes {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        padding: 10px 12px;
+        background: var(--pane);
+        border-bottom: 1px solid var(--border);
+      }
+      .navboxes a {
+        font-size: 12px;
+        color: var(--fg-dim);
+        padding: 2px 10px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        text-decoration: none;
+        letter-spacing: 0.04em;
+      }
+      .navboxes a:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+        background: transparent;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: auto auto auto;
+        gap: 0;
+      }
+      .o1 {
+        order: 1;
+      }
+      .o2 {
+        order: 2;
+      }
+      .o3 {
+        order: 3;
+        border-bottom: none;
+      }
+      .o4 {
+        order: 4;
+        border-bottom: none;
+      }
+      .pane {
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        padding: 0;
+        background: var(--pane);
+      }
+      .pane.full {
+        grid-column: 1 / -1;
+        border-right: none;
+      }
+      .pane.last {
+        border-right: none;
+      }
+      .pane-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        color: var(--fg-dim);
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border);
+        background: var(--pane-2);
+      }
+      .pane-bar .lab {
+        color: var(--accent);
+      }
+      .pane-bar .lab.cyan {
+        color: var(--cyan);
+      }
+      .pane-bar .lab.mag {
+        color: var(--magenta);
+      }
+      .pane-bar .lab.yel {
+        color: var(--yellow);
+      }
+      .pane-bar .fill {
+        flex: 1;
+        border-bottom: 1px dashed var(--fg-mute);
+        margin: 0 4px;
+        height: 0;
+        transform: translateY(2px);
+      }
+      .pane-bar .keys {
+        color: var(--fg-mute);
+      }
+      .pane-body {
+        padding: 12px 14px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 90px 1fr 60px;
+        gap: 10px;
+        align-items: center;
+        padding: 1px 0;
+      }
+      .row .name {
+        color: var(--fg);
+      }
+      .row .pct {
+        text-align: right;
+        color: var(--accent);
+      }
+      .bar {
+        font-family: inherit;
+        color: var(--accent);
+        white-space: pre;
+        overflow: hidden;
+        letter-spacing: -1px;
+      }
+      .bar.cyan {
+        color: var(--cyan);
+      }
+      .bar.yel {
+        color: var(--yellow);
+      }
+      .bar.mag {
+        color: var(--magenta);
+      }
+      .meter-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        padding: 2px 0;
+      }
+      .meter-row .lbl {
+        width: 70px;
+        color: var(--fg-dim);
+      }
+      .meter-row .val {
+        margin-left: auto;
+        color: var(--accent);
+      }
+      .meter {
+        flex: 1;
+        height: 10px;
+        border: 1px solid var(--border);
+        background: var(--pane-2);
+        position: relative;
+      }
+      .meter > i {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        box-shadow: 0 0 6px var(--accent);
+      }
+      .meter.cyan > i {
+        background: var(--cyan);
+        box-shadow: 0 0 6px var(--cyan);
+      }
+      .meter.mag > i {
+        background: var(--magenta);
+        box-shadow: 0 0 6px var(--magenta);
+      }
+      .ascii {
+        white-space: pre;
+        color: var(--fg-dim);
+        margin: 0;
+        font-size: 11px;
+        line-height: 1.05;
+      }
+      .ascii .hi {
+        color: var(--accent);
+      }
+      .lead {
+        margin: 8px 0 4px;
+        color: var(--fg);
+      }
+      .lead b {
+        color: var(--yellow);
+      }
+      .ctas {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 4px 12px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .btn.ghost {
+        border-color: var(--fg-dim);
+        color: var(--fg-dim);
+      }
+      .btn.ghost:hover {
+        background: var(--fg-dim);
+        color: var(--pane);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 2px 8px 2px 0;
+        white-space: nowrap;
+      }
+      thead th {
+        color: var(--fg-dim);
+        border-bottom: 1px dashed var(--border);
+        font-weight: normal;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 11px;
+      }
+      tbody tr:hover {
+        background: var(--pane-2);
+      }
+      td.user {
+        color: var(--cyan);
+      }
+      td.pid {
+        color: var(--fg-dim);
+      }
+      td.cmd {
+        color: var(--fg);
+        white-space: normal;
+        width: 100%;
+      }
+      td.cpu,
+      td.mem {
+        color: var(--accent);
+        text-align: right;
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        margin-top: 6px;
+      }
+      .langs span {
+        color: var(--fg);
+      }
+      .langs span::before {
+        content: "▸ ";
+        color: var(--fg-mute);
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--status-active);
+        color: var(--status-bg);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      @media (max-width: 820px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .pane {
+          border-right: none;
+        }
+        .ttitle {
+          font-size: 11px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <div class="titlebar">
+        <div class="dots">
+          <span class="dot"></span><span class="dot y"></span
+          ><span class="dot g"></span>
+        </div>
+        <div class="ttitle"><b>codeselfstudy</b></div>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </div>
+
+      <nav class="navboxes" aria-label="primary">
+        <a href="#">home</a>
+        <a href="#">events</a>
+        <a href="#">learn</a>
+        <a href="#">forum</a>
+        <a href="#">jobs</a>
+        <a href="#">puzzles</a>
+        <a href="#">tools</a>
+        <a href="#">about</a>
+      </nav>
+
+      <div class="grid">
+        <!-- pane 0 : tracks (what people are working on) -->
+        <div class="pane o3">
+          <div class="pane-bar">
+            <span>0</span><span class="lab">~/tracks</span>
+            <span class="fill"></span>
+            <span class="keys">↑↓ scroll · / filter</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── what people are working on this week ───────────
+            </div>
+            <div class="row">
+              <span class="name">web · frontend</span>
+              <span class="bar"
+                >█████████████████████████████████████████░░░░░</span
+              >
+              <span class="pct">62%</span>
+            </div>
+            <div class="row">
+              <span class="name">backend · api</span>
+              <span class="bar cyan"
+                >██████████████████████████████████░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">54%</span>
+            </div>
+            <div class="row">
+              <span class="name">data · ml</span>
+              <span class="bar cyan"
+                >███████████████████████████████░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">48%</span>
+            </div>
+            <div class="row">
+              <span class="name">systems</span>
+              <span class="bar yel"
+                >████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">35%</span>
+            </div>
+            <div class="row">
+              <span class="name">algorithms</span>
+              <span class="bar yel"
+                >██████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">31%</span>
+            </div>
+            <div class="row">
+              <span class="name">functional</span>
+              <span class="bar mag"
+                >██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">22%</span>
+            </div>
+            <div class="row">
+              <span class="name">devops · infra</span>
+              <span class="bar mag"
+                >████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">19%</span>
+            </div>
+            <div class="row">
+              <span class="name">games · gfx</span>
+              <span class="bar mag"
+                >███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">17%</span>
+            </div>
+            <div class="row">
+              <span class="name">embedded</span>
+              <span class="bar"
+                >█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct">14%</span>
+            </div>
+            <div class="row">
+              <span class="name">+ tag your own</span>
+              <span class="bar" style="color: var(--fg-mute)"
+                >░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--fg-dim)">··</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 1 : community at a glance -->
+        <div class="pane last o4">
+          <div class="pane-bar">
+            <span>1</span><span class="lab cyan">~/at-a-glance</span>
+            <span class="fill"></span><span class="keys">e expand</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── community ──────────────────────
+            </div>
+            <div class="meter-row">
+              <span class="lbl">members</span>
+              <span class="meter"><i style="width: 92%"></i></span>
+              <span class="val">5,000+</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">years up</span>
+              <span class="meter cyan"><i style="width: 82%"></i></span>
+              <span class="val" style="color: var(--cyan)">11</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">langs</span>
+              <span class="meter mag"><i style="width: 70%"></i></span>
+              <span class="val" style="color: var(--magenta)">20+</span>
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 6px">
+              ── net · this week ────────────────
+            </div>
+            <div style="color: var(--fg)">
+              ↓ <span style="color: var(--accent)">12</span> meetups / month
+            </div>
+            <div style="color: var(--fg)">
+              ↑ <span style="color: var(--cyan)">234</span> forum posts
+            </div>
+            <div style="color: var(--fg)">
+              ⇄ <span style="color: var(--yellow)">38</span> intros & jobs
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 4px">
+              ── load avg ───────────────────────
+            </div>
+            <pre
+              class="ascii"
+            ><span class="hi">▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅</span>
+12mo · steady &amp; rising</pre>
+          </div>
+        </div>
+
+        <!-- pane 2 : welcome / CTA -->
+        <div class="pane full o1">
+          <div class="pane-bar">
+            <span>2</span><span class="lab yel">~/welcome</span>
+            <span class="fill"></span>
+            <span class="keys">prefix + ? help</span>
+          </div>
+          <div class="pane-body">
+            <pre class="ascii">
+  <span class="hi">code self study</span> · a friendly programming community in the san francisco bay area
+  <span class="hi">────────────────</span>   est. 2014 · all languages, all levels, in person + online</pre>
+            <p class="lead">
+              Self-study computer programming alongside <b>5,000+</b> members in
+              Berkeley and the SF Bay Area. Bring a project, bring a question,
+              or just show up. We meet in person and online.<span class="blink"
+                >▮</span
+              >
+            </p>
+            <div class="ctas">
+              <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+                >$ meetup --join</a
+              >
+              <a class="btn ghost" href="#">$ forum</a>
+              <a class="btn ghost" href="#">$ events --upcoming</a>
+              <a class="btn ghost" href="#">$ puzzles</a>
+            </div>
+            <div style="margin-top: 14px; color: var(--fg-dim)">
+              what we do ::
+            </div>
+            <div class="langs">
+              <span>build a local community of motivated programmers</span>
+              <span>open to every language &amp; level</span>
+              <span>self-study with mentorship from experienced members</span>
+              <span>bootcamp supplement or alternative</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 3 : recent activity (forum) -->
+        <div class="pane full o2">
+          <div class="pane-bar">
+            <span>3</span><span class="lab mag">recent activity · forum</span>
+            <span class="fill"></span>
+            <span class="keys">↻ live · enter open</span>
+          </div>
+          <div class="pane-body">
+            <table>
+              <thead>
+                <tr>
+                  <th>when</th>
+                  <th>by</th>
+                  <th>category</th>
+                  <th>topic</th>
+                  <th style="text-align: right">replies</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="pid">2m</td>
+                  <td class="user">alice</td>
+                  <td><span style="color: var(--yellow)">#rust</span></td>
+                  <td class="cmd">
+                    code review on a tiny json parser &mdash; got it down to 180
+                    lines, can it be smaller?
+                  </td>
+                  <td class="cpu">8</td>
+                </tr>
+                <tr>
+                  <td class="pid">14m</td>
+                  <td class="user">bob</td>
+                  <td><span style="color: var(--cyan)">#events</span></td>
+                  <td class="cmd">
+                    in-person meetup · Berkeley library · sat 1pm
+                    <span style="color: var(--fg-dim)">· 18 RSVPs</span>
+                  </td>
+                  <td class="cpu">3</td>
+                </tr>
+                <tr>
+                  <td class="pid">42m</td>
+                  <td class="user">carol</td>
+                  <td><span style="color: var(--magenta)">#haskell</span></td>
+                  <td class="cmd">
+                    finally got <code>traverse</code> to click &mdash; short
+                    writeup with the aha moment
+                  </td>
+                  <td class="cpu">12</td>
+                </tr>
+                <tr>
+                  <td class="pid">1h</td>
+                  <td class="user">dan</td>
+                  <td>
+                    <span style="color: var(--accent)">#beginners</span>
+                  </td>
+                  <td class="cmd">
+                    study plan for going from JS → systems programming?
+                  </td>
+                  <td class="cpu">21</td>
+                </tr>
+                <tr>
+                  <td class="pid">3h</td>
+                  <td class="user">eve</td>
+                  <td><span style="color: #ffb86b">#jobs</span></td>
+                  <td class="cmd">
+                    backend role at a small SF startup &mdash; intros welcome
+                  </td>
+                  <td class="cpu">5</td>
+                </tr>
+                <tr>
+                  <td class="pid">5h</td>
+                  <td class="user">frank</td>
+                  <td><span style="color: var(--cyan)">#tools</span></td>
+                  <td class="cmd">
+                    regex-trainer · new contributor · added lookahead exercises
+                  </td>
+                  <td class="cpu">2</td>
+                </tr>
+                <tr>
+                  <td class="pid">8h</td>
+                  <td class="user">grace</td>
+                  <td><span style="color: var(--magenta)">#elixir</span></td>
+                  <td class="cmd">
+                    phoenix study group · weds 7pm · open to all levels
+                  </td>
+                  <td class="cpu">7</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win active">0:home*</span>
+        <span class="win">1:forum</span>
+        <span class="win">2:events</span>
+        <span class="win">3:learn</span>
+        <span class="win">4:jobs</span>
+        <span class="right"
+          >members 5,000+ · est. 2014 · <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/65-tmux-home-split.html
+++ b/mockups/65-tmux-home-split.html
@@ -1,0 +1,786 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — terminal home · meetups</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --border-hi: #5cd65c;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --red: #ff7a7a;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --status-active: #ffe066;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.18);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --border-hi: #1a1a14;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --red: #8a1a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --status-active: #ffe066;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.45;
+        min-height: 100vh;
+        padding: 24px;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .term {
+        max-width: 1180px;
+        margin: 0 auto;
+        background: var(--pane);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.3),
+          0 18px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+        box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .navboxes {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        padding: 10px 12px;
+        background: var(--pane);
+        border-bottom: 1px solid var(--border);
+      }
+      .navboxes a {
+        font-size: 12px;
+        color: var(--fg-dim);
+        padding: 2px 10px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        text-decoration: none;
+        letter-spacing: 0.04em;
+      }
+      .navboxes a:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+        background: transparent;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: auto auto auto;
+        gap: 0;
+      }
+      .o1 {
+        order: 1;
+      }
+      .o2 {
+        order: 2;
+      }
+      .o3 {
+        order: 3;
+        border-bottom: none;
+      }
+      .o4 {
+        order: 4;
+        border-bottom: none;
+      }
+      .pane {
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        padding: 0;
+        background: var(--pane);
+      }
+      .pane.full {
+        grid-column: 1 / -1;
+        border-right: none;
+      }
+      .pane.last {
+        border-right: none;
+      }
+      .pane-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        color: var(--fg-dim);
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border);
+        background: var(--pane-2);
+      }
+      .pane-bar .lab {
+        color: var(--accent);
+      }
+      .pane-bar .lab.cyan {
+        color: var(--cyan);
+      }
+      .pane-bar .lab.mag {
+        color: var(--magenta);
+      }
+      .pane-bar .lab.yel {
+        color: var(--yellow);
+      }
+      .pane-bar .fill {
+        flex: 1;
+        border-bottom: 1px dashed var(--fg-mute);
+        margin: 0 4px;
+        height: 0;
+        transform: translateY(2px);
+      }
+      .pane-bar .keys {
+        color: var(--fg-mute);
+      }
+      .pane-body {
+        padding: 12px 14px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 90px 1fr 60px;
+        gap: 10px;
+        align-items: center;
+        padding: 1px 0;
+      }
+      .row .name {
+        color: var(--fg);
+      }
+      .row .pct {
+        text-align: right;
+        color: var(--accent);
+      }
+      .bar {
+        font-family: inherit;
+        color: var(--accent);
+        white-space: pre;
+        overflow: hidden;
+        letter-spacing: -1px;
+      }
+      .bar.cyan {
+        color: var(--cyan);
+      }
+      .bar.yel {
+        color: var(--yellow);
+      }
+      .bar.mag {
+        color: var(--magenta);
+      }
+      .meter-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        padding: 2px 0;
+      }
+      .meter-row .lbl {
+        width: 70px;
+        color: var(--fg-dim);
+      }
+      .meter-row .val {
+        margin-left: auto;
+        color: var(--accent);
+      }
+      .meter {
+        flex: 1;
+        height: 10px;
+        border: 1px solid var(--border);
+        background: var(--pane-2);
+        position: relative;
+      }
+      .meter > i {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        box-shadow: 0 0 6px var(--accent);
+      }
+      .meter.cyan > i {
+        background: var(--cyan);
+        box-shadow: 0 0 6px var(--cyan);
+      }
+      .meter.mag > i {
+        background: var(--magenta);
+        box-shadow: 0 0 6px var(--magenta);
+      }
+      .ascii {
+        white-space: pre;
+        color: var(--fg-dim);
+        margin: 0;
+        font-size: 11px;
+        line-height: 1.05;
+      }
+      .ascii .hi {
+        color: var(--accent);
+      }
+      .lead {
+        margin: 8px 0 4px;
+        color: var(--fg);
+      }
+      .lead b {
+        color: var(--yellow);
+      }
+      .ctas {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 4px 12px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .btn.ghost {
+        border-color: var(--fg-dim);
+        color: var(--fg-dim);
+      }
+      .btn.ghost:hover {
+        background: var(--fg-dim);
+        color: var(--pane);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 2px 8px 2px 0;
+        white-space: nowrap;
+      }
+      thead th {
+        color: var(--fg-dim);
+        border-bottom: 1px dashed var(--border);
+        font-weight: normal;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 11px;
+      }
+      tbody tr:hover {
+        background: var(--pane-2);
+      }
+      td.user {
+        color: var(--cyan);
+      }
+      td.pid {
+        color: var(--fg-dim);
+      }
+      td.cmd {
+        color: var(--fg);
+        white-space: normal;
+        width: 100%;
+      }
+      td.cpu,
+      td.mem {
+        color: var(--accent);
+        text-align: right;
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        margin-top: 6px;
+      }
+      .langs span {
+        color: var(--fg);
+      }
+      .langs span::before {
+        content: "▸ ";
+        color: var(--fg-mute);
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--status-active);
+        color: var(--status-bg);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      @media (max-width: 820px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .pane {
+          border-right: none;
+        }
+        .ttitle {
+          font-size: 11px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <div class="titlebar">
+        <div class="dots">
+          <span class="dot"></span><span class="dot y"></span
+          ><span class="dot g"></span>
+        </div>
+        <div class="ttitle"><b>codeselfstudy</b></div>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </div>
+
+      <nav class="navboxes" aria-label="primary">
+        <a href="#">home</a>
+        <a href="#">events</a>
+        <a href="#">learn</a>
+        <a href="#">forum</a>
+        <a href="#">jobs</a>
+        <a href="#">puzzles</a>
+        <a href="#">tools</a>
+        <a href="#">about</a>
+      </nav>
+
+      <div class="grid">
+        <!-- pane 0 : upcoming meetups -->
+        <div class="pane o3">
+          <div class="pane-bar">
+            <span>0</span><span class="lab">~/upcoming</span>
+            <span class="fill"></span>
+            <span class="keys">↵ rsvp · / filter</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── meetups, study groups, events ──────────────────
+            </div>
+            <div class="row" style="grid-template-columns: 110px 1fr 80px">
+              <span class="name" style="color: var(--accent)"
+                >sat · 1:00pm</span
+              >
+              <span style="color: var(--fg)">
+                in-person meetup · Berkeley public library
+              </span>
+              <span class="pct">18 in</span>
+            </div>
+            <div class="row" style="grid-template-columns: 110px 1fr 80px">
+              <span class="name" style="color: var(--cyan)">mon · 7:00pm</span>
+              <span style="color: var(--fg)">
+                study group · functional programming · online
+              </span>
+              <span class="pct" style="color: var(--cyan)">9 in</span>
+            </div>
+            <div class="row" style="grid-template-columns: 110px 1fr 80px">
+              <span class="name" style="color: var(--yellow)"
+                >tue · 6:30pm</span
+              >
+              <span style="color: var(--fg)">
+                project night · bring a thing you're stuck on
+              </span>
+              <span class="pct" style="color: var(--yellow)">14 in</span>
+            </div>
+            <div class="row" style="grid-template-columns: 110px 1fr 80px">
+              <span class="name" style="color: var(--magenta)"
+                >weds · 7:00pm</span
+              >
+              <span style="color: var(--fg)">
+                phoenix / elixir study group · all levels
+              </span>
+              <span class="pct" style="color: var(--magenta)">7 in</span>
+            </div>
+            <div class="row" style="grid-template-columns: 110px 1fr 80px">
+              <span class="name" style="color: var(--accent)"
+                >thu · 12:00pm</span
+              >
+              <span style="color: var(--fg)">
+                coworking lunch · Oakland · drop in
+              </span>
+              <span class="pct">5 in</span>
+            </div>
+            <div class="row" style="grid-template-columns: 110px 1fr 80px">
+              <span class="name" style="color: var(--cyan)">fri · 5:30pm</span>
+              <span style="color: var(--fg)">
+                puzzle of the week · pair up online
+              </span>
+              <span class="pct" style="color: var(--cyan)">11 in</span>
+            </div>
+            <div class="row" style="grid-template-columns: 110px 1fr 80px">
+              <span class="name" style="color: var(--fg-dim)">next sat</span>
+              <span style="color: var(--fg)">
+                in-person meetup · SF · location TBA
+              </span>
+              <span class="pct" style="color: var(--fg-dim)">soon</span>
+            </div>
+            <div class="row" style="grid-template-columns: 110px 1fr 80px">
+              <span class="name" style="color: var(--fg-mute)">+ more</span>
+              <span style="color: var(--fg-dim)">
+                see all on the meetup page
+              </span>
+              <span class="pct" style="color: var(--fg-dim)">···</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 1 : community at a glance -->
+        <div class="pane last o4">
+          <div class="pane-bar">
+            <span>1</span><span class="lab cyan">~/at-a-glance</span>
+            <span class="fill"></span><span class="keys">e expand</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── community ──────────────────────
+            </div>
+            <div class="meter-row">
+              <span class="lbl">members</span>
+              <span class="meter"><i style="width: 92%"></i></span>
+              <span class="val">5,000+</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">years up</span>
+              <span class="meter cyan"><i style="width: 82%"></i></span>
+              <span class="val" style="color: var(--cyan)">11</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">langs</span>
+              <span class="meter mag"><i style="width: 70%"></i></span>
+              <span class="val" style="color: var(--magenta)">20+</span>
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 6px">
+              ── net · this week ────────────────
+            </div>
+            <div style="color: var(--fg)">
+              ↓ <span style="color: var(--accent)">12</span> meetups / month
+            </div>
+            <div style="color: var(--fg)">
+              ↑ <span style="color: var(--cyan)">234</span> forum posts
+            </div>
+            <div style="color: var(--fg)">
+              ⇄ <span style="color: var(--yellow)">38</span> intros & jobs
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 4px">
+              ── load avg ───────────────────────
+            </div>
+            <pre
+              class="ascii"
+            ><span class="hi">▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅</span>
+12mo · steady &amp; rising</pre>
+          </div>
+        </div>
+
+        <!-- pane 2 : welcome / CTA -->
+        <div class="pane full o1">
+          <div class="pane-bar">
+            <span>2</span><span class="lab yel">~/welcome</span>
+            <span class="fill"></span>
+            <span class="keys">prefix + ? help</span>
+          </div>
+          <div class="pane-body">
+            <pre class="ascii">
+  <span class="hi">code self study</span> · a friendly programming community in the san francisco bay area
+  <span class="hi">────────────────</span>   est. 2014 · all languages, all levels, in person + online</pre>
+            <p class="lead">
+              Self-study computer programming alongside <b>5,000+</b> members in
+              Berkeley and the SF Bay Area. Bring a project, bring a question,
+              or just show up. We meet in person and online.<span class="blink"
+                >▮</span
+              >
+            </p>
+            <div class="ctas">
+              <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+                >$ meetup --join</a
+              >
+              <a class="btn ghost" href="#">$ forum</a>
+              <a class="btn ghost" href="#">$ events --upcoming</a>
+              <a class="btn ghost" href="#">$ puzzles</a>
+            </div>
+            <div style="margin-top: 14px; color: var(--fg-dim)">
+              what we do ::
+            </div>
+            <div class="langs">
+              <span>build a local community of motivated programmers</span>
+              <span>open to every language &amp; level</span>
+              <span>self-study with mentorship from experienced members</span>
+              <span>bootcamp supplement or alternative</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 3 : recent activity (forum) -->
+        <div class="pane full o2">
+          <div class="pane-bar">
+            <span>3</span><span class="lab mag">recent activity · forum</span>
+            <span class="fill"></span>
+            <span class="keys">↻ live · enter open</span>
+          </div>
+          <div class="pane-body">
+            <table>
+              <thead>
+                <tr>
+                  <th>when</th>
+                  <th>by</th>
+                  <th>category</th>
+                  <th>topic</th>
+                  <th style="text-align: right">replies</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="pid">2m</td>
+                  <td class="user">alice</td>
+                  <td><span style="color: var(--yellow)">#rust</span></td>
+                  <td class="cmd">
+                    code review on a tiny json parser &mdash; got it down to 180
+                    lines, can it be smaller?
+                  </td>
+                  <td class="cpu">8</td>
+                </tr>
+                <tr>
+                  <td class="pid">14m</td>
+                  <td class="user">bob</td>
+                  <td><span style="color: var(--cyan)">#events</span></td>
+                  <td class="cmd">
+                    in-person meetup · Berkeley library · sat 1pm
+                    <span style="color: var(--fg-dim)">· 18 RSVPs</span>
+                  </td>
+                  <td class="cpu">3</td>
+                </tr>
+                <tr>
+                  <td class="pid">42m</td>
+                  <td class="user">carol</td>
+                  <td><span style="color: var(--magenta)">#haskell</span></td>
+                  <td class="cmd">
+                    finally got <code>traverse</code> to click &mdash; short
+                    writeup with the aha moment
+                  </td>
+                  <td class="cpu">12</td>
+                </tr>
+                <tr>
+                  <td class="pid">1h</td>
+                  <td class="user">dan</td>
+                  <td>
+                    <span style="color: var(--accent)">#beginners</span>
+                  </td>
+                  <td class="cmd">
+                    study plan for going from JS → systems programming?
+                  </td>
+                  <td class="cpu">21</td>
+                </tr>
+                <tr>
+                  <td class="pid">3h</td>
+                  <td class="user">eve</td>
+                  <td><span style="color: #ffb86b">#jobs</span></td>
+                  <td class="cmd">
+                    backend role at a small SF startup &mdash; intros welcome
+                  </td>
+                  <td class="cpu">5</td>
+                </tr>
+                <tr>
+                  <td class="pid">5h</td>
+                  <td class="user">frank</td>
+                  <td><span style="color: var(--cyan)">#tools</span></td>
+                  <td class="cmd">
+                    regex-trainer · new contributor · added lookahead exercises
+                  </td>
+                  <td class="cpu">2</td>
+                </tr>
+                <tr>
+                  <td class="pid">8h</td>
+                  <td class="user">grace</td>
+                  <td><span style="color: var(--magenta)">#elixir</span></td>
+                  <td class="cmd">
+                    phoenix study group · weds 7pm · open to all levels
+                  </td>
+                  <td class="cpu">7</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win active">0:home*</span>
+        <span class="win">1:forum</span>
+        <span class="win">2:events</span>
+        <span class="win">3:learn</span>
+        <span class="win">4:jobs</span>
+        <span class="right"
+          >members 5,000+ · est. 2014 · <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/66-tmux-home-frameless.html
+++ b/mockups/66-tmux-home-frameless.html
@@ -1,0 +1,801 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — terminal home · frameless</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --border-hi: #5cd65c;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --red: #ff7a7a;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --status-active: #ffe066;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.18);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --border-hi: #1a1a14;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --red: #8a1a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --status-active: #ffe066;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--pane);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.45;
+        min-height: 100vh;
+        padding: 0;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .term {
+        max-width: none;
+        margin: 0;
+        background: var(--pane);
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+        overflow: visible;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+        box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .navboxes {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 10px 14px;
+        background: var(--pane);
+        border-bottom: 1px solid var(--border);
+      }
+      .navboxes .brand {
+        color: var(--fg);
+        font-size: 13px;
+        margin-right: 12px;
+        letter-spacing: 0.04em;
+      }
+      .navboxes .brand b {
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .navboxes a {
+        font-size: 12px;
+        color: var(--fg-dim);
+        padding: 2px 10px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        text-decoration: none;
+        letter-spacing: 0.04em;
+      }
+      .navboxes a:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+        background: transparent;
+      }
+      .navboxes .toggle {
+        margin-left: auto;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: auto auto auto;
+        gap: 0;
+        flex: 1;
+      }
+      .o1 {
+        order: 1;
+      }
+      .o2 {
+        order: 2;
+      }
+      .o3 {
+        order: 3;
+        border-bottom: none;
+      }
+      .o4 {
+        order: 4;
+        border-bottom: none;
+      }
+      .pane {
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        padding: 0;
+        background: var(--pane);
+      }
+      .pane.full {
+        grid-column: 1 / -1;
+        border-right: none;
+      }
+      .pane.last {
+        border-right: none;
+      }
+      .pane-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        color: var(--fg-dim);
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border);
+        background: var(--pane-2);
+      }
+      .pane-bar .lab {
+        color: var(--accent);
+      }
+      .pane-bar .lab.cyan {
+        color: var(--cyan);
+      }
+      .pane-bar .lab.mag {
+        color: var(--magenta);
+      }
+      .pane-bar .lab.yel {
+        color: var(--yellow);
+      }
+      .pane-bar .fill {
+        flex: 1;
+        border-bottom: 1px dashed var(--fg-mute);
+        margin: 0 4px;
+        height: 0;
+        transform: translateY(2px);
+      }
+      .pane-bar .keys {
+        color: var(--fg-mute);
+      }
+      .pane-body {
+        padding: 12px 14px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 90px 1fr 60px;
+        gap: 10px;
+        align-items: center;
+        padding: 1px 0;
+      }
+      .row .name {
+        color: var(--fg);
+      }
+      .row .pct {
+        text-align: right;
+        color: var(--accent);
+      }
+      .bar {
+        font-family: inherit;
+        color: var(--accent);
+        white-space: pre;
+        overflow: hidden;
+        letter-spacing: -1px;
+      }
+      .bar.cyan {
+        color: var(--cyan);
+      }
+      .bar.yel {
+        color: var(--yellow);
+      }
+      .bar.mag {
+        color: var(--magenta);
+      }
+      .meter-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        padding: 2px 0;
+      }
+      .meter-row .lbl {
+        width: 70px;
+        color: var(--fg-dim);
+      }
+      .meter-row .val {
+        margin-left: auto;
+        color: var(--accent);
+      }
+      .meter {
+        flex: 1;
+        height: 10px;
+        border: 1px solid var(--border);
+        background: var(--pane-2);
+        position: relative;
+      }
+      .meter > i {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        box-shadow: 0 0 6px var(--accent);
+      }
+      .meter.cyan > i {
+        background: var(--cyan);
+        box-shadow: 0 0 6px var(--cyan);
+      }
+      .meter.mag > i {
+        background: var(--magenta);
+        box-shadow: 0 0 6px var(--magenta);
+      }
+      .ascii {
+        white-space: pre;
+        color: var(--fg-dim);
+        margin: 0;
+        font-size: 11px;
+        line-height: 1.05;
+      }
+      .ascii .hi {
+        color: var(--accent);
+      }
+      .lead {
+        margin: 8px 0 4px;
+        color: var(--fg);
+      }
+      .lead b {
+        color: var(--yellow);
+      }
+      .ctas {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 4px 12px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .btn.ghost {
+        border-color: var(--fg-dim);
+        color: var(--fg-dim);
+      }
+      .btn.ghost:hover {
+        background: var(--fg-dim);
+        color: var(--pane);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 2px 8px 2px 0;
+        white-space: nowrap;
+      }
+      thead th {
+        color: var(--fg-dim);
+        border-bottom: 1px dashed var(--border);
+        font-weight: normal;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 11px;
+      }
+      tbody tr:hover {
+        background: var(--pane-2);
+      }
+      td.user {
+        color: var(--cyan);
+      }
+      td.pid {
+        color: var(--fg-dim);
+      }
+      td.cmd {
+        color: var(--fg);
+        white-space: normal;
+        width: 100%;
+      }
+      td.cpu,
+      td.mem {
+        color: var(--accent);
+        text-align: right;
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        margin-top: 6px;
+      }
+      .langs span {
+        color: var(--fg);
+      }
+      .langs span::before {
+        content: "▸ ";
+        color: var(--fg-mute);
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--status-active);
+        color: var(--status-bg);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      @media (max-width: 820px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .pane {
+          border-right: none;
+        }
+        .ttitle {
+          font-size: 11px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <nav class="navboxes" aria-label="primary">
+        <span class="brand"><b>codeselfstudy</b></span>
+        <a href="#">home</a>
+        <a href="#">events</a>
+        <a href="#">learn</a>
+        <a href="#">forum</a>
+        <a href="#">jobs</a>
+        <a href="#">puzzles</a>
+        <a href="#">tools</a>
+        <a href="#">about</a>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </nav>
+
+      <div class="grid">
+        <!-- pane 0 : languages -->
+        <div class="pane o3">
+          <div class="pane-bar">
+            <span>0</span><span class="lab">~/languages</span>
+            <span class="fill"></span>
+            <span class="keys">↑↓ scroll · / filter</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── languages used by members ──────────────────────
+            </div>
+            <div class="row">
+              <span class="name">python</span>
+              <span class="bar"
+                >█████████████████████████████████████████░░░░░</span
+              >
+              <span class="pct">62%</span>
+            </div>
+            <div class="row">
+              <span class="name">javascript</span>
+              <span class="bar cyan"
+                >██████████████████████████████████░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">54%</span>
+            </div>
+            <div class="row">
+              <span class="name">typescript</span>
+              <span class="bar cyan"
+                >███████████████████████████████░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">48%</span>
+            </div>
+            <div class="row">
+              <span class="name">go</span>
+              <span class="bar yel"
+                >████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">35%</span>
+            </div>
+            <div class="row">
+              <span class="name">rust</span>
+              <span class="bar yel"
+                >██████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">31%</span>
+            </div>
+            <div class="row">
+              <span class="name">haskell</span>
+              <span class="bar mag"
+                >██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">22%</span>
+            </div>
+            <div class="row">
+              <span class="name">clojure</span>
+              <span class="bar mag"
+                >████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">19%</span>
+            </div>
+            <div class="row">
+              <span class="name">elixir</span>
+              <span class="bar mag"
+                >███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">17%</span>
+            </div>
+            <div class="row">
+              <span class="name">racket</span>
+              <span class="bar"
+                >█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct">14%</span>
+            </div>
+            <div class="row">
+              <span class="name">+ 12 more</span>
+              <span class="bar" style="color: var(--fg-mute)"
+                >░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--fg-dim)">··</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 1 : stats -->
+        <div class="pane last o4">
+          <div class="pane-bar">
+            <span>1</span><span class="lab cyan">~/stats</span>
+            <span class="fill"></span><span class="keys">e expand</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── community ──────────────────────
+            </div>
+            <div class="meter-row">
+              <span class="lbl">members</span>
+              <span class="meter"><i style="width: 92%"></i></span>
+              <span class="val">5,000+</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">years up</span>
+              <span class="meter cyan"><i style="width: 82%"></i></span>
+              <span class="val" style="color: var(--cyan)">11</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">langs</span>
+              <span class="meter mag"><i style="width: 70%"></i></span>
+              <span class="val" style="color: var(--magenta)">20+</span>
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 6px">
+              ── net · this week ────────────────
+            </div>
+            <div style="color: var(--fg)">
+              ↓ <span style="color: var(--accent)">12</span> meetups / month
+            </div>
+            <div style="color: var(--fg)">
+              ↑ <span style="color: var(--cyan)">234</span> forum posts
+            </div>
+            <div style="color: var(--fg)">
+              ⇄ <span style="color: var(--yellow)">38</span> intros & jobs
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 4px">
+              ── load avg ───────────────────────
+            </div>
+            <pre
+              class="ascii"
+            ><span class="hi">▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅</span>
+12mo · steady &amp; rising</pre>
+          </div>
+        </div>
+
+        <!-- pane 2 : welcome / CTA -->
+        <div class="pane full o1">
+          <div class="pane-bar">
+            <span>2</span><span class="lab yel">~/welcome</span>
+            <span class="fill"></span>
+            <span class="keys">prefix + ? help</span>
+          </div>
+          <div class="pane-body">
+            <pre class="ascii">
+  <span class="hi">code self study</span> · a friendly programming community in the san francisco bay area
+  <span class="hi">────────────────</span>   est. 2014 · all languages, all levels, in person + online</pre>
+            <p class="lead">
+              Self-study computer programming alongside <b>5,000+</b> members in
+              Berkeley and the SF Bay Area. Bring a project, bring a question,
+              or just show up. We meet in person and online.<span class="blink"
+                >▮</span
+              >
+            </p>
+            <div class="ctas">
+              <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+                >$ meetup --join</a
+              >
+              <a class="btn ghost" href="#">$ forum</a>
+              <a class="btn ghost" href="#">$ events --upcoming</a>
+              <a class="btn ghost" href="#">$ puzzles</a>
+            </div>
+            <div style="margin-top: 14px; color: var(--fg-dim)">
+              what we do ::
+            </div>
+            <div class="langs">
+              <span>build a local community of motivated programmers</span>
+              <span>open to every language &amp; level</span>
+              <span>self-study with mentorship from experienced members</span>
+              <span>bootcamp supplement or alternative</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 3 : recent activity (forum) -->
+        <div class="pane full o2">
+          <div class="pane-bar">
+            <span>3</span><span class="lab mag">recent activity · forum</span>
+            <span class="fill"></span>
+            <span class="keys">↻ live · enter open</span>
+          </div>
+          <div class="pane-body">
+            <table>
+              <thead>
+                <tr>
+                  <th>when</th>
+                  <th>by</th>
+                  <th>category</th>
+                  <th>topic</th>
+                  <th style="text-align: right">replies</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="pid">2m</td>
+                  <td class="user">alice</td>
+                  <td><span style="color: var(--yellow)">#rust</span></td>
+                  <td class="cmd">
+                    code review on a tiny json parser &mdash; got it down to 180
+                    lines, can it be smaller?
+                  </td>
+                  <td class="cpu">8</td>
+                </tr>
+                <tr>
+                  <td class="pid">14m</td>
+                  <td class="user">bob</td>
+                  <td><span style="color: var(--cyan)">#events</span></td>
+                  <td class="cmd">
+                    in-person meetup · Berkeley library · sat 1pm
+                    <span style="color: var(--fg-dim)">· 18 RSVPs</span>
+                  </td>
+                  <td class="cpu">3</td>
+                </tr>
+                <tr>
+                  <td class="pid">42m</td>
+                  <td class="user">carol</td>
+                  <td><span style="color: var(--magenta)">#haskell</span></td>
+                  <td class="cmd">
+                    finally got <code>traverse</code> to click &mdash; short
+                    writeup with the aha moment
+                  </td>
+                  <td class="cpu">12</td>
+                </tr>
+                <tr>
+                  <td class="pid">1h</td>
+                  <td class="user">dan</td>
+                  <td>
+                    <span style="color: var(--accent)">#beginners</span>
+                  </td>
+                  <td class="cmd">
+                    study plan for going from JS → systems programming?
+                  </td>
+                  <td class="cpu">21</td>
+                </tr>
+                <tr>
+                  <td class="pid">3h</td>
+                  <td class="user">eve</td>
+                  <td><span style="color: #ffb86b">#jobs</span></td>
+                  <td class="cmd">
+                    backend role at a small SF startup &mdash; intros welcome
+                  </td>
+                  <td class="cpu">5</td>
+                </tr>
+                <tr>
+                  <td class="pid">5h</td>
+                  <td class="user">frank</td>
+                  <td><span style="color: var(--cyan)">#tools</span></td>
+                  <td class="cmd">
+                    regex-trainer · new contributor · added lookahead exercises
+                  </td>
+                  <td class="cpu">2</td>
+                </tr>
+                <tr>
+                  <td class="pid">8h</td>
+                  <td class="user">grace</td>
+                  <td><span style="color: var(--magenta)">#elixir</span></td>
+                  <td class="cmd">
+                    phoenix study group · weds 7pm · open to all levels
+                  </td>
+                  <td class="cpu">7</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win active">0:home*</span>
+        <span class="win">1:forum</span>
+        <span class="win">2:events</span>
+        <span class="win">3:learn</span>
+        <span class="win">4:jobs</span>
+        <span class="right"
+          >members 5,000+ · est. 2014 · <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/67-tmux-home-frameless-cta.html
+++ b/mockups/67-tmux-home-frameless-cta.html
@@ -1,0 +1,798 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — terminal home · frameless · single CTA</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --border-hi: #5cd65c;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --red: #ff7a7a;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --status-active: #ffe066;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.18);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --border-hi: #1a1a14;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --red: #8a1a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --status-active: #ffe066;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--pane);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.45;
+        min-height: 100vh;
+        padding: 0;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .term {
+        max-width: none;
+        margin: 0;
+        background: var(--pane);
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+        overflow: visible;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+        box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .navboxes {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 10px 14px;
+        background: var(--pane);
+        border-bottom: 1px solid var(--border);
+      }
+      .navboxes .brand {
+        color: var(--fg);
+        font-size: 13px;
+        margin-right: 12px;
+        letter-spacing: 0.04em;
+      }
+      .navboxes .brand b {
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .navboxes a {
+        font-size: 12px;
+        color: var(--fg-dim);
+        padding: 2px 10px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        text-decoration: none;
+        letter-spacing: 0.04em;
+      }
+      .navboxes a:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+        background: transparent;
+      }
+      .navboxes .toggle {
+        margin-left: auto;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: auto auto auto;
+        gap: 0;
+        flex: 1;
+      }
+      .o1 {
+        order: 1;
+      }
+      .o2 {
+        order: 2;
+      }
+      .o3 {
+        order: 3;
+        border-bottom: none;
+      }
+      .o4 {
+        order: 4;
+        border-bottom: none;
+      }
+      .pane {
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        padding: 0;
+        background: var(--pane);
+      }
+      .pane.full {
+        grid-column: 1 / -1;
+        border-right: none;
+      }
+      .pane.last {
+        border-right: none;
+      }
+      .pane-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        color: var(--fg-dim);
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border);
+        background: var(--pane-2);
+      }
+      .pane-bar .lab {
+        color: var(--accent);
+      }
+      .pane-bar .lab.cyan {
+        color: var(--cyan);
+      }
+      .pane-bar .lab.mag {
+        color: var(--magenta);
+      }
+      .pane-bar .lab.yel {
+        color: var(--yellow);
+      }
+      .pane-bar .fill {
+        flex: 1;
+        border-bottom: 1px dashed var(--fg-mute);
+        margin: 0 4px;
+        height: 0;
+        transform: translateY(2px);
+      }
+      .pane-bar .keys {
+        color: var(--fg-mute);
+      }
+      .pane-body {
+        padding: 12px 14px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 90px 1fr 60px;
+        gap: 10px;
+        align-items: center;
+        padding: 1px 0;
+      }
+      .row .name {
+        color: var(--fg);
+      }
+      .row .pct {
+        text-align: right;
+        color: var(--accent);
+      }
+      .bar {
+        font-family: inherit;
+        color: var(--accent);
+        white-space: pre;
+        overflow: hidden;
+        letter-spacing: -1px;
+      }
+      .bar.cyan {
+        color: var(--cyan);
+      }
+      .bar.yel {
+        color: var(--yellow);
+      }
+      .bar.mag {
+        color: var(--magenta);
+      }
+      .meter-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        padding: 2px 0;
+      }
+      .meter-row .lbl {
+        width: 70px;
+        color: var(--fg-dim);
+      }
+      .meter-row .val {
+        margin-left: auto;
+        color: var(--accent);
+      }
+      .meter {
+        flex: 1;
+        height: 10px;
+        border: 1px solid var(--border);
+        background: var(--pane-2);
+        position: relative;
+      }
+      .meter > i {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        box-shadow: 0 0 6px var(--accent);
+      }
+      .meter.cyan > i {
+        background: var(--cyan);
+        box-shadow: 0 0 6px var(--cyan);
+      }
+      .meter.mag > i {
+        background: var(--magenta);
+        box-shadow: 0 0 6px var(--magenta);
+      }
+      .ascii {
+        white-space: pre;
+        color: var(--fg-dim);
+        margin: 0;
+        font-size: 11px;
+        line-height: 1.05;
+      }
+      .ascii .hi {
+        color: var(--accent);
+      }
+      .lead {
+        margin: 8px 0 4px;
+        color: var(--fg);
+      }
+      .lead b {
+        color: var(--yellow);
+      }
+      .ctas {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 4px 12px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .btn.ghost {
+        border-color: var(--fg-dim);
+        color: var(--fg-dim);
+      }
+      .btn.ghost:hover {
+        background: var(--fg-dim);
+        color: var(--pane);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 2px 8px 2px 0;
+        white-space: nowrap;
+      }
+      thead th {
+        color: var(--fg-dim);
+        border-bottom: 1px dashed var(--border);
+        font-weight: normal;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 11px;
+      }
+      tbody tr:hover {
+        background: var(--pane-2);
+      }
+      td.user {
+        color: var(--cyan);
+      }
+      td.pid {
+        color: var(--fg-dim);
+      }
+      td.cmd {
+        color: var(--fg);
+        white-space: normal;
+        width: 100%;
+      }
+      td.cpu,
+      td.mem {
+        color: var(--accent);
+        text-align: right;
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        margin-top: 6px;
+      }
+      .langs span {
+        color: var(--fg);
+      }
+      .langs span::before {
+        content: "▸ ";
+        color: var(--fg-mute);
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--status-active);
+        color: var(--status-bg);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      @media (max-width: 820px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .pane {
+          border-right: none;
+        }
+        .ttitle {
+          font-size: 11px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <nav class="navboxes" aria-label="primary">
+        <span class="brand"><b>codeselfstudy</b></span>
+        <a href="#">home</a>
+        <a href="#">events</a>
+        <a href="#">learn</a>
+        <a href="#">forum</a>
+        <a href="#">jobs</a>
+        <a href="#">puzzles</a>
+        <a href="#">tools</a>
+        <a href="#">about</a>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </nav>
+
+      <div class="grid">
+        <!-- pane 0 : languages -->
+        <div class="pane o3">
+          <div class="pane-bar">
+            <span>0</span><span class="lab">~/languages</span>
+            <span class="fill"></span>
+            <span class="keys">↑↓ scroll · / filter</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── languages used by members ──────────────────────
+            </div>
+            <div class="row">
+              <span class="name">python</span>
+              <span class="bar"
+                >█████████████████████████████████████████░░░░░</span
+              >
+              <span class="pct">62%</span>
+            </div>
+            <div class="row">
+              <span class="name">javascript</span>
+              <span class="bar cyan"
+                >██████████████████████████████████░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">54%</span>
+            </div>
+            <div class="row">
+              <span class="name">typescript</span>
+              <span class="bar cyan"
+                >███████████████████████████████░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">48%</span>
+            </div>
+            <div class="row">
+              <span class="name">go</span>
+              <span class="bar yel"
+                >████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">35%</span>
+            </div>
+            <div class="row">
+              <span class="name">rust</span>
+              <span class="bar yel"
+                >██████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">31%</span>
+            </div>
+            <div class="row">
+              <span class="name">haskell</span>
+              <span class="bar mag"
+                >██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">22%</span>
+            </div>
+            <div class="row">
+              <span class="name">clojure</span>
+              <span class="bar mag"
+                >████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">19%</span>
+            </div>
+            <div class="row">
+              <span class="name">elixir</span>
+              <span class="bar mag"
+                >███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">17%</span>
+            </div>
+            <div class="row">
+              <span class="name">racket</span>
+              <span class="bar"
+                >█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct">14%</span>
+            </div>
+            <div class="row">
+              <span class="name">+ 12 more</span>
+              <span class="bar" style="color: var(--fg-mute)"
+                >░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--fg-dim)">··</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 1 : stats -->
+        <div class="pane last o4">
+          <div class="pane-bar">
+            <span>1</span><span class="lab cyan">~/stats</span>
+            <span class="fill"></span><span class="keys">e expand</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── community ──────────────────────
+            </div>
+            <div class="meter-row">
+              <span class="lbl">members</span>
+              <span class="meter"><i style="width: 92%"></i></span>
+              <span class="val">5,000+</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">years up</span>
+              <span class="meter cyan"><i style="width: 82%"></i></span>
+              <span class="val" style="color: var(--cyan)">11</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">langs</span>
+              <span class="meter mag"><i style="width: 70%"></i></span>
+              <span class="val" style="color: var(--magenta)">20+</span>
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 6px">
+              ── net · this week ────────────────
+            </div>
+            <div style="color: var(--fg)">
+              ↓ <span style="color: var(--accent)">12</span> meetups / month
+            </div>
+            <div style="color: var(--fg)">
+              ↑ <span style="color: var(--cyan)">234</span> forum posts
+            </div>
+            <div style="color: var(--fg)">
+              ⇄ <span style="color: var(--yellow)">38</span> intros & jobs
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 4px">
+              ── load avg ───────────────────────
+            </div>
+            <pre
+              class="ascii"
+            ><span class="hi">▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅</span>
+12mo · steady &amp; rising</pre>
+          </div>
+        </div>
+
+        <!-- pane 2 : welcome / CTA -->
+        <div class="pane full o1">
+          <div class="pane-bar">
+            <span>2</span><span class="lab yel">~/welcome</span>
+            <span class="fill"></span>
+            <span class="keys">prefix + ? help</span>
+          </div>
+          <div class="pane-body">
+            <pre class="ascii">
+  <span class="hi">code self study</span> · a friendly programming community in the san francisco bay area
+  <span class="hi">────────────────</span>   est. 2014 · all languages, all levels, in person + online</pre>
+            <p class="lead">
+              Self-study computer programming alongside <b>5,000+</b> members in
+              Berkeley and the SF Bay Area. Bring a project, bring a question,
+              or just show up. We meet in person and online.<span class="blink"
+                >▮</span
+              >
+            </p>
+            <div class="ctas">
+              <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+                >Join</a
+              >
+            </div>
+            <div style="margin-top: 14px; color: var(--fg-dim)">
+              what we do ::
+            </div>
+            <div class="langs">
+              <span>build a local community of motivated programmers</span>
+              <span>open to every language &amp; level</span>
+              <span>self-study with mentorship from experienced members</span>
+              <span>bootcamp supplement or alternative</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 3 : recent activity (forum) -->
+        <div class="pane full o2">
+          <div class="pane-bar">
+            <span>3</span><span class="lab mag">recent activity · forum</span>
+            <span class="fill"></span>
+            <span class="keys">↻ live · enter open</span>
+          </div>
+          <div class="pane-body">
+            <table>
+              <thead>
+                <tr>
+                  <th>when</th>
+                  <th>by</th>
+                  <th>category</th>
+                  <th>topic</th>
+                  <th style="text-align: right">replies</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="pid">2m</td>
+                  <td class="user">alice</td>
+                  <td><span style="color: var(--yellow)">#rust</span></td>
+                  <td class="cmd">
+                    code review on a tiny json parser &mdash; got it down to 180
+                    lines, can it be smaller?
+                  </td>
+                  <td class="cpu">8</td>
+                </tr>
+                <tr>
+                  <td class="pid">14m</td>
+                  <td class="user">bob</td>
+                  <td><span style="color: var(--cyan)">#events</span></td>
+                  <td class="cmd">
+                    in-person meetup · Berkeley library · sat 1pm
+                    <span style="color: var(--fg-dim)">· 18 RSVPs</span>
+                  </td>
+                  <td class="cpu">3</td>
+                </tr>
+                <tr>
+                  <td class="pid">42m</td>
+                  <td class="user">carol</td>
+                  <td><span style="color: var(--magenta)">#haskell</span></td>
+                  <td class="cmd">
+                    finally got <code>traverse</code> to click &mdash; short
+                    writeup with the aha moment
+                  </td>
+                  <td class="cpu">12</td>
+                </tr>
+                <tr>
+                  <td class="pid">1h</td>
+                  <td class="user">dan</td>
+                  <td>
+                    <span style="color: var(--accent)">#beginners</span>
+                  </td>
+                  <td class="cmd">
+                    study plan for going from JS → systems programming?
+                  </td>
+                  <td class="cpu">21</td>
+                </tr>
+                <tr>
+                  <td class="pid">3h</td>
+                  <td class="user">eve</td>
+                  <td><span style="color: #ffb86b">#jobs</span></td>
+                  <td class="cmd">
+                    backend role at a small SF startup &mdash; intros welcome
+                  </td>
+                  <td class="cpu">5</td>
+                </tr>
+                <tr>
+                  <td class="pid">5h</td>
+                  <td class="user">frank</td>
+                  <td><span style="color: var(--cyan)">#tools</span></td>
+                  <td class="cmd">
+                    regex-trainer · new contributor · added lookahead exercises
+                  </td>
+                  <td class="cpu">2</td>
+                </tr>
+                <tr>
+                  <td class="pid">8h</td>
+                  <td class="user">grace</td>
+                  <td><span style="color: var(--magenta)">#elixir</span></td>
+                  <td class="cmd">
+                    phoenix study group · weds 7pm · open to all levels
+                  </td>
+                  <td class="cpu">7</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win active">0:home*</span>
+        <span class="win">1:forum</span>
+        <span class="win">2:events</span>
+        <span class="win">3:learn</span>
+        <span class="win">4:jobs</span>
+        <span class="right"
+          >members 5,000+ · est. 2014 · <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/68-tmux-home-cta-below.html
+++ b/mockups/68-tmux-home-cta-below.html
@@ -1,0 +1,796 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — terminal home · CTA below what-we-do</title>
+    <style>
+      :root {
+        --bg: #050805;
+        --pane: #0a0f0a;
+        --pane-2: #0d130d;
+        --fg: #b8f5b8;
+        --fg-dim: #4a7a4a;
+        --fg-mute: #2a4a2a;
+        --border: #2a5a2a;
+        --border-hi: #5cd65c;
+        --accent: #c4ff5e;
+        --magenta: #ff7ac6;
+        --cyan: #66ddff;
+        --yellow: #ffe066;
+        --red: #ff7a7a;
+        --status-bg: #1f4a1f;
+        --status-fg: #050805;
+        --status-active: #ffe066;
+        --dot-red: #ff5f56;
+        --dot-yellow: #ffbd2e;
+        --dot-green: #27c93f;
+        --glow: rgba(184, 245, 184, 0.18);
+        --scanline: rgba(0, 0, 0, 0.18);
+      }
+      [data-theme="light"] {
+        --bg: #d8d2c0;
+        --pane: #efe9d6;
+        --pane-2: #e6dfca;
+        --fg: #1a1a14;
+        --fg-dim: #6a6860;
+        --fg-mute: #a8a294;
+        --border: #807a6a;
+        --border-hi: #1a1a14;
+        --accent: #1a4a8a;
+        --magenta: #8a1a5a;
+        --cyan: #1a6a8a;
+        --yellow: #6a5a00;
+        --red: #8a1a2a;
+        --status-bg: #1a1a14;
+        --status-fg: #efe9d6;
+        --status-active: #ffe066;
+        --dot-red: #b8513f;
+        --dot-yellow: #b88a1f;
+        --dot-green: #2a8a35;
+        --glow: rgba(26, 26, 20, 0);
+        --scanline: rgba(0, 0, 0, 0.04);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--pane);
+        color: var(--fg);
+        font-family:
+          "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code",
+          ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.45;
+        min-height: 100vh;
+        padding: 0;
+        background-image: repeating-linear-gradient(
+          0deg,
+          transparent 0 2px,
+          var(--scanline) 2px 3px
+        );
+        text-shadow: 0 0 6px var(--glow);
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .term {
+        max-width: none;
+        margin: 0;
+        background: var(--pane);
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+        overflow: visible;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: linear-gradient(180deg, var(--pane-2) 0%, var(--pane) 100%);
+        border-bottom: 1px solid var(--border);
+        padding: 8px 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 7px;
+      }
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--dot-red);
+        box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3);
+      }
+      .dot.y {
+        background: var(--dot-yellow);
+      }
+      .dot.g {
+        background: var(--dot-green);
+      }
+      .ttitle {
+        flex: 1;
+        text-align: center;
+        color: var(--fg-dim);
+        font-size: 12px;
+        letter-spacing: 0.04em;
+      }
+      .ttitle b {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+        color: var(--fg-dim);
+        font-size: 12px;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+      }
+      .toggle:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .navboxes {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 10px 14px;
+        background: var(--pane);
+        border-bottom: 1px solid var(--border);
+      }
+      .navboxes .brand {
+        color: var(--fg);
+        font-size: 13px;
+        margin-right: 12px;
+        letter-spacing: 0.04em;
+      }
+      .navboxes .brand b {
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .navboxes a {
+        font-size: 12px;
+        color: var(--fg-dim);
+        padding: 2px 10px;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        text-decoration: none;
+        letter-spacing: 0.04em;
+      }
+      .navboxes a:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+        background: transparent;
+      }
+      .navboxes .toggle {
+        margin-left: auto;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: auto auto auto;
+        gap: 0;
+        flex: 1;
+      }
+      .o1 {
+        order: 1;
+      }
+      .o2 {
+        order: 2;
+      }
+      .o3 {
+        order: 3;
+        border-bottom: none;
+      }
+      .o4 {
+        order: 4;
+        border-bottom: none;
+      }
+      .pane {
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        padding: 0;
+        background: var(--pane);
+      }
+      .pane.full {
+        grid-column: 1 / -1;
+        border-right: none;
+      }
+      .pane.last {
+        border-right: none;
+      }
+      .pane-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        color: var(--fg-dim);
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border);
+        background: var(--pane-2);
+      }
+      .pane-bar .lab {
+        color: var(--accent);
+      }
+      .pane-bar .lab.cyan {
+        color: var(--cyan);
+      }
+      .pane-bar .lab.mag {
+        color: var(--magenta);
+      }
+      .pane-bar .lab.yel {
+        color: var(--yellow);
+      }
+      .pane-bar .fill {
+        flex: 1;
+        border-bottom: 1px dashed var(--fg-mute);
+        margin: 0 4px;
+        height: 0;
+        transform: translateY(2px);
+      }
+      .pane-bar .keys {
+        color: var(--fg-mute);
+      }
+      .pane-body {
+        padding: 12px 14px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 90px 1fr 60px;
+        gap: 10px;
+        align-items: center;
+        padding: 1px 0;
+      }
+      .row .name {
+        color: var(--fg);
+      }
+      .row .pct {
+        text-align: right;
+        color: var(--accent);
+      }
+      .bar {
+        font-family: inherit;
+        color: var(--accent);
+        white-space: pre;
+        overflow: hidden;
+        letter-spacing: -1px;
+      }
+      .bar.cyan {
+        color: var(--cyan);
+      }
+      .bar.yel {
+        color: var(--yellow);
+      }
+      .bar.mag {
+        color: var(--magenta);
+      }
+      .meter-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        padding: 2px 0;
+      }
+      .meter-row .lbl {
+        width: 70px;
+        color: var(--fg-dim);
+      }
+      .meter-row .val {
+        margin-left: auto;
+        color: var(--accent);
+      }
+      .meter {
+        flex: 1;
+        height: 10px;
+        border: 1px solid var(--border);
+        background: var(--pane-2);
+        position: relative;
+      }
+      .meter > i {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        box-shadow: 0 0 6px var(--accent);
+      }
+      .meter.cyan > i {
+        background: var(--cyan);
+        box-shadow: 0 0 6px var(--cyan);
+      }
+      .meter.mag > i {
+        background: var(--magenta);
+        box-shadow: 0 0 6px var(--magenta);
+      }
+      .ascii {
+        white-space: pre;
+        color: var(--fg-dim);
+        margin: 0;
+        font-size: 11px;
+        line-height: 1.05;
+      }
+      .ascii .hi {
+        color: var(--accent);
+      }
+      .lead {
+        margin: 8px 0 4px;
+        color: var(--fg);
+      }
+      .lead b {
+        color: var(--yellow);
+      }
+      .ctas {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .btn {
+        display: inline-block;
+        padding: 4px 12px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+      }
+      .btn:hover {
+        background: var(--accent);
+        color: var(--pane);
+      }
+      .btn.ghost {
+        border-color: var(--fg-dim);
+        color: var(--fg-dim);
+      }
+      .btn.ghost:hover {
+        background: var(--fg-dim);
+        color: var(--pane);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 2px 8px 2px 0;
+        white-space: nowrap;
+      }
+      thead th {
+        color: var(--fg-dim);
+        border-bottom: 1px dashed var(--border);
+        font-weight: normal;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 11px;
+      }
+      tbody tr:hover {
+        background: var(--pane-2);
+      }
+      td.user {
+        color: var(--cyan);
+      }
+      td.pid {
+        color: var(--fg-dim);
+      }
+      td.cmd {
+        color: var(--fg);
+        white-space: normal;
+        width: 100%;
+      }
+      td.cpu,
+      td.mem {
+        color: var(--accent);
+        text-align: right;
+      }
+      .langs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        margin-top: 6px;
+      }
+      .langs span {
+        color: var(--fg);
+      }
+      .langs span::before {
+        content: "▸ ";
+        color: var(--fg-mute);
+      }
+      .blink {
+        color: var(--accent);
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      .tmux {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 4px 12px;
+        background: var(--status-bg);
+        color: var(--status-fg);
+        font-size: 12px;
+      }
+      .tmux .session {
+        background: var(--status-active);
+        color: var(--status-bg);
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .tmux .win {
+        opacity: 0.7;
+      }
+      .tmux .win.active {
+        opacity: 1;
+        text-decoration: underline;
+      }
+      .tmux .right {
+        margin-left: auto;
+        opacity: 0.85;
+      }
+      @media (max-width: 820px) {
+        body {
+          padding: 8px;
+        }
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .pane {
+          border-right: none;
+        }
+        .ttitle {
+          font-size: 11px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="term">
+      <nav class="navboxes" aria-label="primary">
+        <span class="brand"><b>codeselfstudy</b></span>
+        <a href="#">home</a>
+        <a href="#">events</a>
+        <a href="#">learn</a>
+        <a href="#">forum</a>
+        <a href="#">jobs</a>
+        <a href="#">puzzles</a>
+        <a href="#">tools</a>
+        <a href="#">about</a>
+        <span
+          class="toggle"
+          id="theme-toggle"
+          role="button"
+          tabindex="0"
+          aria-label="Toggle light and dark mode"
+          >◐ <span id="theme-label">dark</span></span
+        >
+      </nav>
+
+      <div class="grid">
+        <!-- pane 0 : languages -->
+        <div class="pane o3">
+          <div class="pane-bar">
+            <span>0</span><span class="lab">~/languages</span>
+            <span class="fill"></span>
+            <span class="keys">↑↓ scroll · / filter</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── languages used by members ──────────────────────
+            </div>
+            <div class="row">
+              <span class="name">python</span>
+              <span class="bar"
+                >█████████████████████████████████████████░░░░░</span
+              >
+              <span class="pct">62%</span>
+            </div>
+            <div class="row">
+              <span class="name">javascript</span>
+              <span class="bar cyan"
+                >██████████████████████████████████░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">54%</span>
+            </div>
+            <div class="row">
+              <span class="name">typescript</span>
+              <span class="bar cyan"
+                >███████████████████████████████░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--cyan)">48%</span>
+            </div>
+            <div class="row">
+              <span class="name">go</span>
+              <span class="bar yel"
+                >████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">35%</span>
+            </div>
+            <div class="row">
+              <span class="name">rust</span>
+              <span class="bar yel"
+                >██████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--yellow)">31%</span>
+            </div>
+            <div class="row">
+              <span class="name">haskell</span>
+              <span class="bar mag"
+                >██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">22%</span>
+            </div>
+            <div class="row">
+              <span class="name">clojure</span>
+              <span class="bar mag"
+                >████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">19%</span>
+            </div>
+            <div class="row">
+              <span class="name">elixir</span>
+              <span class="bar mag"
+                >███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--magenta)">17%</span>
+            </div>
+            <div class="row">
+              <span class="name">racket</span>
+              <span class="bar"
+                >█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct">14%</span>
+            </div>
+            <div class="row">
+              <span class="name">+ 12 more</span>
+              <span class="bar" style="color: var(--fg-mute)"
+                >░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░</span
+              >
+              <span class="pct" style="color: var(--fg-dim)">··</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 1 : stats -->
+        <div class="pane last o4">
+          <div class="pane-bar">
+            <span>1</span><span class="lab cyan">~/stats</span>
+            <span class="fill"></span><span class="keys">e expand</span>
+          </div>
+          <div class="pane-body">
+            <div style="color: var(--fg-dim); margin-bottom: 6px">
+              ── community ──────────────────────
+            </div>
+            <div class="meter-row">
+              <span class="lbl">members</span>
+              <span class="meter"><i style="width: 92%"></i></span>
+              <span class="val">5,000+</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">years up</span>
+              <span class="meter cyan"><i style="width: 82%"></i></span>
+              <span class="val" style="color: var(--cyan)">11</span>
+            </div>
+            <div class="meter-row">
+              <span class="lbl">langs</span>
+              <span class="meter mag"><i style="width: 70%"></i></span>
+              <span class="val" style="color: var(--magenta)">20+</span>
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 6px">
+              ── net · this week ────────────────
+            </div>
+            <div style="color: var(--fg)">
+              ↓ <span style="color: var(--accent)">12</span> meetups / month
+            </div>
+            <div style="color: var(--fg)">
+              ↑ <span style="color: var(--cyan)">234</span> forum posts
+            </div>
+            <div style="color: var(--fg)">
+              ⇄ <span style="color: var(--yellow)">38</span> intros & jobs
+            </div>
+            <div style="color: var(--fg-dim); margin: 12px 0 4px">
+              ── load avg ───────────────────────
+            </div>
+            <pre
+              class="ascii"
+            ><span class="hi">▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅</span>
+12mo · steady &amp; rising</pre>
+          </div>
+        </div>
+
+        <!-- pane 2 : welcome / CTA -->
+        <div class="pane full o1">
+          <div class="pane-bar">
+            <span>2</span><span class="lab yel">~/welcome</span>
+            <span class="fill"></span>
+            <span class="keys">prefix + ? help</span>
+          </div>
+          <div class="pane-body">
+            <pre class="ascii">
+  <span class="hi">code self study</span> · a friendly programming community in the san francisco bay area
+  <span class="hi">────────────────</span>   est. 2014 · all languages, all levels, in person + online</pre>
+            <p class="lead">
+              Self-study computer programming alongside <b>5,000+</b> members in
+              Berkeley and the SF Bay Area. Bring a project, bring a question,
+              or just show up. We meet in person and online.<span class="blink"
+                >▮</span
+              >
+            </p>
+            <div style="color: var(--fg-dim)">what we do ::</div>
+            <div class="langs">
+              <span>build a local community of motivated programmers</span>
+              <span>open to every language &amp; level</span>
+              <span>self-study with mentorship from experienced members</span>
+              <span>bootcamp supplement or alternative</span>
+            </div>
+            <div class="ctas" style="margin-top: 14px">
+              <a class="btn" href="https://www.meetup.com/codeselfstudy/"
+                >Join</a
+              >
+            </div>
+          </div>
+        </div>
+
+        <!-- pane 3 : recent activity (forum) -->
+        <div class="pane full o2">
+          <div class="pane-bar">
+            <span>3</span><span class="lab mag">recent activity · forum</span>
+            <span class="fill"></span>
+            <span class="keys">↻ live · enter open</span>
+          </div>
+          <div class="pane-body">
+            <table>
+              <thead>
+                <tr>
+                  <th>when</th>
+                  <th>by</th>
+                  <th>category</th>
+                  <th>topic</th>
+                  <th style="text-align: right">replies</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="pid">2m</td>
+                  <td class="user">alice</td>
+                  <td><span style="color: var(--yellow)">#rust</span></td>
+                  <td class="cmd">
+                    code review on a tiny json parser &mdash; got it down to 180
+                    lines, can it be smaller?
+                  </td>
+                  <td class="cpu">8</td>
+                </tr>
+                <tr>
+                  <td class="pid">14m</td>
+                  <td class="user">bob</td>
+                  <td><span style="color: var(--cyan)">#events</span></td>
+                  <td class="cmd">
+                    in-person meetup · Berkeley library · sat 1pm
+                    <span style="color: var(--fg-dim)">· 18 RSVPs</span>
+                  </td>
+                  <td class="cpu">3</td>
+                </tr>
+                <tr>
+                  <td class="pid">42m</td>
+                  <td class="user">carol</td>
+                  <td><span style="color: var(--magenta)">#haskell</span></td>
+                  <td class="cmd">
+                    finally got <code>traverse</code> to click &mdash; short
+                    writeup with the aha moment
+                  </td>
+                  <td class="cpu">12</td>
+                </tr>
+                <tr>
+                  <td class="pid">1h</td>
+                  <td class="user">dan</td>
+                  <td>
+                    <span style="color: var(--accent)">#beginners</span>
+                  </td>
+                  <td class="cmd">
+                    study plan for going from JS → systems programming?
+                  </td>
+                  <td class="cpu">21</td>
+                </tr>
+                <tr>
+                  <td class="pid">3h</td>
+                  <td class="user">eve</td>
+                  <td><span style="color: #ffb86b">#jobs</span></td>
+                  <td class="cmd">
+                    backend role at a small SF startup &mdash; intros welcome
+                  </td>
+                  <td class="cpu">5</td>
+                </tr>
+                <tr>
+                  <td class="pid">5h</td>
+                  <td class="user">frank</td>
+                  <td><span style="color: var(--cyan)">#tools</span></td>
+                  <td class="cmd">
+                    regex-trainer · new contributor · added lookahead exercises
+                  </td>
+                  <td class="cpu">2</td>
+                </tr>
+                <tr>
+                  <td class="pid">8h</td>
+                  <td class="user">grace</td>
+                  <td><span style="color: var(--magenta)">#elixir</span></td>
+                  <td class="cmd">
+                    phoenix study group · weds 7pm · open to all levels
+                  </td>
+                  <td class="cpu">7</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="tmux" role="status">
+        <span class="session">[codeselfstudy]</span>
+        <span class="win active">0:home*</span>
+        <span class="win">1:forum</span>
+        <span class="win">2:events</span>
+        <span class="win">3:learn</span>
+        <span class="win">4:jobs</span>
+        <span class="right"
+          >members 5,000+ · est. 2014 · <span id="clock">18:42</span></span
+        >
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var label = document.getElementById("theme-label");
+        var toggle = document.getElementById("theme-toggle");
+        var KEY = "tmux-theme";
+        function apply(t) {
+          if (t === "light") {
+            root.setAttribute("data-theme", "light");
+            label.textContent = "light";
+          } else {
+            root.removeAttribute("data-theme");
+            label.textContent = "dark";
+          }
+        }
+        apply(localStorage.getItem(KEY) || "dark");
+        function flip() {
+          var n =
+            root.getAttribute("data-theme") === "light" ? "dark" : "light";
+          apply(n);
+          localStorage.setItem(KEY, n);
+        }
+        toggle.addEventListener("click", flip);
+        toggle.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        });
+        var c = document.getElementById("clock");
+        function tick() {
+          var d = new Date();
+          c.textContent =
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+        tick();
+        setInterval(tick, 30000);
+      })();
+    </script>
+  </body>
+</html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -417,8 +417,56 @@
             as outlined boxes.
           </p></a
         >
+        <a class="card" href="63-tmux-home.html"
+          ><div class="num">63</div>
+          <h2>terminal home · languages</h2>
+          <p>
+            Generic TUI. Welcome, recent forum topics, languages bars. No btop
+            branding.
+          </p></a
+        >
+        <a class="card" href="64-tmux-home-tracks.html"
+          ><div class="num">64</div>
+          <h2>terminal home · tracks</h2>
+          <p>
+            Bottom bars reframed as topic tracks (web, backend, systems, ml, …)
+            instead of languages.
+          </p></a
+        >
+        <a class="card" href="65-tmux-home-split.html"
+          ><div class="num">65</div>
+          <h2>terminal home · meetups</h2>
+          <p>
+            Bottom replaces bars with an upcoming-meetups schedule by day and
+            time.
+          </p></a
+        >
+        <a class="card" href="66-tmux-home-frameless.html"
+          ><div class="num">66</div>
+          <h2>terminal home · frameless</h2>
+          <p>
+            Same as 63 but no window chrome — the page is the terminal interior.
+            Brand and theme toggle live in the navbar.
+          </p></a
+        >
+        <a class="card" href="67-tmux-home-frameless-cta.html"
+          ><div class="num">67</div>
+          <h2>terminal home · single CTA</h2>
+          <p>
+            Frameless variant with a single &ldquo;Join&rdquo; button instead of
+            four shell-style links.
+          </p></a
+        >
+        <a class="card" href="68-tmux-home-cta-below.html"
+          ><div class="num">68</div>
+          <h2>terminal home · CTA below</h2>
+          <p>
+            Single Join button moved beneath the &ldquo;what we do&rdquo; list
+            so it lands after the elevator pitch.
+          </p></a
+        >
       </div>
-      <footer>All 61 live under <code>./mockups/</code>.</footer>
+      <footer>All 67 live under <code>./mockups/</code>.</footer>
     </div>
   </body>
 </html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -377,8 +377,48 @@
           <h2>BBS · plasma</h2>
           <p>Orange plasma panel; rust-on-oat light mode.</p></a
         >
+        <a class="card" href="57-tmux-btop.html"
+          ><div class="num">57</div>
+          <h2>tmux · btop</h2>
+          <p>
+            System-monitor TUI: language bars, community meters, activity
+            processes.
+          </p></a
+        >
+        <a class="card" href="58-tmux-neovim.html"
+          ><div class="num">58</div>
+          <h2>tmux · neovim</h2>
+          <p>
+            File tree + welcome.md buffer with syntax colors and lualine.
+          </p></a
+        >
+        <a class="card" href="59-tmux-lazygit.html"
+          ><div class="num">59</div>
+          <h2>tmux · lazygit</h2>
+          <p>
+            Status / files / branches / commits stack with live diff pane.
+          </p></a
+        >
+        <a class="card" href="60-tmux-irc.html"
+          ><div class="num">60</div>
+          <h2>tmux · weechat</h2>
+          <p>Channel list, #welcome chat log with bot, nick column.</p></a
+        >
+        <a class="card" href="61-tmux-yazi.html"
+          ><div class="num">61</div>
+          <h2>tmux · yazi</h2>
+          <p>Miller-columns file manager with markdown preview pane.</p></a
+        >
+        <a class="card" href="62-tmux-btop-v2.html"
+          ><div class="num">62</div>
+          <h2>tmux · btop · v2</h2>
+          <p>
+            Welcome on top, activity in the middle, languages on the bottom; nav
+            as outlined boxes.
+          </p></a
+        >
       </div>
-      <footer>All 55 live under <code>./mockups/</code>.</footer>
+      <footer>All 61 live under <code>./mockups/</code>.</footer>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Six new homepage mockups in [mockups/](mockups/) styled as a tmux session running TUI apps. Mac-style window chrome, pane borders, tmux status bar at the bottom, and a green-phosphor / paperwhite light-dark toggle that shares a storage key across all six (so flipping it on one carries to the others).

- **57 · btop** — system monitor; languages-as-CPU bars, community meters, recent activity as a process list.
- **58 · neovim** — file tree + syntax-colored welcome.md buffer + lualine.
- **59 · lazygit** — status / files / branches / commits stack with a homepage-as-diff pane.
- **60 · weechat** — channel list, #welcome chat log with a greeter bot, nick column.
- **61 · yazi** — miller-columns file manager with markdown preview of the homepage.
- **62 · btop · v2** — variant of 57 with sections reordered (welcome → activity → languages), simplified title bar (just "codeselfstudy"), and outlined-box nav links.

Each file is standalone HTML/CSS/JS, no build step. Index card descriptions added in [mockups/index.html](mockups/index.html).

## Test plan

- [x] Open each of 57–62 in light + dark modes; confirm theme toggle persists across files.
- [x] Resize to mobile width; confirm panes stack reasonably.
- [x] Verify nav and meetup CTA links are present in each (no broken anchors expected — most are `href="#"` placeholders).