### PR TITLE
Phase 2: <TermNav> + NAV_LINKS

### DIFF
--- a/src/components/terminal/term-nav.test.tsx
+++ b/src/components/terminal/term-nav.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { NAV_LINKS, TermNav } from "./term-nav";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    children,
+    ...rest
+  }: {
+    to: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+afterEach(() => cleanup());
+
+describe("TermNav", () => {
+  test("renders the brand", () => {
+    render(<TermNav />);
+    expect(screen.getByText("codeselfstudy")).toBeTruthy();
+  });
+
+  test("renders every NAV_LINKS entry as an <a> with correct href", () => {
+    render(<TermNav />);
+    for (const link of NAV_LINKS) {
+      const a = screen.getByRole("link", { name: link.label });
+      expect(a.getAttribute("href")).toBe(link.to);
+    }
+  });
+
+  test("primary nav landmark has aria-label='primary'", () => {
+    render(<TermNav />);
+    const nav = screen.getByRole("navigation", { name: "primary" });
+    expect(nav).toBeTruthy();
+  });
+
+  test("themeToggle slot renders when provided", () => {
+    render(<TermNav themeToggle={<button>tt</button>} />);
+    expect(screen.getByRole("button", { name: "tt" })).toBeTruthy();
+  });
+
+  test("custom links prop overrides the default NAV_LINKS", () => {
+    render(
+      <TermNav
+        links={[
+          { to: "/x", label: "x-page" },
+          { to: "/y", label: "y-page" },
+        ]}
+      />
+    );
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+    expect(screen.getByRole("link", { name: "x-page" })).toBeTruthy();
+  });
+});

--- a/src/components/terminal/term-nav.tsx
+++ b/src/components/terminal/term-nav.tsx
@@ -1,0 +1,77 @@
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+export type NavLink = {
+  to: string;
+  label: string;
+};
+
+export const NAV_LINKS: Array<NavLink> = [
+  { to: "/", label: "home" },
+  { to: "/events", label: "events" },
+  { to: "/learn", label: "learn" },
+  { to: "/forum", label: "forum" },
+  { to: "/jobs", label: "jobs" },
+  { to: "/puzzles", label: "puzzles" },
+  { to: "/tools", label: "tools" },
+  { to: "/about", label: "about" },
+];
+
+type TermNavProps = {
+  /** Slot for the theme toggle (kept as a slot so TermNav stays presentational). */
+  themeToggle?: ReactNode;
+  /** Override the link list (default: NAV_LINKS). */
+  links?: Array<NavLink>;
+};
+
+export function TermNav({ themeToggle, links = NAV_LINKS }: TermNavProps) {
+  return (
+    <nav
+      aria-label="primary"
+      style={{
+        display: "flex",
+        gap: 8,
+        flexWrap: "wrap",
+        alignItems: "center",
+        padding: "10px 14px",
+        background: "var(--term-pane)",
+        borderBottom: "1px solid var(--term-border)",
+        fontFamily: "var(--font-terminal-mono)",
+      }}
+    >
+      <span
+        style={{
+          color: "var(--term-fg)",
+          fontSize: 13,
+          marginRight: 12,
+          letterSpacing: "0.04em",
+        }}
+      >
+        <b style={{ color: "var(--term-accent)", fontWeight: 600 }}>
+          codeselfstudy
+        </b>
+      </span>
+      {links.map((link) => (
+        // @ts-expect-error TanStack Router's typed routes are codegen'd; allow string `to`.
+        <Link
+          key={link.to}
+          to={link.to}
+          style={{
+            fontSize: 12,
+            color: "var(--term-fg-dim)",
+            padding: "2px 10px",
+            border: "1px solid var(--term-border)",
+            borderRadius: 4,
+            textDecoration: "none",
+            letterSpacing: "0.04em",
+          }}
+        >
+          {link.label}
+        </Link>
+      ))}
+      {themeToggle ? (
+        <span style={{ marginLeft: "auto" }}>{themeToggle}</span>
+      ) : null}
+    </nav>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -46,6 +46,63 @@
     "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
     "Helvetica Neue", sans-serif;
   --header-font: "Anton", var(--root-font-sans);
+
+  /* Terminal/tmux redesign tokens (mockup 68). Namespaced --term-* so they
+     don't clash with shadcn's --accent / --border / etc. Default = dark. */
+  --term-bg: #050805;
+  --term-pane: #0a0f0a;
+  --term-pane-2: #0d130d;
+  --term-fg: #b8f5b8;
+  --term-fg-dim: #4a7a4a;
+  --term-fg-mute: #2a4a2a;
+  --term-border: #2a5a2a;
+  --term-border-hi: #5cd65c;
+  --term-accent: #c4ff5e;
+  --term-magenta: #ff7ac6;
+  --term-cyan: #6df;
+  --term-yellow: #ffe066;
+  --term-red: #ff7a7a;
+  --term-status-bg: #1f4a1f;
+  --term-status-fg: #050805;
+  --term-status-active: #ffe066;
+  --term-dot-red: #ff5f56;
+  --term-dot-yellow: #ffbd2e;
+  --term-dot-green: #27c93f;
+  --term-glow: rgb(184 245 184 / 18%);
+  --term-scanline: rgb(0 0 0 / 18%);
+  --font-terminal-mono:
+    "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code", ui-monospace,
+    "SF Mono", menlo, consolas, monospace;
+}
+
+[data-theme="light"] {
+  --term-bg: #d8d2c0;
+  --term-pane: #efe9d6;
+  --term-pane-2: #e6dfca;
+  --term-fg: #1a1a14;
+  --term-fg-dim: #6a6860;
+  --term-fg-mute: #a8a294;
+  --term-border: #807a6a;
+  --term-border-hi: #1a1a14;
+  --term-accent: #1a4a8a;
+  --term-magenta: #8a1a5a;
+  --term-cyan: #1a6a8a;
+  --term-yellow: #6a5a00;
+  --term-red: #8a1a2a;
+  --term-status-bg: #1a1a14;
+  --term-status-fg: #efe9d6;
+  --term-status-active: #ffe066;
+  --term-dot-red: #b8513f;
+  --term-dot-yellow: #b88a1f;
+  --term-dot-green: #2a8a35;
+  --term-glow: rgb(26 26 20 / 0%);
+  --term-scanline: rgb(0 0 0 / 4%);
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
 }
 
 .dark {
@@ -175,6 +232,24 @@
 }
 
 @layer components {
+  /* Terminal shell wrapper — used by Phase 2's <TerminalShell> component
+     (mockup 68). Kept off <body> on purpose so existing pages keep their
+     current look until the chrome is swapped in Phase 4. */
+  .terminal-shell {
+    background: var(--term-pane);
+    color: var(--term-fg);
+    font-family: var(--font-terminal-mono);
+    font-size: 13px;
+    line-height: 1.45;
+    min-height: 100vh;
+    background-image: repeating-linear-gradient(
+      0deg,
+      transparent 0 2px,
+      var(--term-scanline) 2px 3px
+    );
+    text-shadow: 0 0 6px var(--term-glow);
+  }
+
   /* The patterns are from https://www.heropatterns.com/ */
   .bg-bevel-circle {
     background-color: var(--background);

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const cssPath = fileURLToPath(new URL("./styles.css", import.meta.url));
+const css = readFileSync(cssPath, "utf-8");
+
+const REQUIRED_TOKENS = [
+  "--term-bg",
+  "--term-pane",
+  "--term-pane-2",
+  "--term-fg",
+  "--term-fg-dim",
+  "--term-fg-mute",
+  "--term-border",
+  "--term-border-hi",
+  "--term-accent",
+  "--term-magenta",
+  "--term-cyan",
+  "--term-yellow",
+  "--term-red",
+  "--term-status-bg",
+  "--term-status-fg",
+  "--term-status-active",
+  "--term-dot-red",
+  "--term-dot-yellow",
+  "--term-dot-green",
+  "--term-glow",
+  "--term-scanline",
+];
+
+function blockFor(selector: string): string {
+  const re = new RegExp(
+    `${selector.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")}\\s*\\{([^}]*)\\}`,
+    "m"
+  );
+  const m = css.match(re);
+  if (!m) throw new Error(`selector not found in styles.css: ${selector}`);
+  return m[1];
+}
+
+describe("terminal theme tokens", () => {
+  test(":root defines every required terminal token", () => {
+    const root = blockFor(":root");
+    for (const token of REQUIRED_TOKENS) {
+      expect(root, `missing ${token} in :root`).toContain(token);
+    }
+  });
+
+  test(`[data-theme="light"] overrides every required terminal token`, () => {
+    const light = blockFor(`[data-theme="light"]`);
+    for (const token of REQUIRED_TOKENS) {
+      expect(light, `missing ${token} in [data-theme="light"]`).toContain(
+        token
+      );
+    }
+  });
+
+  test("dark and light values for --term-accent differ", () => {
+    const root = blockFor(":root");
+    const light = blockFor(`[data-theme="light"]`);
+    const re = /--term-accent:\s*([^;]+);/;
+    const dark = root.match(re)?.[1].trim();
+    const lightVal = light.match(re)?.[1].trim();
+    expect(dark).toBeTruthy();
+    expect(lightVal).toBeTruthy();
+    expect(dark).not.toBe(lightVal);
+  });
+
+  test("monospace font variable is registered", () => {
+    expect(css).toMatch(/--font-terminal-mono:\s*"JetBrains Mono"/);
+  });
+
+  test("@keyframes blink is defined", () => {
+    expect(css).toMatch(/@keyframes\s+blink\s*\{[^}]*opacity:\s*0/);
+  });
+
+  test(".terminal-shell utility applies scanline + mono font", () => {
+    const re = /\.terminal-shell\s*\{([^}]*)\}/m;
+    const block = css.match(re)?.[1];
+    expect(block).toBeTruthy();
+    expect(block).toContain("var(--font-terminal-mono)");
+    expect(block).toContain("repeating-linear-gradient");
+    expect(block).toContain("var(--term-scanline)");
+    expect(block).toContain("text-shadow");
+  });
+});


### PR DESCRIPTION
## Summary
- `<TermNav>` — the navboxes row from mockup 68: brand, link list, theme-toggle slot.
- Exports `NAV_LINKS` const with the 8 routes the mockup shows: home, events, learn, forum, jobs, puzzles, tools, about. All routes already exist under `src/routes/`.
- Uses TanStack Router's `<Link>`.
- Tests mock `@tanstack/react-router` to a plain `<a>`, sidestepping the need for a router context in unit tests.

## Stacked on
`issue-139-theme-tokens` (#156) for the `--term-*` tokens.

## Test plan
- [x] `bun run test` — 23 passed (5 new TermNav tests + 18 existing). Coverage:
  - Brand renders.
  - Each NAV_LINKS entry renders as a link with correct `href`.
  - Nav landmark has `aria-label='primary'`.
  - Theme-toggle slot renders when provided.
  - Custom `links` prop overrides defaults.
- [x] `bun run lint` — clean.

Closes #142. Part of #106.