### PR TITLE
Fix test lint errors and enforce lint in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: ESLint
+        run: bun run eslint .
+
+      - name: Stylelint
+        run: bun run stylelint "**/*.{css,scss}"
+
       - name: Run tests with coverage
         run: bun run test:coverage
 

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -1,3 +1,3 @@
 import type { RequestHandler } from "msw";
 
-export const handlers: RequestHandler[] = [];
+export const handlers: Array<RequestHandler> = [];

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,7 +10,10 @@ afterEach(() => {
 });
 afterAll(() => server.close());
 
-if (typeof window !== "undefined" && !window.matchMedia) {
+if (
+  typeof window !== "undefined" &&
+  !(window as { matchMedia?: unknown }).matchMedia
+) {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: vi.fn().mockImplementation((query: string) => ({


### PR DESCRIPTION
## Summary

- `test/mocks/handlers.ts`: switch `RequestHandler[]` to `Array<RequestHandler>` to satisfy `@typescript-eslint/array-type` (the TanStack ESLint config sets it to `generic`).
- `test/setup.ts`: cast `window` so the runtime check for `matchMedia` (which jsdom doesn't provide) doesn't trip `@typescript-eslint/no-unnecessary-condition`. The `lib.dom` types declare `matchMedia` as always defined, but at runtime under jsdom it isn't, so the guard is meaningful — only the type-level check needs softening.
- `.github/workflows/test.yml`: run `eslint` and `stylelint` on every PR / push to main, without `--fix`, so style/correctness regressions are caught at PR time instead of only when a contributor's pre-push hook trips.

The two lint errors came in with the Vitest coverage tooling commit (9bbf304) and were silently sitting on `main` until a push touched the lint stage.

## Test plan

- [x] `bun run eslint .` passes locally
- [x] `bun run stylelint "**/*.{css,scss}"` passes locally
- [x] `bun run test` passes locally
- [x] CI green