### PR TITLE
Phase 3: <ForumActivityPane>

### DIFF
--- a/src/components/terminal/forum-activity-pane.test.tsx
+++ b/src/components/terminal/forum-activity-pane.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { ForumActivityPane } from "./forum-activity-pane";
+import { FORUM_ACTIVITY } from "@/content/mock-home-data";
+
+afterEach(() => cleanup());
+
+describe("ForumActivityPane", () => {
+  test("renders one row per post in tbody", () => {
+    render(<ForumActivityPane />);
+    const table = screen.getByRole("table");
+    const tbody = table.querySelector("tbody");
+    const rows = tbody?.querySelectorAll("tr") ?? [];
+    expect(rows).toHaveLength(FORUM_ACTIVITY.length);
+  });
+
+  test("first row contains alice / #rust / 8 replies", () => {
+    render(<ForumActivityPane />);
+    expect(screen.getByText("alice")).toBeTruthy();
+    expect(screen.getByText("#rust")).toBeTruthy();
+    expect(screen.getByText("8")).toBeTruthy();
+    expect(screen.getByText(/code review on a tiny json parser/)).toBeTruthy();
+  });
+
+  test("table has the expected column headers", () => {
+    render(<ForumActivityPane />);
+    for (const header of ["when", "by", "category", "topic", "replies"]) {
+      expect(screen.getByRole("columnheader", { name: header })).toBeTruthy();
+    }
+  });
+
+  test("custom posts prop overrides the default", () => {
+    render(
+      <ForumActivityPane
+        posts={[
+          {
+            when: "1y",
+            by: "zelda",
+            category: "#test",
+            categoryColor: "#fff",
+            topic: "test post",
+            replies: 99,
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText("zelda")).toBeTruthy();
+    expect(screen.getByText("test post")).toBeTruthy();
+    expect(screen.queryByText("alice")).toBeNull();
+  });
+});

--- a/src/components/terminal/forum-activity-pane.tsx
+++ b/src/components/terminal/forum-activity-pane.tsx
@@ -1,0 +1,111 @@
+import { TermPane } from "./term-pane";
+import type { ForumPost } from "@/content/mock-home-data";
+import { FORUM_ACTIVITY } from "@/content/mock-home-data";
+
+type ForumActivityPaneProps = {
+  posts?: Array<ForumPost>;
+};
+
+export function ForumActivityPane({
+  posts = FORUM_ACTIVITY,
+}: ForumActivityPaneProps = {}) {
+  return (
+    <TermPane
+      index={3}
+      label="recent activity · forum"
+      labelColor="magenta"
+      keys="↻ live · enter open"
+      variant="full"
+    >
+      <table
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          fontSize: 12,
+          fontFamily: "inherit",
+        }}
+      >
+        <thead>
+          <tr>
+            <Th>when</Th>
+            <Th>by</Th>
+            <Th>category</Th>
+            <Th>topic</Th>
+            <Th align="right">replies</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {posts.map((post) => (
+            <tr key={`${post.when}-${post.by}`}>
+              <Td color="var(--term-fg-dim)">{post.when}</Td>
+              <Td color="var(--term-cyan)">{post.by}</Td>
+              <Td>
+                <span style={{ color: post.categoryColor }}>
+                  {post.category}
+                </span>
+              </Td>
+              <Td color="var(--term-fg)" wrap>
+                {post.topic}
+              </Td>
+              <Td color="var(--term-accent)" align="right">
+                {post.replies}
+              </Td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </TermPane>
+  );
+}
+
+function Th({
+  children,
+  align = "left",
+}: {
+  children: React.ReactNode;
+  align?: "left" | "right";
+}) {
+  return (
+    <th
+      style={{
+        textAlign: align,
+        padding: "2px 8px 2px 0",
+        whiteSpace: "nowrap",
+        color: "var(--term-fg-dim)",
+        borderBottom: "1px dashed var(--term-border)",
+        fontWeight: "normal",
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+        fontSize: 11,
+      }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  color,
+  align = "left",
+  wrap = false,
+}: {
+  children: React.ReactNode;
+  color?: string;
+  align?: "left" | "right";
+  wrap?: boolean;
+}) {
+  return (
+    <td
+      style={{
+        textAlign: align,
+        padding: "2px 8px 2px 0",
+        whiteSpace: wrap ? "normal" : "nowrap",
+        width: wrap ? "100%" : undefined,
+        color,
+      }}
+    >
+      {children}
+    </td>
+  );
+}


### PR DESCRIPTION
## Summary
Composes `<TermPane>` + a semantic `<table>` (with `<thead>`/`<tbody>` and column headers) into the recent forum activity pane from mockup 68. One row per `ForumPost` with category color applied inline.

## Test plan
- [x] `bun run test` — 60 passed (4 new + 56 existing). Coverage: row count matches FORUM_ACTIVITY length, first row content (alice/#rust/8/topic), all 5 column headers present (`getByRole('columnheader')`), custom `posts` prop overrides default.
- [x] `bun run lint` — clean.

Closes #149. Part of #106.