### PR TITLE
Phase 3: <LanguagesPane>

### DIFF
--- a/src/components/terminal/languages-pane.test.tsx
+++ b/src/components/terminal/languages-pane.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { LanguagesPane } from "./languages-pane";
+import { LANGUAGES } from "@/content/mock-home-data";
+
+afterEach(() => cleanup());
+
+describe("LanguagesPane", () => {
+  test("renders one row per language plus the overflow row", () => {
+    render(<LanguagesPane />);
+    for (const lang of LANGUAGES) {
+      expect(screen.getByText(lang.name)).toBeTruthy();
+      expect(screen.getByText(`${lang.percent}%`)).toBeTruthy();
+    }
+    expect(screen.getByText(/\+ 12 more/)).toBeTruthy();
+  });
+
+  test("first row is python at 62%", () => {
+    render(<LanguagesPane />);
+    expect(screen.getByText("python")).toBeTruthy();
+    expect(screen.getByText("62%")).toBeTruthy();
+  });
+
+  test("custom languages prop overrides default", () => {
+    render(
+      <LanguagesPane
+        languages={[{ name: "lisp", percent: 100, color: "magenta" }]}
+        overflowLabel=""
+      />
+    );
+    expect(screen.getByText("lisp")).toBeTruthy();
+    expect(screen.getByText("100%")).toBeTruthy();
+    expect(screen.queryByText("python")).toBeNull();
+  });
+});

--- a/src/components/terminal/languages-pane.tsx
+++ b/src/components/terminal/languages-pane.tsx
@@ -1,0 +1,78 @@
+import { TermPane } from "./term-pane";
+import { AsciiBar } from "./ascii-bar";
+import type { Language, TermColor } from "@/content/mock-home-data";
+import { LANGUAGES, LANGUAGES_OVERFLOW_LABEL } from "@/content/mock-home-data";
+
+const PCT_COLOR_VAR: Record<TermColor, string> = {
+  green: "var(--term-accent)",
+  cyan: "var(--term-cyan)",
+  yellow: "var(--term-yellow)",
+  magenta: "var(--term-magenta)",
+};
+
+const BAR_WIDTH = 46;
+
+type LanguagesPaneProps = {
+  languages?: Array<Language>;
+  overflowLabel?: string;
+};
+
+export function LanguagesPane({
+  languages = LANGUAGES,
+  overflowLabel = LANGUAGES_OVERFLOW_LABEL,
+}: LanguagesPaneProps = {}) {
+  return (
+    <TermPane index={0} label="~/languages" keys="↑↓ scroll · / filter">
+      <div style={{ color: "var(--term-fg-dim)", marginBottom: 6 }}>
+        ── languages used by members ──────────────────────
+      </div>
+      {languages.map((lang) => (
+        <div
+          key={lang.name}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "90px 1fr 60px",
+            gap: 10,
+            alignItems: "center",
+            padding: "1px 0",
+          }}
+        >
+          <span style={{ color: "var(--term-fg)" }}>{lang.name}</span>
+          <AsciiBar value={lang.percent} width={BAR_WIDTH} color={lang.color} />
+          <span
+            style={{
+              textAlign: "right",
+              color: PCT_COLOR_VAR[lang.color],
+            }}
+          >
+            {lang.percent}%
+          </span>
+        </div>
+      ))}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "90px 1fr 60px",
+          gap: 10,
+          alignItems: "center",
+          padding: "1px 0",
+        }}
+      >
+        <span style={{ color: "var(--term-fg)" }}>{overflowLabel}</span>
+        <span
+          aria-hidden="true"
+          style={{
+            color: "var(--term-fg-mute)",
+            whiteSpace: "pre",
+            letterSpacing: "-1px",
+          }}
+        >
+          {"░".repeat(BAR_WIDTH)}
+        </span>
+        <span style={{ textAlign: "right", color: "var(--term-fg-dim)" }}>
+          ··
+        </span>
+      </div>
+    </TermPane>
+  );
+}


### PR DESCRIPTION
## Summary
Composes `<TermPane>` + `<AsciiBar>` into the languages bar chart from mockup 68. One row per Language plus an overflow row for the '+ N more' tail.

## Test plan
- [x] `bun run test` — 36 passed (3 new + 33 existing). Coverage: every language row renders with name + percent, first row is python at 62%, custom `languages` prop overrides default.
- [x] `bun run lint` — clean.

Closes #147. Part of #106.