### PR TITLE
Phase 3: <WelcomePane>

### DIFF
--- a/src/components/terminal/ascii-bar.test.tsx
+++ b/src/components/terminal/ascii-bar.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { AsciiBar } from "./ascii-bar";
+
+afterEach(() => cleanup());
+
+describe("AsciiBar", () => {
+  test("renders proportional fill at 50%", () => {
+    const { container } = render(<AsciiBar value={50} width={10} />);
+    expect(container.textContent).toBe("█████░░░░░");
+  });
+
+  test("clamps values above 100", () => {
+    const { container } = render(<AsciiBar value={250} width={4} />);
+    expect(container.textContent).toBe("████");
+  });
+
+  test("clamps negative values to 0", () => {
+    const { container } = render(<AsciiBar value={-5} width={4} />);
+    expect(container.textContent).toBe("░░░░");
+  });
+
+  test("color variant maps to --term-cyan token", () => {
+    const { container } = render(
+      <AsciiBar value={20} width={5} color="cyan" />
+    );
+    const span = container.querySelector("span");
+    expect(span?.style.color).toContain("--term-cyan");
+  });
+});

--- a/src/components/terminal/ascii-bar.tsx
+++ b/src/components/terminal/ascii-bar.tsx
@@ -1,0 +1,37 @@
+type Color = "green" | "cyan" | "yellow" | "magenta";
+
+const COLOR_VAR: Record<Color, string> = {
+  green: "var(--term-accent)",
+  cyan: "var(--term-cyan)",
+  yellow: "var(--term-yellow)",
+  magenta: "var(--term-magenta)",
+};
+
+type AsciiBarProps = {
+  /** 0–100, clamped. */
+  value: number;
+  /** Total character width of the bar. */
+  width: number;
+  color?: Color;
+};
+
+export function AsciiBar({ value, width, color = "green" }: AsciiBarProps) {
+  const clamped = Math.max(0, Math.min(100, value));
+  const filled = Math.round((clamped / 100) * width);
+  const empty = width - filled;
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        color: COLOR_VAR[color],
+        whiteSpace: "pre",
+        overflow: "hidden",
+        letterSpacing: "-1px",
+        fontFamily: "inherit",
+      }}
+    >
+      {"█".repeat(filled)}
+      {"░".repeat(empty)}
+    </span>
+  );
+}

--- a/src/components/terminal/blinking-cursor.test.tsx
+++ b/src/components/terminal/blinking-cursor.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { BlinkingCursor } from "./blinking-cursor";
+
+afterEach(() => cleanup());
+
+describe("BlinkingCursor", () => {
+  test("renders ▮ glyph", () => {
+    const { container } = render(<BlinkingCursor />);
+    expect(container.textContent).toBe("▮");
+  });
+
+  test("has blink animation applied", () => {
+    const { container } = render(<BlinkingCursor />);
+    const span = container.querySelector("span");
+    expect(span?.style.animation).toContain("blink");
+  });
+});

--- a/src/components/terminal/blinking-cursor.tsx
+++ b/src/components/terminal/blinking-cursor.tsx
@@ -1,0 +1,13 @@
+export function BlinkingCursor() {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        color: "var(--term-accent)",
+        animation: "blink 1.1s steps(1) infinite",
+      }}
+    >
+      ▮
+    </span>
+  );
+}

