### PR TITLE
Phase 2: <ThemeToggle> component

### DIFF
--- a/src/components/terminal/theme-toggle.test.tsx
+++ b/src/components/terminal/theme-toggle.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ThemeToggle } from "./theme-toggle";
+
+beforeEach(() => {
+  document.documentElement.removeAttribute("data-theme");
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ThemeToggle", () => {
+  test("renders button with default 'dark' label", () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByRole("button", { name: /toggle light and dark/i });
+    expect(btn.textContent).toContain("dark");
+  });
+
+  test("click flips data-theme to light and persists", () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByRole("button", { name: /toggle light and dark/i });
+
+    fireEvent.click(btn);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(window.localStorage.getItem("tmux-theme")).toBe("light");
+    expect(btn.textContent).toContain("light");
+
+    fireEvent.click(btn);
+    expect(document.documentElement.getAttribute("data-theme")).toBe(null);
+    expect(window.localStorage.getItem("tmux-theme")).toBe("dark");
+    expect(btn.textContent).toContain("dark");
+  });
+
+  test("Enter and Space key activate the toggle", () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByRole("button", { name: /toggle light and dark/i });
+
+    fireEvent.keyDown(btn, { key: "Enter" });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+
+    fireEvent.keyDown(btn, { key: " " });
+    expect(document.documentElement.getAttribute("data-theme")).toBe(null);
+  });
+
+  test("initial render reads stored theme from localStorage", () => {
+    window.localStorage.setItem("tmux-theme", "light");
+    render(<ThemeToggle />);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    const btn = screen.getByRole("button", { name: /toggle light and dark/i });
+    expect(btn.textContent).toContain("light");
+  });
+});

--- a/src/components/terminal/theme-toggle.tsx
+++ b/src/components/terminal/theme-toggle.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+
+type Theme = "dark" | "light";
+
+const STORAGE_KEY = "tmux-theme";
+
+function applyTheme(theme: Theme) {
+  if (typeof document === "undefined") return;
+  if (theme === "light") {
+    document.documentElement.setAttribute("data-theme", "light");
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
+}
+
+function readStoredTheme(): Theme {
+  if (typeof window === "undefined") return "dark";
+  const v = window.localStorage.getItem(STORAGE_KEY);
+  return v === "light" ? "light" : "dark";
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("dark");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const initial = readStoredTheme();
+    setTheme(initial);
+    applyTheme(initial);
+    setMounted(true);
+  }, []);
+
+  function flip() {
+    const next: Theme = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    applyTheme(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* localStorage may be unavailable (e.g. private mode); ignore. */
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={flip}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          flip();
+        }
+      }}
+      aria-label="Toggle light and dark mode"
+      className="terminal-theme-toggle"
+      style={{
+        cursor: "pointer",
+        userSelect: "none",
+        color: "var(--term-fg-dim)",
+        fontSize: 12,
+        padding: "2px 8px",
+        border: "1px solid var(--term-border)",
+        borderRadius: 4,
+        background: "transparent",
+        fontFamily: "inherit",
+      }}
+    >
+      ◐ <span>{mounted ? theme : "dark"}</span>
+    </button>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -46,6 +46,63 @@
     "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
     "Helvetica Neue", sans-serif;
   --header-font: "Anton", var(--root-font-sans);
