### PR TITLE
Phase 3: Build/deploy/dev pipeline for the new stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,93 +1,66 @@
-fly.toml
-mockups/
-.claude/
-.gemini/
-.output/
-.tanstack/
-manual/
-tmp/
+# Only the prebuilt apps/web/.output/public ships in the build context;
+# the Go binary serves it. Source / installs aren't needed at build time.
+
+.git
+.github
+.claude
+.gemini
+.vscode
+.worktrees
+
+# Repo-level docs and dev tooling — not needed inside the image.
+README.md
 AGENTS.md
 CLAUDE.md
 CONTRIBUTING.md
+LICENSE.md
 justfile
-README.md
-dev.db
-scripts/
+lefthook.yml
+.editorconfig
+.prettierrc.mjs
+.prettierignore
+.stylelintignore
+stylelint.config.mjs
+.bun-version
+.dockerignore
+.gitignore
+fly.toml
 
-**/*.db
-**/TANK
+# Side projects / fixtures
+manual/
+mockups/
+scripts/
+dotfiles/
+tmp/
+
+# Web workspace source — only the prerendered output ships.
+apps/web/src
+apps/web/public
+apps/web/test
+apps/web/node_modules
+apps/web/.tanstack
+apps/web/dist
+apps/web/.cta.json
+apps/web/components.json
+apps/web/drizzle.config.ts
+apps/web/eslint.config.js
+apps/web/package.json
+apps/web/tsconfig.json
+apps/web/vite.config.ts
+apps/web/vitest.config.ts
+
+# Root JS install artifacts
+node_modules
+bun.lock
+package.json
+
+# Env & local files
 **/.env
 **/.env*
 **/.env.local
 **/.envrc
-
-**/dist
-**/build
-**/.astro
-
-**/.output/
-**/.tanstack/
-**/.cache
-**/.mypy_cache
-**/.parcel-cache
-**/.netlify
-**/.swc
-**/.gradle
-**/.wrangler
-
 **/*.bak
 **/*.orig
 **/*PENDING_DELETION*
-
-**/*~
-**/tags
-**/tags.*
-**/.idea
-**/.vscode
-**/.vim
-**/*.sw[op]
-
-# Haskell
-**/.stack-work
-**/dist-newstyle
-
-# Python
-**/*.py[cod]
-**/__pycache__
-**/.venv
-
-# Ruby
-.bundle
-
-# Node
-**/node_modules
-
-# Elixir
-**/.elixir_ls
-_build
-cover
-deps
-doc
-.fetch
-**/erl_crash.dump
-**/*.ez
-**/my_app-*.tar
-priv/static
-
-# logs
-**/npm-debug.log*
-**/yarn-debug.log*
-**/yarn-error.log*
-**/pnpm-debug.log*
-
-# environment variables
-**/.env.production
+**/*.db
 **/.DS_Store
-**/dist-ssr
-**/*.local
-**/count.txt
-**/.nitro
-**/.vinxi
-**/todos.json
-
-.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,25 @@
-# syntax = docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
+#
+# The web app is built locally (see `just deploy`) and apps/web/.output/public
+# ships in the build context. That avoids re-running `bun install` on Fly's
+# remote builder, which was ~10min on a cold cache.
 
-# This is a multi-stage build for deployment on Fly.io
-# (not for local development)
+# 1. Build the Go binary, copying the prebuilt static site as ./static.
+FROM golang:1.26-alpine AS api
+WORKDIR /src
+COPY apps/api/go.mod apps/api/go.sum ./
+RUN go mod download
+COPY apps/api ./
+COPY apps/web/.output/public ./static
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/server .
 