--- a/src/components/terminal/meter.test.tsx
+++ b/src/components/terminal/meter.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Meter } from "./meter";
+
+afterEach(() => cleanup());
+
+describe("Meter", () => {
+  test("inner fill width matches the value prop", () => {
+    const { container } = render(<Meter value={73} />);
+    const inner = container.querySelector("i");
+    expect(inner?.style.width).toBe("73%");
+  });
+
+  test("clamps values above 100", () => {
+    const { container } = render(<Meter value={250} />);
+    const inner = container.querySelector("i");
+    expect(inner?.style.width).toBe("100%");
+  });
+
+  test("exposes aria meter semantics", () => {
+    render(<Meter value={42} ariaLabel="members" />);
+    const meter = screen.getByRole("meter", { name: "members" });
+    expect(meter.getAttribute("aria-valuenow")).toBe("42");
+    expect(meter.getAttribute("aria-valuemin")).toBe("0");
+    expect(meter.getAttribute("aria-valuemax")).toBe("100");
+  });
+
+  test("color variant maps to --term-magenta token", () => {
+    const { container } = render(<Meter value={50} color="magenta" />);
+    const inner = container.querySelector("i");
+    expect(inner?.style.background).toContain("--term-magenta");
+  });
+});

--- a/src/components/terminal/meter.tsx
+++ b/src/components/terminal/meter.tsx
@@ -1,0 +1,46 @@
+type Color = "green" | "cyan" | "magenta";
+
+const COLOR_VAR: Record<Color, string> = {
+  green: "var(--term-accent)",
+  cyan: "var(--term-cyan)",
+  magenta: "var(--term-magenta)",
+};
+
+type MeterProps = {
+  /** 0–100, clamped. */
+  value: number;
+  color?: Color;
+  ariaLabel?: string;
+};
+
+export function Meter({ value, color = "green", ariaLabel }: MeterProps) {
+  const clamped = Math.max(0, Math.min(100, value));
+  const fill = COLOR_VAR[color];
+  return (
+    <span
+      role="meter"
+      aria-label={ariaLabel}
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      style={{
+        flex: 1,
+        display: "block",
+        height: 10,
+        border: "1px solid var(--term-border)",
+        background: "var(--term-pane-2)",
+        position: "relative",
+      }}
+    >
+      <i
+        style={{
+          display: "block",
+          height: "100%",
+          width: `${clamped}%`,
+          background: fill,
+          boxShadow: `0 0 6px ${fill}`,
+        }}
+      />
+    </span>
+  );
+}

