### PR TITLE
Phase 4: rebuild home-content with terminal panes

### DIFF
--- a/src/content/copyrighted/home-content.test.tsx
+++ b/src/content/copyrighted/home-content.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { HomeContent } from "./home-content";
+
+afterEach(() => cleanup());
+
+describe("HomeContent", () => {
+  test("renders all four feature panes", () => {
+    render(<HomeContent />);
+    // One distinctive label / piece of content per pane.
+    expect(screen.getByText("~/welcome")).toBeTruthy();
+    expect(screen.getByText("~/languages")).toBeTruthy();
+    expect(screen.getByText("~/stats")).toBeTruthy();
+    expect(screen.getByText("recent activity · forum")).toBeTruthy();
+  });
+
+  test("uses the .terminal-home-grid layout class", () => {
+    const { container } = render(<HomeContent />);
+    expect(container.querySelector(".terminal-home-grid")).toBeTruthy();
+  });
+});

--- a/src/content/copyrighted/home-content.tsx
+++ b/src/content/copyrighted/home-content.tsx
@@ -1,114 +1,23 @@
-import { cn } from "@/lib/utils";
-import { buttonVariants } from "@/components/ui/button";
+import { WelcomePane } from "@/components/terminal/welcome-pane";
+import { ForumActivityPane } from "@/components/terminal/forum-activity-pane";
+import { LanguagesPane } from "@/components/terminal/languages-pane";
+import { StatsPane } from "@/components/terminal/stats-pane";
 
 export function HomeContent() {
   return (
-    <>
-      <div className="bg-circuit-board bg-gray-200 bg-center py-20">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="w-fit rounded bg-white p-6">
-            <h1>Code Self Study</h1>
-            <p className="text-xl font-bold">
-              Self-study computer programming in a community of like-minded
-              people
-            </p>
-            <p className="mb-8 max-w-2xl text-lg">
-              We're a friendly programming community made up of over 5,000
-              programmers in Berkeley and the San Francisco Bay Area. All
-              programming languages and levels of experience are welcome!
-            </p>
-            <a
-              href="https://www.meetup.com/codeselfstudy/"
-              target="_blank"
-              rel="noopener noreferrer nofollow"
-              className={cn(
-                buttonVariants({ size: "lg" }),
-                "bg-blue-600 text-lg text-white hover:bg-blue-700"
-              )}
-            >
-              Join the Community
-            </a>
-          </div>
-        </div>
+    <div className="terminal-home-grid">
+      <div style={{ order: 1 }}>
+        <WelcomePane />
       </div>
-
-      <section className="py-12">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid gap-8 md:grid-cols-3">
-            <div>
-              <h2>Community</h2>
-              <p>
-                Attend our meetups and get out of your room to meet like-minded
-                programmers.
-              </p>
-            </div>
-            <div>
-              <h2>Get Help</h2>
-              <p>
-                The experienced members in the group help the beginners. Bring
-                your programming questions, and don't hesitate to ask. We can
-                also help you design study plans. The model is self-study with
-                mentorship.
-              </p>
-            </div>
-            <div>
-              <h2>Networking</h2>
-              <p>
-                It's easier to get a job when you know people in the industry.
-                Many people in the group have gotten jobs through networking or
-                through tips they've acquired from other group members.
-              </p>
-            </div>
-          </div>
-          <hr className="my-12 border-gray-200" />
-        </div>
-      </section>
-
-      <section className="pb-12">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <h2>What We Do</h2>
-          <p>
-            There are dozens of local meetup groups that teach people how to
-            code. Here are some ways that we are different from most other
-            groups:
-          </p>
-          <ul>
-            <li>
-              We are building a local community of friendly, creative,
-              highly-motivated programmers in the San Francisco Bay Area.
-            </li>
-            <li>
-              We're open to all programming languages, all levels of ability,
-              and all types of computer programming.
-            </li>
-            <li>
-              The format is self study with advice and mentorship from the more
-              experienced members. We can help you with study plans and guidance
-              &mdash; just let us know at a meetup or in the forum.
-            </li>
-          </ul>
-          <p>
-            Some of the languages our members have been working with are:
-            Python, JavaScript, TypeScript, Go, Rust, WebAssembly, Java, Scheme,
-            Racket, Haskell, Clojure, Common Lisp, C, C++, C#, F#, Lua, Elixir,
-            Erlang, Elm, Purescript, Ruby, Scala, PHP, R, Julia, HTML/CSS,
-            Octave, SQL and more. We're open to anything that is
-            computer-related.
-          </p>
-
-          <h2>Coding Bootcamp Supplement</h2>
-          <p>
-            You can attend our meetings as a self-directed, coding bootcamp
-            supplement or alternative. Experienced programmers in the group can
-            offer mentorship on a project-based approach to learning.
-          </p>
-          <p>
-            This community is self-directed &mdash; if you would like assistance
-            with forming a study plan, let us know in the forum, chatroom,
-            and/or at the meetups.
-          </p>
-        </div>
-      </section>
-    </>
+      <div style={{ order: 2 }}>
+        <ForumActivityPane />
+      </div>
+      <div style={{ order: 3 }}>
+        <LanguagesPane />
+      </div>
+      <div style={{ order: 4 }}>
+        <StatsPane />
+      </div>
+    </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -250,6 +250,21 @@
     text-shadow: 0 0 6px var(--term-glow);
   }
 
+  /* Home page grid — welcome + forum span full width; languages + stats
+     sit side by side in the third row. Mockup 68. */
+  .terminal-home-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 0;
+    flex: 1;
+  }
+
+  @media (width <= 820px) {
+    .terminal-home-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
   /* The patterns are from https://www.heropatterns.com/ */
   .bg-bevel-circle {
     background-color: var(--background);


### PR DESCRIPTION
## Summary
- `src/content/copyrighted/home-content.tsx`: replaces old hero + 3-column feature section with the mockup-68 grid:
  - **Row 1 (full):** `<WelcomePane>`
  - **Row 2 (full):** `<ForumActivityPane>`
  - **Row 3:** `<LanguagesPane>` + `<StatsPane>` side-by-side
- `src/styles.css`: adds `.terminal-home-grid` utility (CSS grid with `2fr 1fr` columns; collapses to a single column under 820px to match the mockup's responsive rule).

## Test plan
- [x] `bun run test` — 69 passed (2 new home-content tests + 67 existing).
- [x] `bun run lint` — clean.
- [x] `bun run build` — succeeds.

Closes #150. Part of #106.