### PR TITLE
Phase 2: <TmuxStatusBar> + <Clock>

### DIFF
--- a/src/components/terminal/tmux-status-bar.test.tsx
+++ b/src/components/terminal/tmux-status-bar.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { Clock, TmuxStatusBar } from "./tmux-status-bar";
+import type { TmuxWindow } from "@/content/mock-home-data";
+
+const WINDOWS: Array<TmuxWindow> = [
+  { id: 0, label: "home" },
+  { id: 1, label: "forum" },
+  { id: 2, label: "events" },
+];
+
+afterEach(() => cleanup());
+
+describe("TmuxStatusBar", () => {
+  test("renders session label in brackets", () => {
+    render(<TmuxStatusBar windows={WINDOWS} activeIndex={0} />);
+    expect(screen.getByText("[codeselfstudy]")).toBeTruthy();
+  });
+
+  test("renders every window with id:label format", () => {
+    render(
+      <TmuxStatusBar
+        windows={WINDOWS}
+        activeIndex={1}
+        session="codeselfstudy"
+      />
+    );
+    expect(screen.getByText(/0:home/)).toBeTruthy();
+    expect(screen.getByText(/1:forum/)).toBeTruthy();
+    expect(screen.getByText(/2:events/)).toBeTruthy();
+  });
+
+  test("active window gets aria-current='page' and asterisk suffix", () => {
+    render(<TmuxStatusBar windows={WINDOWS} activeIndex={1} />);
+    const active = screen.getByText(/1:forum\*/);
+    expect(active.getAttribute("aria-current")).toBe("page");
+    const inactive = screen.getByText(/0:home/);
+    expect(inactive.getAttribute("aria-current")).toBe(null);
+  });
+
+  test("renders custom 'right' slot", () => {
+    render(
+      <TmuxStatusBar
+        windows={WINDOWS}
+        activeIndex={0}
+        right={<span>custom-right</span>}
+      />
+    );
+    expect(screen.getByText("custom-right")).toBeTruthy();
+  });
+});
+
+describe("Clock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-26T18:42:00"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("renders HH:MM after mount and updates after 30s", () => {
+    render(<Clock />);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(screen.getByLabelText("current time").textContent).toBe("18:42");
+
+    vi.setSystemTime(new Date("2026-04-26T18:43:00"));
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(screen.getByLabelText("current time").textContent).toBe("18:43");
+  });
+});

--- a/src/components/terminal/tmux-status-bar.tsx
+++ b/src/components/terminal/tmux-status-bar.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import type { TmuxWindow } from "@/content/mock-home-data";
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function nowHHMM(): string {
+  const d = new Date();
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** Live HH:MM clock; SSR-safe (renders empty placeholder until mounted). */
+export function Clock() {
+  const [text, setText] = useState<string>("");
+  useEffect(() => {
+    setText(nowHHMM());
+    const id = window.setInterval(() => setText(nowHHMM()), 30_000);
+    return () => window.clearInterval(id);
+  }, []);
+  return (
+    <span aria-label="current time" suppressHydrationWarning>
+      {text}
+    </span>
+  );
+}
+
+type TmuxStatusBarProps = {
+  session?: string;
+  windows: Array<TmuxWindow>;
+  /** Index of the active window (0-based). */
+  activeIndex: number;
+  /** Right-aligned status content. Defaults to the right text + <Clock />. */
+  right?: ReactNode;
+};
+
+export function TmuxStatusBar({
+  session = "codeselfstudy",
+  windows,
+  activeIndex,
+  right,
+}: TmuxStatusBarProps) {
+  return (
+    <div
+      role="status"
+      aria-label="tmux status bar"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+        padding: "4px 12px",
+        background: "var(--term-status-bg)",
+        color: "var(--term-status-fg)",
+        fontSize: 12,
+        fontFamily: "var(--font-terminal-mono)",
+      }}
+    >
+      <span
+        style={{
+          background: "var(--term-status-active)",
+          color: "var(--term-status-bg)",
+          padding: "0 6px",
+          fontWeight: 600,
+        }}
+      >
+        [{session}]
+      </span>
+      {windows.map((w, i) => {
+        const active = i === activeIndex;
+        return (
+          <span
+            key={w.id}
+            aria-current={active ? "page" : undefined}
+            style={{
+              opacity: active ? 1 : 0.7,
+              textDecoration: active ? "underline" : "none",
+            }}
+          >
+            {w.id}:{w.label}
+            {active ? "*" : ""}
+          </span>
+        );
+      })}
+      <span style={{ marginLeft: "auto", opacity: 0.85 }}>{right}</span>
+    </div>
+  );
+}