--- a/src/components/terminal/term-pane.test.tsx
+++ b/src/components/terminal/term-pane.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { TermPane } from "./term-pane";
+
+afterEach(() => cleanup());
+
+describe("TermPane", () => {
+  test("renders index, label, and child body", () => {
+    render(
+      <TermPane index={2} label="~/welcome">
+        <div>body</div>
+      </TermPane>
+    );
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("~/welcome")).toBeTruthy();
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+
+  test("renders keys hint when provided", () => {
+    render(
+      <TermPane index={0} label="~/x" keys="↑↓ scroll">
+        <span />
+      </TermPane>
+    );
+    expect(screen.getByText("↑↓ scroll")).toBeTruthy();
+  });
+
+  test("variant='full' applies grid-column 1 / -1", () => {
+    const { container } = render(
+      <TermPane index={0} label="~/x" variant="full">
+        <span />
+      </TermPane>
+    );
+    const section = container.querySelector("section");
+    expect(section?.style.gridColumn).toBe("1 / -1");
+  });
+
+  test("variant='last' drops the right border", () => {
+    const { container } = render(
+      <TermPane index={0} label="~/x" variant="last">
+        <span />
+      </TermPane>
+    );
+    const section = container.querySelector("section");
+    expect(section?.style.borderRightWidth).toBe("0px");
+  });
+
+  test("labelColor='magenta' colors the label with --term-magenta", () => {
+    const { container } = render(
+      <TermPane index={3} label="recent" labelColor="magenta">
+        <span />
+      </TermPane>
+    );
+    const labelSpan = container.querySelector("header span:nth-child(2)");
+    expect((labelSpan as HTMLElement | null)?.style.color).toContain(
+      "--term-magenta"
+    );
+  });
+});

--- a/src/components/terminal/term-pane.tsx
+++ b/src/components/terminal/term-pane.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+
+type LabelColor = "green" | "cyan" | "magenta" | "yellow";
+type Variant = "default" | "full" | "last";
+
+const LABEL_COLOR_VAR: Record<LabelColor, string> = {
+  green: "var(--term-accent)",
+  cyan: "var(--term-cyan)",
+  magenta: "var(--term-magenta)",
+  yellow: "var(--term-yellow)",
+};
+
+type TermPaneProps = {
+  index: number;
+  label: string;
+  labelColor?: LabelColor;
+  /** Right-aligned hint text in the pane bar (e.g. "↑↓ scroll · / filter"). */
+  keys?: string;
+  /** "full" spans both grid columns; "last" removes the right border. */
+  variant?: Variant;
+  children: ReactNode;
+};
+
+export function TermPane({
+  index,
+  label,
+  labelColor = "green",
+  keys,
+  variant = "default",
+  children,
+}: TermPaneProps) {
+  const noRightBorder = variant === "last" || variant === "full";
+  return (
+    <section
+      style={{
+        background: "var(--term-pane)",
+        borderRightStyle: "solid",
+        borderRightWidth: noRightBorder ? 0 : 1,
+        borderRightColor: "var(--term-border)",
+        borderBottom: "1px solid var(--term-border)",
+        gridColumn: variant === "full" ? "1 / -1" : undefined,
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "4px 10px",
+          color: "var(--term-fg-dim)",
+          fontSize: 12,
+          borderBottom: "1px dashed var(--term-border)",
+          background: "var(--term-pane-2)",
+        }}
+      >
+        <span>{index}</span>
+        <span style={{ color: LABEL_COLOR_VAR[labelColor] }}>{label}</span>
+        <span
+          aria-hidden="true"
+          style={{
+            flex: 1,
+            borderBottom: "1px dashed var(--term-fg-mute)",
+            margin: "0 4px",
+            height: 0,
+            transform: "translateY(2px)",
+          }}
+        />
+        {keys ? (
+          <span style={{ color: "var(--term-fg-mute)" }}>{keys}</span>
+        ) : null}
+      </header>
+      <div style={{ padding: "12px 14px" }}>{children}</div>
+    </section>
+  );
+}

--- a/src/components/terminal/welcome-pane.test.tsx
+++ b/src/components/terminal/welcome-pane.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { WelcomePane } from "./welcome-pane";
+import { WELCOME_COPY } from "@/content/mock-home-data";
+
+afterEach(() => cleanup());
+
+describe("WelcomePane", () => {
+  test("renders title text", () => {
+    render(<WelcomePane />);
+    expect(screen.getByText(WELCOME_COPY.title)).toBeTruthy();
+  });
+
+  test("renders every whatWeDo bullet", () => {
+    render(<WelcomePane />);
+    for (const item of WELCOME_COPY.whatWeDo) {
+      expect(screen.getByText(item)).toBeTruthy();
+    }
+  });
+
+  test("CTA renders with correct label and href", () => {
+    render(<WelcomePane />);
+    const cta = screen.getByRole("link", { name: WELCOME_COPY.cta.label });
+    expect(cta.getAttribute("href")).toBe(WELCOME_COPY.cta.href);
+  });
+
+  test("highlights the leadHighlight substring", () => {
+    render(<WelcomePane />);
+    const bold = screen.getByText(WELCOME_COPY.leadHighlight);
+    expect(bold.tagName.toLowerCase()).toBe("b");
+  });
+
+  test("renders the blinking cursor glyph", () => {
+    const { container } = render(<WelcomePane />);
+    expect(container.textContent).toContain("▮");
+  });
+
+  test("custom copy prop overrides default", () => {
+    render(
+      <WelcomePane
+        copy={{
+          ...WELCOME_COPY,
+          title: "different title",
+          cta: { label: "Sign up", href: "https://example.com" },
+        }}
+      />
+    );
+    expect(screen.getByText("different title")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Sign up" }).getAttribute("href")
+    ).toBe("https://example.com");
+  });
+});

--- a/src/components/terminal/welcome-pane.tsx
+++ b/src/components/terminal/welcome-pane.tsx
@@ -1,0 +1,85 @@
+import { TermPane } from "./term-pane";
+import { BlinkingCursor } from "./blinking-cursor";
+import { WELCOME_COPY } from "@/content/mock-home-data";
+
+type WelcomePaneProps = {
+  copy?: typeof WELCOME_COPY;
+};
+
+export function WelcomePane({ copy = WELCOME_COPY }: WelcomePaneProps = {}) {
+  const [leadBefore, leadAfter] = copy.lead.split(copy.leadHighlight);
+
+  return (
+    <TermPane
+      index={2}
+      label="~/welcome"
+      labelColor="yellow"
+      keys="prefix + ? help"
+      variant="full"
+    >
+      <pre
+        style={{
+          whiteSpace: "pre",
+          margin: 0,
+          fontSize: 11,
+          lineHeight: 1.05,
+          color: "var(--term-fg-dim)",
+          fontFamily: "inherit",
+        }}
+      >
+        {"  "}
+        <span style={{ color: "var(--term-accent)" }}>{copy.title}</span>
+        {" · "}
+        {copy.tagline}
+      </pre>
+      <p style={{ margin: "8px 0 4px", color: "var(--term-fg)" }}>
+        {leadBefore}
+        <b style={{ color: "var(--term-yellow)" }}>{copy.leadHighlight}</b>
+        {leadAfter}
+        <BlinkingCursor />
+      </p>
+      <div style={{ color: "var(--term-fg-dim)" }}>what we do ::</div>
+      <ul
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "4px 10px",
+          marginTop: 6,
+          padding: 0,
+          listStyle: "none",
+        }}
+      >
+        {copy.whatWeDo.map((item) => (
+          <li key={item} style={{ color: "var(--term-fg)" }}>
+            <span aria-hidden="true" style={{ color: "var(--term-fg-mute)" }}>
+              ▸{" "}
+            </span>
+            {item}
+          </li>
+        ))}
+      </ul>
+      <div
+        style={{
+          display: "flex",
+          gap: 10,
+          flexWrap: "wrap",
+          marginTop: 14,
+        }}
+      >
+        <a
+          href={copy.cta.href}
+          style={{
+            display: "inline-block",
+            padding: "4px 12px",
+            border: "1px solid var(--term-accent)",
+            color: "var(--term-accent)",
+            textDecoration: "none",
+            fontFamily: "inherit",
+          }}
+        >
+          {copy.cta.label}
+        </a>
+      </div>
+    </TermPane>
+  );
+}