+
+  /* Terminal/tmux redesign tokens (mockup 68). Namespaced --term-* so they
+     don't clash with shadcn's --accent / --border / etc. Default = dark. */
+  --term-bg: #050805;
+  --term-pane: #0a0f0a;
+  --term-pane-2: #0d130d;
+  --term-fg: #b8f5b8;
+  --term-fg-dim: #4a7a4a;
+  --term-fg-mute: #2a4a2a;
+  --term-border: #2a5a2a;
+  --term-border-hi: #5cd65c;
+  --term-accent: #c4ff5e;
+  --term-magenta: #ff7ac6;
+  --term-cyan: #6df;
+  --term-yellow: #ffe066;
+  --term-red: #ff7a7a;
+  --term-status-bg: #1f4a1f;
+  --term-status-fg: #050805;
+  --term-status-active: #ffe066;
+  --term-dot-red: #ff5f56;
+  --term-dot-yellow: #ffbd2e;
+  --term-dot-green: #27c93f;
+  --term-glow: rgb(184 245 184 / 18%);
+  --term-scanline: rgb(0 0 0 / 18%);
+  --font-terminal-mono:
+    "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code", ui-monospace,
+    "SF Mono", menlo, consolas, monospace;
+}
+
+[data-theme="light"] {
+  --term-bg: #d8d2c0;
+  --term-pane: #efe9d6;
+  --term-pane-2: #e6dfca;
+  --term-fg: #1a1a14;
+  --term-fg-dim: #6a6860;
+  --term-fg-mute: #a8a294;
+  --term-border: #807a6a;
+  --term-border-hi: #1a1a14;
+  --term-accent: #1a4a8a;
+  --term-magenta: #8a1a5a;
+  --term-cyan: #1a6a8a;
+  --term-yellow: #6a5a00;
+  --term-red: #8a1a2a;
+  --term-status-bg: #1a1a14;
+  --term-status-fg: #efe9d6;
+  --term-status-active: #ffe066;
+  --term-dot-red: #b8513f;
+  --term-dot-yellow: #b88a1f;
+  --term-dot-green: #2a8a35;
+  --term-glow: rgb(26 26 20 / 0%);
+  --term-scanline: rgb(0 0 0 / 4%);
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
 }
 
 .dark {
@@ -175,6 +232,24 @@
 }
 
 @layer components {
+  /* Terminal shell wrapper — used by Phase 2's <TerminalShell> component
+     (mockup 68). Kept off <body> on purpose so existing pages keep their
+     current look until the chrome is swapped in Phase 4. */
+  .terminal-shell {
+    background: var(--term-pane);
+    color: var(--term-fg);
+    font-family: var(--font-terminal-mono);
+    font-size: 13px;
+    line-height: 1.45;
+    min-height: 100vh;
+    background-image: repeating-linear-gradient(
+      0deg,
+      transparent 0 2px,
+      var(--term-scanline) 2px 3px
+    );
+    text-shadow: 0 0 6px var(--term-glow);
+  }
+
   /* The patterns are from https://www.heropatterns.com/ */
   .bg-bevel-circle {
     background-color: var(--background);

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const cssPath = fileURLToPath(new URL("./styles.css", import.meta.url));
+const css = readFileSync(cssPath, "utf-8");
+
+const REQUIRED_TOKENS = [
+  "--term-bg",
+  "--term-pane",
+  "--term-pane-2",
+  "--term-fg",
+  "--term-fg-dim",
+  "--term-fg-mute",
+  "--term-border",
+  "--term-border-hi",
+  "--term-accent",
+  "--term-magenta",
+  "--term-cyan",
+  "--term-yellow",
+  "--term-red",
+  "--term-status-bg",
+  "--term-status-fg",
+  "--term-status-active",
+  "--term-dot-red",
+  "--term-dot-yellow",
+  "--term-dot-green",
+  "--term-glow",
+  "--term-scanline",
+];
+
+function blockFor(selector: string): string {
+  const re = new RegExp(
+    `${selector.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")}\\s*\\{([^}]*)\\}`,
+    "m"
+  );
+  const m = css.match(re);
+  if (!m) throw new Error(`selector not found in styles.css: ${selector}`);
+  return m[1];
+}
+
+describe("terminal theme tokens", () => {
+  test(":root defines every required terminal token", () => {
+    const root = blockFor(":root");
+    for (const token of REQUIRED_TOKENS) {
+      expect(root, `missing ${token} in :root`).toContain(token);
+    }
+  });
+
+  test(`[data-theme="light"] overrides every required terminal token`, () => {
+    const light = blockFor(`[data-theme="light"]`);
+    for (const token of REQUIRED_TOKENS) {
+      expect(light, `missing ${token} in [data-theme="light"]`).toContain(
+        token
+      );
+    }
+  });
+
+  test("dark and light values for --term-accent differ", () => {
+    const root = blockFor(":root");
+    const light = blockFor(`[data-theme="light"]`);
+    const re = /--term-accent:\s*([^;]+);/;
+    const dark = root.match(re)?.[1].trim();
+    const lightVal = light.match(re)?.[1].trim();
+    expect(dark).toBeTruthy();
+    expect(lightVal).toBeTruthy();
+    expect(dark).not.toBe(lightVal);
+  });
+
+  test("monospace font variable is registered", () => {
+    expect(css).toMatch(/--font-terminal-mono:\s*"JetBrains Mono"/);
+  });
+
+  test("@keyframes blink is defined", () => {
+    expect(css).toMatch(/@keyframes\s+blink\s*\{[^}]*opacity:\s*0/);
+  });
+
+  test(".terminal-shell utility applies scanline + mono font", () => {
+    const re = /\.terminal-shell\s*\{([^}]*)\}/m;
+    const block = css.match(re)?.[1];
+    expect(block).toBeTruthy();
+    expect(block).toContain("var(--font-terminal-mono)");
+    expect(block).toContain("repeating-linear-gradient");
+    expect(block).toContain("var(--term-scanline)");
+    expect(block).toContain("text-shadow");
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/components/terminal/theme-toggle.tsx` — toggles `data-theme="light"` on `<html>`, persists to `localStorage("tmux-theme")`.
- Keyboard accessible: Enter and Space activate.
- SSR-safe: localStorage read deferred to `useEffect`; renders "dark" label on first paint to avoid hydration mismatch.
- Inline styles read `--term-*` tokens from #156 (stacked PR).

## Stacked on
This branch is stacked on `issue-139-theme-tokens` (#156) so the `--term-*` tokens it consumes are present. Once #156 merges, GitHub will auto-rebase this PR onto `redesign/terminal-tmux`.

## Test plan
- [x] `bun run test` — 22 passed (4 new theme-toggle tests + 18 existing).
- [x] `bun run lint` — clean.
- [x] Tests cover: default render, click toggle (both directions), Enter/Space keyboard activation, restoring stored theme on mount.

Closes #141. Part of #106.