### PR TITLE
Add 404 and 500 error pages

### DIFF
--- a/src/components/error-page.tsx
+++ b/src/components/error-page.tsx
@@ -1,0 +1,39 @@
+import { Link, useRouter } from "@tanstack/react-router";
+import { PageWrapper } from "@/components/page-wrapper";
+import { Button, buttonVariants } from "@/components/ui/button";
+
+interface ErrorPageProps {
+  error?: Error;
+}
+
+export function ErrorPage({ error }: ErrorPageProps) {
+  const router = useRouter();
+
+  return (
+    <PageWrapper>
+      <div className="mx-auto max-w-2xl text-center">
+        <p className="text-muted-foreground text-sm font-semibold tracking-widest uppercase">
+          500
+        </p>
+        <h1 className="mt-2 text-4xl font-bold tracking-tight sm:text-5xl">
+          Something went wrong
+        </h1>
+        <p className="text-muted-foreground mt-4 text-base">
+          An unexpected error occurred while loading this page. You can try
+          again, or head back home.
+        </p>
+        {import.meta.env.DEV && error?.message && (
+          <pre className="bg-muted text-muted-foreground mt-6 overflow-x-auto rounded-md p-4 text-left text-xs">
+            {error.message}
+          </pre>
+        )}
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <Button onClick={() => router.invalidate()}>Try again</Button>
+          <Link to="/" className={buttonVariants({ variant: "outline" })}>
+            Go home
+          </Link>
+        </div>
+      </div>
+    </PageWrapper>
+  );
+}

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -1,0 +1,33 @@
+import { Link } from "@tanstack/react-router";
+import { PageWrapper } from "@/components/page-wrapper";
+import { buttonVariants } from "@/components/ui/button";
+
+export function NotFound() {
+  return (
+    <PageWrapper>
+      <div className="mx-auto max-w-2xl text-center">
+        <p className="text-muted-foreground text-sm font-semibold tracking-widest uppercase">
+          404
+        </p>
+        <h1 className="mt-2 text-4xl font-bold tracking-tight sm:text-5xl">
+          Page not found
+        </h1>
+        <p className="text-muted-foreground mt-4 text-base">
+          We couldn&apos;t find the page you were looking for. It may have been
+          moved or no longer exists.
+        </p>
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <Link to="/" className={buttonVariants()}>
+            Go home
+          </Link>
+          <Link
+            to="/contact"
+            className={buttonVariants({ variant: "outline" })}
+          >
+            Contact us
+          </Link>
+        </div>
+      </div>
+    </PageWrapper>
+  );
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -16,8 +16,10 @@ import WorkOSProvider from "@/integrations/workos/provider";
 import TanStackQueryDevtools from "@/integrations/tanstack-query/devtools";
 import appCss from "@/styles.css?url";
 import { Analytics } from "@/components/analytics";
+import { ErrorPage } from "@/components/error-page";
 import { Footer } from "@/components/footer";
 import { Navbar } from "@/components/navbar";
+import { NotFound } from "@/components/not-found";
 
 interface MyRouterContext {
   queryClient: QueryClient;
@@ -56,6 +58,8 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
   }),
 
   shellComponent: RootDocument,
+  notFoundComponent: NotFound,
+  errorComponent: ({ error }) => <ErrorPage error={error} />,
 });
 
 function RootDocument({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

- Adds `NotFound` and `ErrorPage` components and wires them into the root route as `notFoundComponent` / `errorComponent`, so unknown routes render styled content instead of an empty page (404 still serves the correct status header).
- The error page exposes a "Try again" action that invalidates the router and a link back home; the dev build also surfaces the underlying error message for debugging.

Closes #113.

## Test plan

- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run build`
- [ ] Manually visit a missing route (e.g. `/nonexistent-page`) in a properly configured environment and confirm the 404 page renders with the navbar/footer and a 404 status header.
- [ ] Trigger a load-time error and confirm the 500 page renders with a working "Try again" button.