--- a/src/content/mock-home-data.ts
+++ b/src/content/mock-home-data.ts
@@ -1,0 +1,168 @@
+/**
+ * Hardcoded data for the terminal/tmux home redesign (mockup 68).
+ * Values copied verbatim from mockups/68-tmux-home-cta-below.html.
+ * Real data wiring is follow-up work; for now feature panes import from here.
+ */
+
+export type TermColor = "green" | "cyan" | "yellow" | "magenta";
+
+export type Language = {
+  name: string;
+  percent: number;
+  color: TermColor;
+};
+
+export const LANGUAGES: Array<Language> = [
+  { name: "python", percent: 62, color: "green" },
+  { name: "javascript", percent: 54, color: "cyan" },
+  { name: "typescript", percent: 48, color: "cyan" },
+  { name: "go", percent: 35, color: "yellow" },
+  { name: "rust", percent: 31, color: "yellow" },
+  { name: "haskell", percent: 22, color: "magenta" },
+  { name: "clojure", percent: 19, color: "magenta" },
+  { name: "elixir", percent: 17, color: "magenta" },
+  { name: "racket", percent: 14, color: "green" },
+];
+
+export const LANGUAGES_OVERFLOW_LABEL = "+ 12 more";
+
+export type StatRow = {
+  label: string;
+  value: string | number;
+  color: "green" | "cyan" | "magenta";
+  meterPercent: number;
+};
+
+export type NetActivity = {
+  icon: "↓" | "↑" | "⇄";
+  value: number;
+  label: string;
+  color: TermColor;
+};
+
+export const STATS = {
+  community: [
+    { label: "members", value: "5,000+", color: "green", meterPercent: 92 },
+    { label: "years up", value: 11, color: "cyan", meterPercent: 82 },
+    { label: "langs", value: "20+", color: "magenta", meterPercent: 70 },
+  ] satisfies Array<StatRow>,
+  netThisWeek: [
+    { icon: "↓", value: 12, label: "meetups / month", color: "green" },
+    { icon: "↑", value: 234, label: "forum posts", color: "cyan" },
+    { icon: "⇄", value: 38, label: "intros & jobs", color: "yellow" },
+  ] satisfies Array<NetActivity>,
+  loadAvgAscii: "▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅",
+  loadAvgCaption: "12mo · steady & rising",
+} as const;
+
+export type ForumPost = {
+  when: string;
+  by: string;
+  category: string;
+  /** CSS color string — uses the --term-* variables from styles.css. */
+  categoryColor: string;
+  topic: string;
+  replies: number;
+};
+
+export const FORUM_ACTIVITY: Array<ForumPost> = [
+  {
+    when: "2m",
+    by: "alice",
+    category: "#rust",
+    categoryColor: "var(--term-yellow)",
+    topic:
+      "code review on a tiny json parser — got it down to 180 lines, can it be smaller?",
+    replies: 8,
+  },
+  {
+    when: "14m",
+    by: "bob",
+    category: "#events",
+    categoryColor: "var(--term-cyan)",
+    topic: "in-person meetup · Berkeley library · sat 1pm · 18 RSVPs",
+    replies: 3,
+  },
+  {
+    when: "42m",
+    by: "carol",
+    category: "#haskell",
+    categoryColor: "var(--term-magenta)",
+    topic:
+      "finally got `traverse` to click — short writeup with the aha moment",
+    replies: 12,
+  },
+  {
+    when: "1h",
+    by: "dan",
+    category: "#beginners",
+    categoryColor: "var(--term-accent)",
+    topic: "study plan for going from JS → systems programming?",
+    replies: 21,
+  },
+  {
+    when: "3h",
+    by: "eve",
+    category: "#jobs",
+    /* mockup uses #ffb86b, an orange not in the token set; keep literal. */
+    categoryColor: "#ffb86b",
+    topic: "backend role at a small SF startup — intros welcome",
+    replies: 5,
+  },
+  {
+    when: "5h",
+    by: "frank",
+    category: "#tools",
+    categoryColor: "var(--term-cyan)",
+    topic: "regex-trainer · new contributor · added lookahead exercises",
+    replies: 2,
+  },
+  {
+    when: "8h",
+    by: "grace",
+    category: "#elixir",
+    categoryColor: "var(--term-magenta)",
+    topic: "phoenix study group · weds 7pm · open to all levels",
+    replies: 7,
+  },
+];
+
+export const WELCOME_COPY = {
+  title: "code self study",
+  tagline:
+    "a friendly programming community in the san francisco bay area · est. 2014 · all languages, all levels, in person + online",
+  /**
+   * The "5,000+" substring is intended to be visually highlighted by the
+   * <WelcomePane> component (e.g. wrapped in a styled span).
+   */
+  lead: "Self-study computer programming alongside 5,000+ members in Berkeley and the SF Bay Area. Bring a project, bring a question, or just show up. We meet in person and online.",
+  leadHighlight: "5,000+",
+  whatWeDo: [
+    "build a local community of motivated programmers",
+    "open to every language & level",
+    "self-study with mentorship from experienced members",
+    "bootcamp supplement or alternative",
+  ],
+  cta: {
+    label: "Join",
+    href: "https://www.meetup.com/codeselfstudy/",
+  },
+} as const;
+
+export type TmuxWindow = {
+  id: number;
+  label: string;
+  href?: string;
+};
+
+export const TMUX_SESSION = "codeselfstudy" as const;
+
+export const TMUX_WINDOWS: Array<TmuxWindow> = [
+  { id: 0, label: "home", href: "/" },
+  { id: 1, label: "forum", href: "/forum" },
+  { id: 2, label: "events", href: "/events" },
+  { id: 3, label: "learn", href: "/learn" },
+  { id: 4, label: "jobs", href: "/jobs" },
+];
+
+export const TMUX_RIGHT_TEXT = "members 5,000+ · est. 2014" as const;