-# This will crash the deployment if the arg isn't provided.
-# Run `just deploy` to deploy to ensure that the bun version is set.
-ARG BUN_VERSION=must_be_provided
-FROM oven/bun:${BUN_VERSION}-alpine AS base
-
-LABEL fly_launch_runtime="Bun"
-
-WORKDIR /app
-ENV NODE_ENV="production"
-ENV PORT="8080"
-
-# Stage 1: Install production dependencies
-FROM base AS prod-deps
-COPY bun.lock package.json ./
-RUN --mount=type=cache,target=/root/.bun/install/cache \
-    bun install --ci --production
-
-# Stage 2: Build the application
-FROM base AS build
-RUN --mount=type=cache,target=/var/cache/apk \
-    apk update && apk add build-base pkgconfig python3
-COPY bun.lock package.json ./
-RUN --mount=type=cache,target=/root/.bun/install/cache \
-    bun install --ci
-COPY . .
-RUN bun --bun run build
-
-# Stage 3: Final image
-FROM base
-# Copy production dependencies
-COPY --from=prod-deps /app/node_modules /app/node_modules
-# Copy built application
-COPY --from=build /app/.output /app/.output
-COPY --from=build /app/public /app/public
-COPY --from=build /app/package.json /app/package.json
-COPY dotfiles/* /root/
-
+# 2. Distroless runtime. CA certs + nonroot user + BusyBox shell (debug
+# variant) for `fly ssh console`. The shell adds ~2MB on disk and zero
+# steady-state RAM. Swap to `:nonroot` to lock the image down later.
+FROM gcr.io/distroless/static-debian12:debug-nonroot
+WORKDIR /
+COPY --from=api /out/server /server
+COPY --from=api /src/static /static
+USER nonroot
 EXPOSE 8080
-
-CMD [ "bun", "run", "start" ]
+ENTRYPOINT ["/server"]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,9 +6,22 @@ import tailwindcss from "@tailwindcss/vite";
 import { nitro } from "nitro/vite";
 
 const config = defineConfig({
-  // The web app lives in apps/web/. Keep .env.local at the repo root so it's
-  // shared by both the web and api workspaces.
-  envDir: "..",
+  // .env.local lives at the repo root and is forwarded into the Bun process
+  // via `--env-file=.env.local` in the root package.json scripts and
+  // justfile. envDir would only inject VITE_* into the client build; it
+  // wouldn't make non-VITE vars (DATABASE_URL, WORKOS_API_KEY) visible to
+  // server-side code in env.ts. So we rely on --env-file instead.
+  // Proxy API + WebSocket traffic to the Go server in dev so local routing
+  // matches production (Go serves both /api and the prerendered HTML there).
+  server: {
+    proxy: {
+      "/api": "http://localhost:8080",
+      "/ws": {
+        target: "ws://localhost:8080",
+        ws: true,
+      },
+    },
+  },
   resolve: {
     tsconfigPaths: true,
   },

--- a/fly.toml
+++ b/fly.toml
@@ -18,6 +18,6 @@ primary_region = "iad"
 
 [[vm]]
   cpus = 1
-  memory_mb = 512
+  memory_mb = 256
 
 

--- a/justfile
+++ b/justfile
@@ -1,62 +1,90 @@
-# List scripts
+# List available recipes
 default:
   @just --list
 
-# Cleans out build files and things like .DS_Store files
-clean:
-  ./scripts/clean.sh
-
-# Run tests
-test:
-  bun run test
-
-# Run tests in watch mode
-test_watch:
-  bun run test:watch
-
-# Run tests with coverage report
-test_coverage:
-  bun run test:coverage
-
-# Run the dev server
+# Run the web (port 7001) and api (port 8080) dev servers together. The Vite
+# dev server proxies /api and /ws to the Go server.
 dev:
-  bun run dev
+  just dev-api & just dev-web && wait
 
-# Run the build process
+# Web (TanStack Start) dev server only
+dev-web:
+  bun run --env-file=.env.local --filter web dev
+
+# Go API dev server only
+dev-api:
+  cd apps/api && go run .
+
+# Build the prerendered web app, then mirror dist into apps/api/static so the
+# Go binary can serve it locally and so the Dockerfile picks it up directly.
 build: clean
-  bun run build
+  @echo '\nBuilding the project...\n'
+  bun run --env-file=.env.local --filter web build
+  /bin/rm -rf apps/api/static
+  /bin/cp -R apps/web/.output/public apps/api/static
+  @echo '\nDone with building.\n'
 
-# Find all the license files
-find_licenses:
-  find . -name "LICENSE.md" -not -path "*/node_modules/*"
+# Run unit tests across the whole repo (Go race tests + Vitest)
+test:
+  cd apps/api && go test -race ./...
+  bun run --filter web test
 
-# Deploy to Fly.io using the local .bun-version
-deploy:
-  if [ -f .bun-version ]; then time fly deploy --build-arg BUN_VERSION="$(cat .bun-version)"; else echo "Error: .bun-version file not found in repository root. Please create it or specify BUN_VERSION another way." >&2; exit 1; fi
+# Run web tests in watch mode
+test-watch:
+  bun run --filter web test:watch
+
+# Run web tests with coverage
+test-coverage:
+  bun run --filter web test:coverage
+
+# Format the whole repo with prettier
+format:
+  bun run format
+
+# Lint web (eslint + stylelint)
+lint:
+  bun run --filter web lint
+
+# Build and deploy to Fly. We build locally so the remote builder doesn't
+# re-run `bun install` (~10min on a cold cache).
+deploy: build
+  fly deploy
+
+# Tail Fly logs for the deployed app
+logs:
+  fly logs
+
+# Show Fly machine status (memory, region, state)
+status:
+  fly status
 
 # SSH into a live Fly machine
 ssh:
   fly ssh console
 
-# Generate a database migration
+# Generate a database migration (Drizzle, web workspace)
 db_generate:
-  bun run --bun drizzle-kit generate
+  cd apps/web && bun run --bun drizzle-kit generate
 
 # Migrate the database
 db_migrate:
-  bun run --bun drizzle-kit migrate
+  cd apps/web && bun run --bun drizzle-kit migrate
 
-# Open the database studio
+# Open the Drizzle studio
 db_studio:
-  bun run --bun drizzle-kit studio
+  cd apps/web && bun run --bun drizzle-kit studio
 
-# Push schema changes directly to the database (prototyping)
+# Push schema changes directly (prototyping)
 db_push:
-  bun run --bun drizzle-kit push
+  cd apps/web && bun run --bun drizzle-kit push
 
 # Introspect the database to generate schema files
 db_pull:
-  bun run --bun drizzle-kit pull
+  cd apps/web && bun run --bun drizzle-kit pull
+
+# Find all the license files
+find_licenses:
+  find . -name "LICENSE.md" -not -path "*/node_modules/*"
 
 # View HTML mockups
 mockups:
@@ -66,3 +94,9 @@ mockups:
 # View the manual in the browser
 manual:
   cd manual && mdbook serve -p 8001 --open
+
+# Remove build artifacts (web .output/.tanstack, api ./static, root node_modules cache)
+clean:
+  @echo '\nCleaning project...\n'
+  ./scripts/clean.sh
+  @echo '\nDone with cleaning.\n'

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "apps/web"
   ],
   "scripts": {
-    "dev": "bun run --filter web dev",
-    "dev:web": "bun run --filter web dev",
-    "build": "bun run --filter web build",
-    "build:web": "bun run --filter web build",
+    "dev": "bun run --env-file=.env.local --filter web dev",
+    "dev:web": "bun run --env-file=.env.local --filter web dev",
+    "build": "bun run --env-file=.env.local --filter web build",
+    "build:web": "bun run --env-file=.env.local --filter web build",
     "test": "bun run --filter web test",
     "test:web": "bun run --filter web test",
     "lint": "bun run --filter web lint",

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,69 +1,35 @@
 #!/usr/bin/env bash
 
-# This script deletes unnecessary files.
-# Edit the arrays to customize it.
+# Deletes build artifacts and stray junk files. Edit the lists at the top to
+# customize. Kept simple so it runs under bash 3.2 (macOS default).
 
 set -euo pipefail
 
-# Common directories to delete
-/bin/rm -rfv tmp-*
-/bin/rm -rfv dist/
-/bin/rm -rfv .output/
-/bin/rm -rfv .tanstack/
+# Web build outputs (TanStack Start + Vite + Nitro).
+/bin/rm -rfv apps/web/.output
+/bin/rm -rfv apps/web/.tanstack
+/bin/rm -rfv apps/web/dist
 
-# node_modules cache
+# Go static-asset mirror (populated by `just build` from .output/public).
+/bin/rm -rfv apps/api/static
+
+# Local Go binaries from `go build .` if anyone runs them.
+/bin/rm -fv apps/api/api apps/api/server
+
+# Stray top-level dirs that older configs sometimes left behind.
+/bin/rm -rfv tmp-*
+
+# Prettier cache inside hoisted node_modules.
 /bin/rm -rfv ./node_modules/.cache/prettier/.prettier-cache
 
-# Directories to exclude from traversal
-excluded_dirs=(
-  '.claude'
-  '.worktrees'
-)
-
-# Files deleted by find
-find_files=(
-  '.DS_Store'
-  'Thumbs.db'
-  '*.pyc'
-  '*.pyo'
-  '*~'
-)
-
-# Directories deleted by find
-find_dirs=(
-  '__pycache__'
-)
-
-# ======= You don't need to edit below this line =======
-
-build_name_expr() {
-  local -n arr=$1
-  local out=()
-
-  for pattern in "${arr[@]}"; do
-    out+=( -name "$pattern" -o )
-  done
-
-  unset 'out[-1]'
-  printf '%q ' "${out[@]}"
-}
-
-build_excluded_expr() {
-  local out=()
-
-  for dir in "${excluded_dirs[@]}"; do
-    out+=( -path "./$dir" -o -path "./$dir/*" -o )
-  done
-
-  unset 'out[-1]'
-  printf '%q ' "${out[@]}"
-}
-
-excluded_expr=$(build_excluded_expr)
-file_expr=$(build_name_expr find_files)
-dir_expr=$(build_name_expr find_dirs)
-
-eval "find . \
-  \( $excluded_expr \) -prune -o \
-  \( -type f \( $file_expr \) -print -exec /bin/rm -fv {} + \) -o \
-  \( -type d \( $dir_expr \) -print -exec /bin/rm -rfv {} + \)"
+# OS / editor junk anywhere in the tree, except inside the listed dirs.
+find . \
+  \( -path './.claude' -o -path './.claude/*' \
+  -o -path './.worktrees' -o -path './.worktrees/*' \
+  -o -path './node_modules' -o -path './node_modules/*' \
+  -o -path './apps/*/node_modules' -o -path './apps/*/node_modules/*' \
+  -o -path './.git' -o -path './.git/*' \) -prune -o \
+  \( -type f \( -name '.DS_Store' -o -name 'Thumbs.db' \
+  -o -name '*.pyc' -o -name '*.pyo' -o -name '*~' \) \
+  -print -exec /bin/rm -fv {} + \) -o \
+  \( -type d -name '__pycache__' -print -exec /bin/rm -rfv {} + \)


### PR DESCRIPTION
Phase 3 of #195. **Stacked on #208** (Phase 2). Auto-retargets to the integration branch as earlier PRs merge.

## Summary

Final piece that makes the new stack runnable end-to-end. After this phase: `just build` produces a deployable artifact, `just dev` boots both servers with the correct proxy, and the distroless image carries no JS runtime.

- **Dockerfile**: multi-stage Go build → `gcr.io/distroless/static-debian12:debug-nonroot`. Ships only the Go binary and the prebuilt `apps/web/.output/public/` (copied to `./static`). No Node, no Bun at runtime.
- **`.dockerignore`**: tightened so only what the binary needs ends up in the build context.
- **`justfile`**: rewritten on the astro_go_stack model — parallel `dev`, separate `dev-api`/`dev-web`, `build` mirrors `.output/public` into `apps/api/static`, `test` runs Go race tests + Vitest, `deploy: build` ships to Fly. `db_*` recipes `cd` into `apps/web/`.
- **`vite.config.ts`**: dev proxy `/api` and `/ws` → `http://localhost:8080` (with `ws: true`). `envDir: ".."` from Phase 1 is removed (see ergonomics fix below).
- **`fly.toml`**: `memory_mb` 512 → 256 now that the JS runtime is gone.

## Two ergonomics fixes that surfaced during verification

These weren't in the original Phase 3 issues but blocked verification:

1. **Server env vars + Bun `--filter`**: `.env.local` lives at the repo root, but `bun run --filter web` `cd`s into `apps/web/` before auto-loading `.env`, and Bun doesn't walk up. The fix is `--env-file=.env.local` in the root scripts and `justfile` recipes that need real env. Tests don't need it (they mock). Phase 1's `envDir: ".."` was helping client-side `VITE_*` injection but not the server-side `process.env` reads in `env.ts`, so I removed it.
2. **`scripts/clean.sh` ran on bash 3.2 (macOS default)**: it used `local -n` (bash 4.3+), so `just clean` had been silently broken. Simplified to inline `find` calls and updated paths for the new layout.

## Test plan

- [x] `just build` → 13 pages prerendered, mirrored into `apps/api/static/`
- [x] `cd apps/api && go run .` then `curl`:
  - `/healthz` → 204
  - `/about/` → 200 (prerendered HTML)
  - `/nonexistent/` → 404 (SSG fallback)
  - `/api/missing` → 404 (no SSG, plain Echo 404)
- [x] `just test` → Go 9/9 + Vitest 51/51 pass
- [ ] Reviewer: `docker build .` and `docker run -p 8080:8080 ...` (Docker daemon wasn't available in my session)
- [x] Reviewer: `just dev` end-to-end — open `http://localhost:7001`, confirm Vite proxies `/api` to the Go server and the WorkOS sign-in still works

## Required env

`.env.local` at the repo root with the four vars from `env.local.example`. The example file was at the root before this PR and stays there.

Closes #199.
Closes #200.
Closes #201.