--- a/src/content/mock-home-data.ts
+++ b/src/content/mock-home-data.ts
@@ -1,0 +1,168 @@
+/**
+ * Hardcoded data for the terminal/tmux home redesign (mockup 68).
+ * Values copied verbatim from mockups/68-tmux-home-cta-below.html.
+ * Real data wiring is follow-up work; for now feature panes import from here.
+ */
+
+export type TermColor = "green" | "cyan" | "yellow" | "magenta";
+
+export type Language = {
+  name: string;
+  percent: number;
+  color: TermColor;
+};
+
+export const LANGUAGES: Array<Language> = [
+  { name: "python", percent: 62, color: "green" },
+  { name: "javascript", percent: 54, color: "cyan" },
+  { name: "typescript", percent: 48, color: "cyan" },
+  { name: "go", percent: 35, color: "yellow" },
+  { name: "rust", percent: 31, color: "yellow" },
+  { name: "haskell", percent: 22, color: "magenta" },
+  { name: "clojure", percent: 19, color: "magenta" },
+  { name: "elixir", percent: 17, color: "magenta" },
+  { name: "racket", percent: 14, color: "green" },
+];
+
+export const LANGUAGES_OVERFLOW_LABEL = "+ 12 more";
+
+export type StatRow = {
+  label: string;
+  value: string | number;
+  color: "green" | "cyan" | "magenta";
+  meterPercent: number;
+};
+
+export type NetActivity = {
+  icon: "↓" | "↑" | "⇄";
+  value: number;
+  label: string;
+  color: TermColor;
+};
+
+export const STATS = {
+  community: [
+    { label: "members", value: "5,000+", color: "green", meterPercent: 92 },
+    { label: "years up", value: 11, color: "cyan", meterPercent: 82 },
+    { label: "langs", value: "20+", color: "magenta", meterPercent: 70 },
+  ] satisfies Array<StatRow>,
+  netThisWeek: [
+    { icon: "↓", value: 12, label: "meetups / month", color: "green" },
+    { icon: "↑", value: 234, label: "forum posts", color: "cyan" },
+    { icon: "⇄", value: 38, label: "intros & jobs", color: "yellow" },
+  ] satisfies Array<NetActivity>,
+  loadAvgAscii: "▁▂▃▅▆▇█▇▆▅▆▇█▇▆▅▃▂▃▅▇█▇▆▅▆▇█▇▆▅",
+  loadAvgCaption: "12mo · steady & rising",
+} as const;
+
+export type ForumPost = {
+  when: string;
+  by: string;
+  category: string;
+  /** CSS color string — uses the --term-* variables from styles.css. */
+  categoryColor: string;
+  topic: string;
+  replies: number;
+};
+
+export const FORUM_ACTIVITY: Array<ForumPost> = [
+  {
+    when: "2m",
+    by: "alice",
+    category: "#rust",
+    categoryColor: "var(--term-yellow)",
+    topic:
+      "code review on a tiny json parser — got it down to 180 lines, can it be smaller?",
+    replies: 8,
+  },
+  {
+    when: "14m",
+    by: "bob",
+    category: "#events",
+    categoryColor: "var(--term-cyan)",
+    topic: "in-person meetup · Berkeley library · sat 1pm · 18 RSVPs",
+    replies: 3,
+  },
+  {
+    when: "42m",
+    by: "carol",
+    category: "#haskell",
+    categoryColor: "var(--term-magenta)",
+    topic:
+      "finally got `traverse` to click — short writeup with the aha moment",
+    replies: 12,
+  },
+  {
+    when: "1h",
+    by: "dan",
+    category: "#beginners",
+    categoryColor: "var(--term-accent)",
+    topic: "study plan for going from JS → systems programming?",
+    replies: 21,
+  },
+  {
+    when: "3h",
+    by: "eve",
+    category: "#jobs",
+    /* mockup uses #ffb86b, an orange not in the token set; keep literal. */
+    categoryColor: "#ffb86b",
+    topic: "backend role at a small SF startup — intros welcome",
+    replies: 5,
+  },
+  {
+    when: "5h",
+    by: "frank",
+    category: "#tools",
+    categoryColor: "var(--term-cyan)",
+    topic: "regex-trainer · new contributor · added lookahead exercises",
+    replies: 2,
+  },
+  {
+    when: "8h",
+    by: "grace",
+    category: "#elixir",
+    categoryColor: "var(--term-magenta)",
+    topic: "phoenix study group · weds 7pm · open to all levels",
+    replies: 7,
+  },
+];
+
+export const WELCOME_COPY = {
+  title: "code self study",
+  tagline:
+    "a friendly programming community in the san francisco bay area · est. 2014 · all languages, all levels, in person + online",
+  /**
+   * The "5,000+" substring is intended to be visually highlighted by the
+   * <WelcomePane> component (e.g. wrapped in a styled span).
+   */
+  lead: "Self-study computer programming alongside 5,000+ members in Berkeley and the SF Bay Area. Bring a project, bring a question, or just show up. We meet in person and online.",
+  leadHighlight: "5,000+",
+  whatWeDo: [
+    "build a local community of motivated programmers",
+    "open to every language & level",
+    "self-study with mentorship from experienced members",
+    "bootcamp supplement or alternative",
+  ],
+  cta: {
+    label: "Join",
+    href: "https://www.meetup.com/codeselfstudy/",
+  },
+} as const;
+
+export type TmuxWindow = {
+  id: number;
+  label: string;
+  href?: string;
+};
+
+export const TMUX_SESSION = "codeselfstudy" as const;
+
+export const TMUX_WINDOWS: Array<TmuxWindow> = [
+  { id: 0, label: "home", href: "/" },
+  { id: 1, label: "forum", href: "/forum" },
+  { id: 2, label: "events", href: "/events" },
+  { id: 3, label: "learn", href: "/learn" },
+  { id: 4, label: "jobs", href: "/jobs" },
+];
+
+export const TMUX_RIGHT_TEXT = "members 5,000+ · est. 2014" as const;

