### PR TITLE
Update manual to reflect justfile and CI changes

### DIFF
--- a/manual/src/getting-started.md
+++ b/manual/src/getting-started.md
@@ -11,7 +11,7 @@
 bun install
 
 # Run the dev server
-bun run dev
+just dev
 ```
 
 The dev server runs at `http://localhost:7001`.
@@ -19,7 +19,7 @@ The dev server runs at `http://localhost:7001`.
 ## Build and Preview
 
 ```bash
-bun run build
+just build
 bun run preview
 ```
 
@@ -52,7 +52,11 @@ console.log(env.SERVER_URL);
 ## Database Tasks
 
 ```bash
-bun run db:generate
-bun run db:migrate
-bun run db:studio
+just db_generate
+just db_migrate
+just db_studio
+just db_push
+just db_pull
 ```
+
+These are wrappers around `drizzle-kit` that ensure it runs under Bun.

--- a/manual/src/scripts.md
+++ b/manual/src/scripts.md
@@ -1,5 +1,9 @@
 # Scripts
 
+Prefer `just` for top-level developer workflows (dev, build, clean, deploy,
+database tasks). It wraps the underlying `bun run` and `drizzle-kit` commands
+so you don't have to remember which tool runs what.
+
 ## Just
 
 Run Just scripts with [Just](https://just.systems/).
@@ -16,6 +20,9 @@ just --list
 # or
 just -l
 ```
+
+Common recipes: `just dev`, `just build`, `just clean`, `just deploy`,
+`just ssh`, `just db_generate`, `just db_migrate`, `just db_studio`.
 
 ## Bun
 

--- a/manual/src/tooling-and-quality.md
+++ b/manual/src/tooling-and-quality.md
@@ -3,10 +3,12 @@
 ## Scripts
 
 ```bash
-bun run test     # Vitest
-bun run lint     # ESLint + Stylelint
-bun run format   # Prettier
-bun run check    # Prettier + ESLint
+bun run test            # Vitest
+bun run test:watch      # Vitest in watch mode
+bun run test:coverage   # Vitest with coverage report
+bun run lint            # ESLint + Stylelint
+bun run format          # Prettier
+bun run check           # Prettier + ESLint
 ```
 
 ## Linting and Formatting
@@ -15,6 +17,17 @@ bun run check    # Prettier + ESLint
 - Stylelint checks CSS and Tailwind usage.
 - Prettier is the standard formatter.
 - Styling is done with Tailwind CSS.
+
+## Tests and Coverage
+
+Tests run with [Vitest](https://vitest.dev/). `bun run test:coverage`
+produces an HTML report under `coverage/`.
+
+## Continuous Integration
+
+`.github/workflows/test.yml` runs `bun run test:coverage` on every pull
+request and on pushes to `main`. The coverage HTML report is uploaded as a
+build artifact (`coverage-html`) and retained for 14 days.
 
 ## Git Hooks
 


### PR DESCRIPTION
## Summary

- `manual/src/getting-started.md`: switch dev/build/database commands to `just`. The `bun run db:*` scripts in `package.json` now intentionally error out and direct users to the justfile, so the previous instructions were actively broken.
- `manual/src/scripts.md`: recommend `just` for top-level workflows and list common recipes, matching the c72eaa5 commit's stated goal of consolidating developer tasks under `just`.
- `manual/src/tooling-and-quality.md`: document the new `test:watch` and `test:coverage` scripts, and describe the `.github/workflows/test.yml` CI workflow (added in 9bbf304).

## Test plan

- [x] Skim the rendered manual pages to confirm formatting still looks right