### PR TITLE
Phase 3: <StatsPane>

### DIFF
--- a/src/components/terminal/stats-pane.test.tsx
+++ b/src/components/terminal/stats-pane.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { StatsPane } from "./stats-pane";
+import { STATS } from "@/content/mock-home-data";
+
+afterEach(() => cleanup());
+
+describe("StatsPane", () => {
+  test("renders all three community meters", () => {
+    render(<StatsPane />);
+    for (const row of STATS.community) {
+      expect(screen.getByText(row.label)).toBeTruthy();
+      expect(screen.getByText(String(row.value))).toBeTruthy();
+      expect(screen.getByRole("meter", { name: row.label })).toBeTruthy();
+    }
+  });
+
+  test("renders the net-this-week lines", () => {
+    render(<StatsPane />);
+    for (const row of STATS.netThisWeek) {
+      expect(screen.getByText(row.label)).toBeTruthy();
+      expect(screen.getByText(String(row.value))).toBeTruthy();
+    }
+  });
+
+  test("renders the load-avg ASCII string and caption", () => {
+    const { container } = render(<StatsPane />);
+    expect(container.textContent).toContain(STATS.loadAvgAscii);
+    expect(container.textContent).toContain(STATS.loadAvgCaption);
+  });
+
+  test("custom stats prop overrides default", () => {
+    render(
+      <StatsPane
+        stats={{
+          ...STATS,
+          community: [
+            {
+              label: "custom-label",
+              value: "999",
+              color: "green",
+              meterPercent: 50,
+            },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByText("custom-label")).toBeTruthy();
+    expect(screen.getByText("999")).toBeTruthy();
+    expect(screen.queryByText("members")).toBeNull();
+  });
+});

--- a/src/components/terminal/stats-pane.tsx
+++ b/src/components/terminal/stats-pane.tsx
@@ -1,0 +1,96 @@
+import { TermPane } from "./term-pane";
+import { Meter } from "./meter";
+import type { TermColor } from "@/content/mock-home-data";
+import { STATS } from "@/content/mock-home-data";
+
+const NET_COLOR_VAR: Record<TermColor, string> = {
+  green: "var(--term-accent)",
+  cyan: "var(--term-cyan)",
+  yellow: "var(--term-yellow)",
+  magenta: "var(--term-magenta)",
+};
+
+const COMMUNITY_VALUE_COLOR: Record<"green" | "cyan" | "magenta", string> = {
+  green: "var(--term-accent)",
+  cyan: "var(--term-cyan)",
+  magenta: "var(--term-magenta)",
+};
+
+type StatsPaneProps = {
+  stats?: typeof STATS;
+};
+
+export function StatsPane({ stats = STATS }: StatsPaneProps = {}) {
+  return (
+    <TermPane
+      index={1}
+      label="~/stats"
+      labelColor="cyan"
+      keys="e expand"
+      variant="last"
+    >
+      <div style={{ color: "var(--term-fg-dim)", marginBottom: 6 }}>
+        ── community ──────────────────────
+      </div>
+      {stats.community.map((row) => (
+        <div
+          key={row.label}
+          style={{
+            display: "flex",
+            gap: 10,
+            alignItems: "center",
+            padding: "2px 0",
+          }}
+        >
+          <span style={{ width: 70, color: "var(--term-fg-dim)" }}>
+            {row.label}
+          </span>
+          <Meter
+            value={row.meterPercent}
+            color={row.color}
+            ariaLabel={row.label}
+          />
+          <span
+            style={{
+              marginLeft: "auto",
+              color: COMMUNITY_VALUE_COLOR[row.color],
+            }}
+          >
+            {row.value}
+          </span>
+        </div>
+      ))}
+      <div style={{ color: "var(--term-fg-dim)", margin: "12px 0 6px" }}>
+        ── net · this week ────────────────
+      </div>
+      {stats.netThisWeek.map((row) => (
+        <div key={row.label} style={{ color: "var(--term-fg)" }}>
+          <span aria-hidden="true">{row.icon} </span>
+          <span style={{ color: NET_COLOR_VAR[row.color] }}>
+            {row.value}
+          </span>{" "}
+          {row.label}
+        </div>
+      ))}
+      <div style={{ color: "var(--term-fg-dim)", margin: "12px 0 4px" }}>
+        ── load avg ───────────────────────
+      </div>
+      <pre
+        style={{
+          whiteSpace: "pre",
+          color: "var(--term-fg-dim)",
+          margin: 0,
+          fontSize: 11,
+          lineHeight: 1.05,
+          fontFamily: "inherit",
+        }}
+      >
+        <span style={{ color: "var(--term-accent)" }}>
+          {stats.loadAvgAscii}
+        </span>
+        {"\n"}
+        {stats.loadAvgCaption}
+      </pre>
+    </TermPane>
+  );
+}


### PR DESCRIPTION
## Summary
Composes `<TermPane>` + `<Meter>` into the community stats pane from mockup 68: three meters (members/years/langs), the 'net · this week' lines, and the load-avg ASCII sparkline.

## Test plan
- [x] `bun run test` — 60 passed (4 new + 56 existing). Coverage: every community meter renders with role+label+value, every net-this-week line renders, load-avg ASCII + caption render, custom `stats` prop overrides default.
- [x] `bun run lint` — clean.

Closes #148. Part of #106.