--- a/src/styles.css
+++ b/src/styles.css
@@ -46,6 +46,63 @@
     "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
     "Helvetica Neue", sans-serif;
   --header-font: "Anton", var(--root-font-sans);
+
+  /* Terminal/tmux redesign tokens (mockup 68). Namespaced --term-* so they
+     don't clash with shadcn's --accent / --border / etc. Default = dark. */
+  --term-bg: #050805;
+  --term-pane: #0a0f0a;
+  --term-pane-2: #0d130d;
+  --term-fg: #b8f5b8;
+  --term-fg-dim: #4a7a4a;
+  --term-fg-mute: #2a4a2a;
+  --term-border: #2a5a2a;
+  --term-border-hi: #5cd65c;
+  --term-accent: #c4ff5e;
+  --term-magenta: #ff7ac6;
+  --term-cyan: #6df;
+  --term-yellow: #ffe066;
+  --term-red: #ff7a7a;
+  --term-status-bg: #1f4a1f;
+  --term-status-fg: #050805;
+  --term-status-active: #ffe066;
+  --term-dot-red: #ff5f56;
+  --term-dot-yellow: #ffbd2e;
+  --term-dot-green: #27c93f;
+  --term-glow: rgb(184 245 184 / 18%);
+  --term-scanline: rgb(0 0 0 / 18%);
+  --font-terminal-mono:
+    "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code", ui-monospace,
+    "SF Mono", menlo, consolas, monospace;
+}
+
+[data-theme="light"] {
+  --term-bg: #d8d2c0;
+  --term-pane: #efe9d6;
+  --term-pane-2: #e6dfca;
+  --term-fg: #1a1a14;
+  --term-fg-dim: #6a6860;
+  --term-fg-mute: #a8a294;
+  --term-border: #807a6a;
+  --term-border-hi: #1a1a14;
+  --term-accent: #1a4a8a;
+  --term-magenta: #8a1a5a;
+  --term-cyan: #1a6a8a;
+  --term-yellow: #6a5a00;
+  --term-red: #8a1a2a;
+  --term-status-bg: #1a1a14;
+  --term-status-fg: #efe9d6;
+  --term-status-active: #ffe066;
+  --term-dot-red: #b8513f;
+  --term-dot-yellow: #b88a1f;
+  --term-dot-green: #2a8a35;
+  --term-glow: rgb(26 26 20 / 0%);
+  --term-scanline: rgb(0 0 0 / 4%);
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
 }
 
 .dark {
@@ -175,6 +232,24 @@
 }
 
 @layer components {
+  /* Terminal shell wrapper — used by Phase 2's <TerminalShell> component
+     (mockup 68). Kept off <body> on purpose so existing pages keep their
+     current look until the chrome is swapped in Phase 4. */
+  .terminal-shell {
+    background: var(--term-pane);
+    color: var(--term-fg);
+    font-family: var(--font-terminal-mono);
+    font-size: 13px;
+    line-height: 1.45;
+    min-height: 100vh;
+    background-image: repeating-linear-gradient(
+      0deg,
+      transparent 0 2px,
+      var(--term-scanline) 2px 3px
+    );
+    text-shadow: 0 0 6px var(--term-glow);
+  }
+
   /* The patterns are from https://www.heropatterns.com/ */
   .bg-bevel-circle {
     background-color: var(--background);

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const cssPath = fileURLToPath(new URL("./styles.css", import.meta.url));
+const css = readFileSync(cssPath, "utf-8");
+
+const REQUIRED_TOKENS = [
+  "--term-bg",
+  "--term-pane",
+  "--term-pane-2",
+  "--term-fg",
+  "--term-fg-dim",
+  "--term-fg-mute",
+  "--term-border",
+  "--term-border-hi",
+  "--term-accent",
+  "--term-magenta",
+  "--term-cyan",
+  "--term-yellow",
+  "--term-red",
+  "--term-status-bg",
+  "--term-status-fg",
+  "--term-status-active",
+  "--term-dot-red",
+  "--term-dot-yellow",
+  "--term-dot-green",
+  "--term-glow",
+  "--term-scanline",
+];
+
+function blockFor(selector: string): string {
+  const re = new RegExp(
+    `${selector.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")}\\s*\\{([^}]*)\\}`,
+    "m"
+  );
+  const m = css.match(re);
+  if (!m) throw new Error(`selector not found in styles.css: ${selector}`);
+  return m[1];
+}
+
+describe("terminal theme tokens", () => {
+  test(":root defines every required terminal token", () => {
+    const root = blockFor(":root");
+    for (const token of REQUIRED_TOKENS) {
+      expect(root, `missing ${token} in :root`).toContain(token);
+    }
+  });
+
+  test(`[data-theme="light"] overrides every required terminal token`, () => {
+    const light = blockFor(`[data-theme="light"]`);
+    for (const token of REQUIRED_TOKENS) {
+      expect(light, `missing ${token} in [data-theme="light"]`).toContain(
+        token
+      );
+    }
+  });
+
+  test("dark and light values for --term-accent differ", () => {
+    const root = blockFor(":root");
+    const light = blockFor(`[data-theme="light"]`);
+    const re = /--term-accent:\s*([^;]+);/;
+    const dark = root.match(re)?.[1].trim();
+    const lightVal = light.match(re)?.[1].trim();
+    expect(dark).toBeTruthy();
+    expect(lightVal).toBeTruthy();
+    expect(dark).not.toBe(lightVal);
+  });
+
+  test("monospace font variable is registered", () => {
+    expect(css).toMatch(/--font-terminal-mono:\s*"JetBrains Mono"/);
+  });
+
+  test("@keyframes blink is defined", () => {
+    expect(css).toMatch(/@keyframes\s+blink\s*\{[^}]*opacity:\s*0/);
+  });
+
+  test(".terminal-shell utility applies scanline + mono font", () => {
+    const re = /\.terminal-shell\s*\{([^}]*)\}/m;
+    const block = css.match(re)?.[1];
+    expect(block).toBeTruthy();
+    expect(block).toContain("var(--font-terminal-mono)");
+    expect(block).toContain("repeating-linear-gradient");
+    expect(block).toContain("var(--term-scanline)");
+    expect(block).toContain("text-shadow");
+  });
+});


### PR DESCRIPTION
## Summary
- `<TmuxStatusBar>` — bottom status bar from mockup 68: session label, window list, active window marked with asterisk + underline + `aria-current='page'`, right-aligned slot.
- `<Clock>` — SSR-safe live HH:MM clock, updates every 30s via `setInterval` in `useEffect`. Renders empty until mounted to avoid hydration mismatch.

## Stacked on
`issue-145-mock-data` (#157) for the `TmuxWindow` type, plus a merge of `issue-139-theme-tokens` (#156) for the `--term-status-*` tokens.

## Test plan
- [x] `bun run test` — 23 passed (5 new tmux-status-bar tests + 18 existing). Coverage:
  - Session label rendering.
  - All windows render with `id:label` format.
  - Active window has `aria-current='page'` and asterisk suffix; inactive does not.
  - Custom `right` slot renders.
  - Clock renders HH:MM after mount and advances after 30s (vitest fake timers).
- [x] `bun run lint` — clean.

Closes #143. Part of #106.