--- a/src/styles.css
+++ b/src/styles.css
@@ -46,6 +46,63 @@
     "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
     "Helvetica Neue", sans-serif;
   --header-font: "Anton", var(--root-font-sans);
+
+  /* Terminal/tmux redesign tokens (mockup 68). Namespaced --term-* so they
+     don't clash with shadcn's --accent / --border / etc. Default = dark. */
+  --term-bg: #050805;
+  --term-pane: #0a0f0a;
+  --term-pane-2: #0d130d;
+  --term-fg: #b8f5b8;
+  --term-fg-dim: #4a7a4a;
+  --term-fg-mute: #2a4a2a;
+  --term-border: #2a5a2a;
+  --term-border-hi: #5cd65c;
+  --term-accent: #c4ff5e;
+  --term-magenta: #ff7ac6;
+  --term-cyan: #6df;
+  --term-yellow: #ffe066;
+  --term-red: #ff7a7a;
+  --term-status-bg: #1f4a1f;
+  --term-status-fg: #050805;
+  --term-status-active: #ffe066;
+  --term-dot-red: #ff5f56;
+  --term-dot-yellow: #ffbd2e;
+  --term-dot-green: #27c93f;
+  --term-glow: rgb(184 245 184 / 18%);
+  --term-scanline: rgb(0 0 0 / 18%);
+  --font-terminal-mono:
+    "JetBrains Mono", "IBM Plex Mono", "Iosevka", "Fira Code", ui-monospace,
+    "SF Mono", menlo, consolas, monospace;
+}
+
+[data-theme="light"] {
+  --term-bg: #d8d2c0;
+  --term-pane: #efe9d6;
+  --term-pane-2: #e6dfca;
+  --term-fg: #1a1a14;
+  --term-fg-dim: #6a6860;
+  --term-fg-mute: #a8a294;
+  --term-border: #807a6a;
+  --term-border-hi: #1a1a14;
+  --term-accent: #1a4a8a;
+  --term-magenta: #8a1a5a;
+  --term-cyan: #1a6a8a;
+  --term-yellow: #6a5a00;
+  --term-red: #8a1a2a;
+  --term-status-bg: #1a1a14;
+  --term-status-fg: #efe9d6;
+  --term-status-active: #ffe066;
+  --term-dot-red: #b8513f;
+  --term-dot-yellow: #b88a1f;
+  --term-dot-green: #2a8a35;
+  --term-glow: rgb(26 26 20 / 0%);
+  --term-scanline: rgb(0 0 0 / 4%);
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
 }
 
 .dark {
@@ -175,6 +232,24 @@
 }
 
 @layer components {
+  /* Terminal shell wrapper — used by Phase 2's <TerminalShell> component
+     (mockup 68). Kept off <body> on purpose so existing pages keep their
+     current look until the chrome is swapped in Phase 4. */
+  .terminal-shell {
+    background: var(--term-pane);
+    color: var(--term-fg);
+    font-family: var(--font-terminal-mono);
+    font-size: 13px;
+    line-height: 1.45;
+    min-height: 100vh;
+    background-image: repeating-linear-gradient(
+      0deg,
+      transparent 0 2px,
+      var(--term-scanline) 2px 3px
+    );
+    text-shadow: 0 0 6px var(--term-glow);
+  }
+
   /* The patterns are from https://www.heropatterns.com/ */
   .bg-bevel-circle {
     background-color: var(--background);

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const cssPath = fileURLToPath(new URL("./styles.css", import.meta.url));
+const css = readFileSync(cssPath, "utf-8");
+
+const REQUIRED_TOKENS = [
+  "--term-bg",
+  "--term-pane",
+  "--term-pane-2",
+  "--term-fg",
+  "--term-fg-dim",
+  "--term-fg-mute",
+  "--term-border",
+  "--term-border-hi",
+  "--term-accent",
+  "--term-magenta",
+  "--term-cyan",
+  "--term-yellow",
+  "--term-red",
+  "--term-status-bg",
+  "--term-status-fg",
+  "--term-status-active",
+  "--term-dot-red",
+  "--term-dot-yellow",
+  "--term-dot-green",
+  "--term-glow",
+  "--term-scanline",
+];
+
+function blockFor(selector: string): string {
+  const re = new RegExp(
+    `${selector.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")}\\s*\\{([^}]*)\\}`,
+    "m"
+  );
+  const m = css.match(re);
+  if (!m) throw new Error(`selector not found in styles.css: ${selector}`);
+  return m[1];
+}
+
+describe("terminal theme tokens", () => {
+  test(":root defines every required terminal token", () => {
+    const root = blockFor(":root");
+    for (const token of REQUIRED_TOKENS) {
+      expect(root, `missing ${token} in :root`).toContain(token);
+    }
+  });
+
+  test(`[data-theme="light"] overrides every required terminal token`, () => {
+    const light = blockFor(`[data-theme="light"]`);
+    for (const token of REQUIRED_TOKENS) {
+      expect(light, `missing ${token} in [data-theme="light"]`).toContain(
+        token
+      );
+    }
+  });
+
+  test("dark and light values for --term-accent differ", () => {
+    const root = blockFor(":root");
+    const light = blockFor(`[data-theme="light"]`);
+    const re = /--term-accent:\s*([^;]+);/;
+    const dark = root.match(re)?.[1].trim();
+    const lightVal = light.match(re)?.[1].trim();
+    expect(dark).toBeTruthy();
+    expect(lightVal).toBeTruthy();
+    expect(dark).not.toBe(lightVal);
+  });
+
+  test("monospace font variable is registered", () => {
+    expect(css).toMatch(/--font-terminal-mono:\s*"JetBrains Mono"/);
+  });
+
+  test("@keyframes blink is defined", () => {
+    expect(css).toMatch(/@keyframes\s+blink\s*\{[^}]*opacity:\s*0/);
+  });
+
+  test(".terminal-shell utility applies scanline + mono font", () => {
+    const re = /\.terminal-shell\s*\{([^}]*)\}/m;
+    const block = css.match(re)?.[1];
+    expect(block).toBeTruthy();
+    expect(block).toContain("var(--font-terminal-mono)");
+    expect(block).toContain("repeating-linear-gradient");
+    expect(block).toContain("var(--term-scanline)");
+    expect(block).toContain("text-shadow");
+  });
+});


### PR DESCRIPTION
## Summary
Composes `<TermPane>` + `<BlinkingCursor>` into the welcome/CTA pane from mockup 68. Reads from `WELCOME_COPY` (overridable via prop). Highlights the `leadHighlight` substring in yellow.

## Stacked on
`redesign-phase3-base` (combines #144 primitives + #145 mock-data). Re-targets `redesign/terminal-tmux` after both base PRs merge.

## Test plan
- [x] `bun run test` — 39 passed (6 new + 33 existing). Coverage: title, every whatWeDo bullet, CTA href/label, lead-highlight is bold, blinking cursor glyph, custom `copy` prop override.
- [x] `bun run lint` — clean.

Closes #146. Part of #106.