### PR TITLE
Fix: restore TANK and broader defensive globs in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,10 +54,51 @@ node_modules
 bun.lock
 package.json
 
+# Personal scratchpad / private dirs that must never reach the image.
+**/TANK
+
+# Defensive globs for caches and build outputs that might appear anywhere
+# in the tree. Prevents leakage if a workspace adds an unexpected one.
+**/dist
+**/dist-ssr
+**/build
+**/.astro
+**/.output
+**/.tanstack
+**/.nitro
+**/.vinxi
+**/.cache
+**/.mypy_cache
+**/.parcel-cache
+**/.netlify
+**/.swc
+**/.gradle
+**/.wrangler
+
+# Editor / OS junk
+**/*~
+**/tags
+**/tags.*
+**/.idea
+**/.vim
+**/*.sw[op]
+
+# Logs
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+**/pnpm-debug.log*
+
+# Stray artifacts that have shown up in history
+**/count.txt
+**/todos.json
+**/*.local
+
 # Env & local files
 **/.env
 **/.env*
 **/.env.local
+**/.env.production
 **/.envrc
 **/*.bak
 **/*.orig

--- a/.dockerignore
+++ b/.dockerignore
@@ -62,11 +62,18 @@ package.json
 **/dist
 **/dist-ssr
 **/build
+**/_site
+**/coverage
+**/.nyc_output
 **/.astro
 **/.output
 **/.tanstack
 **/.nitro
 **/.vinxi
+**/.next
+**/.nuxt
+**/.svelte-kit
+**/.vercel
 **/.cache
 **/.mypy_cache
 **/.parcel-cache
@@ -74,6 +81,22 @@ package.json
 **/.swc
 **/.gradle
 **/.wrangler
+**/.turbo
+**/.bun
+**/.yarn
+**/.pnp.*
+**/target
+
+# Test / coverage artifacts (HTML reports, lcov, etc).
+**/coverage-final.json
+**/lcov.info
+**/lcov-report
+
+# Lockfiles from other package managers — bun.lock is already excluded
+# in the explicit list above; these are pure noise if they ever sneak in.
+**/package-lock.json
+**/pnpm-lock.yaml
+**/yarn.lock
 
 # Editor / OS junk
 **/*~
@@ -81,7 +104,16 @@ package.json
 **/tags.*
 **/.idea
 **/.vim
+**/.vs
 **/*.sw[op]
+**/*.swn
+**/*.swm
+**/.history
+**/.ionide
+**/*.code-workspace
+**/Thumbs.db
+**/Desktop.ini
+**/ehthumbs.db
 
 # Logs
 **/npm-debug.log*
@@ -99,9 +131,57 @@ package.json
 **/.env*
 **/.env.local
 **/.env.production
+**/.env.development
 **/.envrc
 **/*.bak
 **/*.orig
+**/*.rej
 **/*PENDING_DELETION*
 **/*.db
+**/*.db-journal
+**/*.db-shm
+**/*.db-wal
+**/*.sqlite
+**/*.sqlite3
 **/.DS_Store
+
+# Language ecosystem build artifacts. Defensive — most aren't used here,
+# but the cost of listing them is zero and the cost of one slipping
+# through is leaking source / secrets / large binaries into the image.
+
+# Python
+**/*.py[cod]
+**/__pycache__
+**/.venv
+**/.tox
+**/.pytest_cache
+**/.ruff_cache
+
+# Ruby
+**/.bundle
+**/vendor/bundle
+**/.rspec_status
+
+# Rust / Go (Go build cache lives under GOCACHE, not in tree)
+**/target
+
+# Haskell
+**/.stack-work
+**/dist-newstyle
+
+# Elixir / Erlang
+**/.elixir_ls
+**/_build
+**/cover
+**/deps
+**/doc
+**/.fetch
+**/erl_crash.dump
+**/*.ez
+**/my_app-*.tar
+**/priv/static
+
+# Java / Kotlin
+**/*.class
+**/out
+**/.gradle


### PR DESCRIPTION
Targets `claude/elastic-lamarr-1af992` (not main).

## Why

Phase 3 (#209) rewrote `.dockerignore` and dropped several defensive globs from the original — most importantly `**/TANK`, the personal scratchpad pattern that must never reach the production image. That was a mistake on my part: pruning "unused" patterns saves nothing in build context size and removes a cheap safety net.

## What

Two commits:

1. **Restore TANK + the obviously-relevant defensive blocks** — `**/TANK`, build/cache globs (`**/dist`, `**/.output`, `**/.tanstack`, `**/.cache`, etc.), editor/OS junk (`**/*~`, `**/.idea`, `**/*.sw[op]`, etc.), JS log files, stray artifacts (`**/count.txt`, `**/todos.json`).
2. **Comprehensive coverage** — language-ecosystem blocks the original had (Python `__pycache__` / `.venv` / `.tox` / `.ruff_cache`, Ruby `.bundle`, Haskell `.stack-work` / `dist-newstyle`, Elixir `_build` / `deps` / `*.ez` / `erl_crash.dump`, Java `*.class` / `out`, Rust/Go `target`), additional framework caches (`.next`, `.nuxt`, `.svelte-kit`, `.vercel`, `.turbo`, `.bun`, `.yarn`, `.pnp.*`), more SQLite siblings (`*.db-journal`, `*.db-wal`, `*.sqlite*`), more editor/OS junk, other-PM lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`), and `.env.development`/`*.rej`.

Net change: 41 + 80 = 121 added lines.

## Test plan

- [x] Visual diff review
- [ ] Reviewer: `docker build .` and verify the build context size is the same or smaller than before this PR (it should be smaller, since these are exclusions). `docker build --progress=plain . 2>&1 | grep "transferring context"` shows the size.

Reported by @Josh in review of [#209](https://github.com/codeselfstudy/codeselfstudy/pull/209).