### PR TITLE
Phase 4: PageWrapper wraps children in <TermPane>

### DIFF
--- a/src/components/page-wrapper.test.tsx
+++ b/src/components/page-wrapper.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { PageWrapper } from "./page-wrapper";
+
+vi.mock("@tanstack/react-router", () => ({
+  useLocation: () => ({ pathname: "/about" }),
+}));
+
+afterEach(() => cleanup());
+
+describe("PageWrapper", () => {
+  test("wraps children in a TermPane", () => {
+    render(
+      <PageWrapper>
+        <p>hello</p>
+      </PageWrapper>
+    );
+    expect(screen.getByText("hello")).toBeTruthy();
+    expect(screen.getByText("~/about")).toBeTruthy();
+  });
+
+  test("custom paneTitle overrides the derived label", () => {
+    render(
+      <PageWrapper paneTitle="~/custom">
+        <span>x</span>
+      </PageWrapper>
+    );
+    expect(screen.getByText("~/custom")).toBeTruthy();
+    expect(screen.queryByText("~/about")).toBeNull();
+  });
+
+  test("paneIndex is rendered in the pane bar", () => {
+    render(
+      <PageWrapper paneIndex={5} paneTitle="~/x">
+        <span />
+      </PageWrapper>
+    );
+    expect(screen.getByText("5")).toBeTruthy();
+  });
+});

--- a/src/components/page-wrapper.tsx
+++ b/src/components/page-wrapper.tsx
@@ -1,16 +1,32 @@
+import { useLocation } from "@tanstack/react-router";
 import type { ReactNode } from "react";
+import { TermPane } from "@/components/terminal/term-pane";
 
-interface PageWrapperProps {
+type PageWrapperProps = {
   children: ReactNode;
-  className?: string;
+  /** Pane label override. Defaults to `~/<first route segment>`. */
+  paneTitle?: string;
+  paneIndex?: number;
+};
+
+function deriveTitle(pathname: string): string {
+  const seg = pathname.replace(/^\/+/, "").split("/")[0] ?? "";
+  return seg ? `~/${seg}` : "~/home";
 }
 
-export function PageWrapper({ children, className = "" }: PageWrapperProps) {
+export function PageWrapper({
+  children,
+  paneTitle,
+  paneIndex = 0,
+}: PageWrapperProps) {
+  const { pathname } = useLocation();
   return (
-    <div
-      className={`container mx-auto px-4 pt-24 pb-12 sm:px-6 lg:px-8 ${className}`}
+    <TermPane
+      index={paneIndex}
+      label={paneTitle ?? deriveTitle(pathname)}
+      variant="full"
     >
       {children}
-    </div>
+    </TermPane>
   );
 }


### PR DESCRIPTION
## Summary
- `src/components/page-wrapper.tsx`: replaces the old `container/pt-24` div with a full-width `<TermPane>`. Derives the pane label from the first route segment (e.g. `/about` → `~/about`); falls back to `~/home` for `/`.
- New optional props `paneTitle` and `paneIndex` let routes override.
- Removed `pt-24` (no fixed-position navbar to clear anymore).
- Cascades the terminal look to every non-home route via this one change.

## Stacked on
`redesign/terminal-tmux` directly. Best paired with #168 (root layout swap) for visual coherence, but the two are independent edits.

## Test plan
- [x] `bun run test` — 66 passed (3 new + 63 existing).
- [x] `bun run lint` — clean.

Closes #152. Part of #106.