### PR TITLE
Phase 6: Update AGENTS.md and README.md for the new architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,24 @@
 
 ## Project Structure & Module Organization
 
-This is a Vite + React (TanStack Start) app with TypeScript.
+This is a Bun workspace with two apps:
 
-- `src/` holds application code.
-- `src/routes/` defines route entries (TanStack Router).
-- `src/components/` contains reusable UI components.
-- `src/content/` and `src/data/` store site content and data helpers.
-- `src/db/` contains database schema and access code (Drizzle).
-- `public/` contains static assets.
-- `manual/` contains the mdBook manual content. Write documentation for any changed code. Mermaid is available.
+- `apps/web/` — TanStack Start (Vite + React 19 + TypeScript). Prerenders to `apps/web/.output/public/` at build time.
+  - `src/routes/` — TanStack Router file-based routes.
+  - `src/components/` — reusable UI components.
+  - `src/content/` and `src/data/` — site content and data helpers.
+  - `src/db/` — Drizzle schema and access for the web side. **Drizzle is the source of truth for the schema**; the Go backend reads/writes via plain SQL.
+  - `src/lib/` — shared utilities, including `useApiFetch` for authenticated calls into the Go API.
+  - `src/integrations/workos/` — WorkOS AuthKit provider; sign-in flow stays client-side.
+  - `public/` — static assets passed through to the prerendered output.
+  - `test/` — Vitest setup and MSW handlers.
+- `apps/api/` — Go + Echo backend.
+  - `main.go` — Echo bootstrap, static serving, route wiring.
+  - `internal/auth/` — WorkOS JWKS verifier + Echo middleware (validates bearer tokens against WorkOS-issued JWTs).
+  - `internal/db/` — SQLite access via `modernc.org/sqlite` (pure Go, no CGO). Mirrors the schema from `apps/web/src/db/schema.ts`.
+  - `static/` — populated at build time by `just build` from `apps/web/.output/public/`. Gitignored.
+- `manual/` — mdBook documentation. Write documentation for any changed code. Mermaid is available.
+- `mockups/` — HTML mockups, served via `just mockups`.
 
 ## Build, Test, and Development Commands
 
@@ -18,41 +27,58 @@ Never commit code unless I specifically request it.
 
 If I ask a question, do not automatically implement a solution. Just answer the question, and I will let you know if I would like you to implement it.
 
-Use bun. Do not use npm, pnpm, or yarn commands.
+Use Bun. Do not use npm, pnpm, or yarn commands. Bun handles the entire JS pipeline (install, run, build) — Node.js is not required at any point.
 
-- `bun run dev`: start the dev server at `http://localhost:7001`.
-- `bun run build`: create the production build.
-- `bun run preview`: serve the production build locally.
-- `bun run test`: run Vitest once (passes if no tests exist).
-- `bun run lint`: run ESLint and Stylelint (auto-fix enabled).
-- `bun run format`: format code with Prettier.
-- `bun run db:generate|db:migrate|db:push|db:pull|db:studio`: Drizzle database tasks.
-- `just find_licenses`: list embedded `LICENSE.md` files.
+From the repo root:
+
+- `just dev` — runs the Go API (`:8080`) and the web dev server (`:7001`) together. The Vite dev server proxies `/api` and `/ws` to the Go server.
+- `just dev-web` — web only.
+- `just dev-api` — Go API only.
+- `just build` — prerenders the web app and mirrors `.output/public/` into `apps/api/static/` so the Go binary serves it.
+- `just test` — Go race tests + Vitest.
+- `just deploy` — `just build` then `fly deploy`. The web is built locally and the prebuilt `dist` ships in the Docker build context (Fly's remote builder doesn't re-run `bun install`).
+- `just db_generate|db_migrate|db_push|db_pull|db_studio` — Drizzle tasks (run inside `apps/web/`).
+- `just find_licenses` — list embedded `LICENSE.md` files.
+
+Inside `apps/web/`:
+
+- `bun run dev|build|preview|test|test:watch|test:coverage|lint`.
+
+Inside `apps/api/`:
+
+- `go run .` — start the API. Requires `apps/api/static/` to exist (run `just build` first if you want it to serve the web pages).
+- `go test -race ./...` — run all Go tests.
+- `go vet ./...`.
 
 Do NOT add the agent name (e.g. Claude, Generated with Claude Code, Co-Authored-By Claude) anywhere in commit messages, PR descriptions, or other Git/GitHub messages.
 
 ## Coding Style & Naming Conventions
 
-- TypeScript + React, module syntax is ESM.
-- Indentation is 2 spaces (follow existing files).
-- Components and hooks use `PascalCase`/`camelCase`.
-- Routes follow the TanStack conventions in `src/routes/`.
-- Formatting and linting are handled by `prettier`, `eslint`, and `stylelint`.
+- TypeScript + React (frontend), Go (backend). Module syntax in JS is ESM.
+- Indentation is 2 spaces (follow existing files). Go follows `gofmt`.
+- React components and hooks use `PascalCase`/`camelCase`.
+- Routes follow the TanStack conventions in `apps/web/src/routes/`.
+- Formatting and linting in JS are handled by `prettier`, `eslint`, and `stylelint`. CI runs them without `--fix`; local `lint` script auto-fixes.
 
 ## Testing Guidelines
 
-- Framework: Vitest (`vitest.config.ts`).
-- Name tests `*.test.ts` or `*.test.tsx` near the module under test.
-- Run `bun run test` before opening a PR; add tests for new behavior when practical.
+- Web framework: Vitest (`apps/web/vitest.config.ts`). Tests live next to the module under test as `*.test.ts` / `*.test.tsx`.
+- API framework: stdlib `testing` + `httptest`. All Go code requires test coverage — this is a hard requirement of the stack experiment.
+- Run `just test` before opening a PR. CI runs the same plus `go vet`.
+- Web coverage: `apps/web/src/lib/**`, `apps/web/src/data/**`, `apps/web/src/hooks/**`, and `apps/web/src/env.ts` enforce 100% (lines/functions/statements) per `vitest.config.ts`. Follow the same when adding code in those paths.
 
 ## Commit & Pull Request Guidelines
 
 - Commit messages in history are short, sentence-case summaries (often with a period). Follow that style.
-- PRs should include: a concise summary, testing notes (`bun run test`, `bun run lint`), and screenshots for UI changes.
+- PRs include: a concise summary, testing notes (`just test`), and screenshots for UI changes.
+- Default merge mode is "Create a merge commit" — preserves per-PR history. Don't rebase the PR branch on the integration branch unless explicitly asked.
 
 ## Configuration & Environment
 
-- Environment variables are validated in `src/env.ts`.
-- Required server vars: `SERVER_URL`, `WORKOS_API_KEY`, and `DATABASE_URL` (for Drizzle).
-- Client-side variables must be prefixed with `VITE_`.
+- Required env vars (in `.env.local` at the repo root):
+  - **Server-side**: `WORKOS_API_KEY`, `DATABASE_URL`. Optionally `TURSO_AUTH_TOKEN`, `WORKOS_CLIENT_ID`, `WORKOS_API_HOSTNAME`.
+  - **Client-side (Vite)**: `VITE_WORKOS_CLIENT_ID`, `VITE_WORKOS_API_HOSTNAME`. Client-side variables must be prefixed with `VITE_`.
+- `.env.local` lives at the repo root. The root scripts and justfile recipes pass `--env-file=.env.local` into `bun run` so the env propagates through Bun's `--filter` (which `cd`s into `apps/web/` and otherwise wouldn't auto-load it).
+- The Go API also reads `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` (falling back to the `VITE_`-prefixed versions) and `DATABASE_URL`. Both `/api/me` and `/api/todos` are disabled if the relevant env is missing — useful for static-only smoke tests.
+- The schema lives in Drizzle (`apps/web/src/db/schema.ts`). The Go side mirrors it in `apps/api/internal/db/db.go` (`Schema` constant) for tests; production migrations stay JS-side.
 - Don't read files or directories ending in `.bak` or that are blocked by `.gitignore`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,48 @@ Attend a meetup to find out how to contribute. :construction:
 
 See the documentation in [manual](./manual/src/SUMMARY.md). If [just](https://just.systems/) is installed, you can view the manual in the browser with the command: `just manual`.
 
+## Architecture
+
+Bun workspace with two apps and a Go binary that fronts the whole thing in production.
+
+```
+codeselfstudy/
+├── apps/
+│   ├── web/                  TanStack Start (Vite + React + TS).
+│   │   └── .output/public/   Prerendered static site (build-time output).
+│   └── api/                  Go + Echo backend.
+│       └── static/           Mirrored from web's .output/public at build time.
+├── Dockerfile                Multi-stage: Go build + distroless runtime.
+├── fly.toml                  256 MB shared-cpu-1x.
+└── justfile                  dev / build / test / deploy.
+```
+
+The Go binary serves the prerendered HTML, the JSON API (`/api/*`), and a future WebSocket endpoint (`/ws`). No JS runtime in production. Targets a single 256 MB Fly machine.
+
+**Auth.** WorkOS AuthKit on the client; the Go middleware validates access tokens against the WorkOS JWKS for protected `/api/*` routes.
+
+**Database.** SQLite via `modernc.org/sqlite` (pure Go). Drizzle owns the schema in `apps/web/src/db/schema.ts`; the Go side reads/writes through plain SQL. Remote Turso (libsql://) is a follow-up.
+
+**Build.** `bun run build` prerenders all routes; `just build` mirrors the output into `apps/api/static/` so the Go binary picks it up. The Docker build runs locally and ships the prebuilt `dist` in the build context — Fly's remote builder doesn't re-run `bun install`.
+
+## Quick start
+
+```sh
+# clone, then:
+bun install
+cp env.local.example .env.local   # fill in WorkOS + DATABASE_URL
+just dev                          # web :7001, api :8080, proxied
+```
+
+```sh
+# Common tasks
+just build       # produce a deployable artifact
+just test        # Go race tests + Vitest
+just deploy      # build, then fly deploy
+```
+
+See [AGENTS.md](AGENTS.md) for the full developer guide.
+
 ## Goals:
 
 - help people in the group find something in common to work on


### PR DESCRIPTION
Phase 6 (docs) of #195. Targets `claude/elastic-lamarr-1af992`. Last piece of the experiment.

## Summary

`CLAUDE.md` is unchanged — it already points at `AGENTS.md` as the source of truth.

### `AGENTS.md`

- Project structure rewritten around `apps/web/` and `apps/api/`, including the new `internal/auth/` and `internal/db/` packages.
- Build/dev commands point at the `justfile` targets and per-workspace `bun` scripts.
- Replaces "use bun, not pnpm" with "Bun handles the entire pipeline; Node.js is not required at any point" — matches the result of Phase 1's Bun-vs-Node decision gate.
- Test guidelines: Go code requires test coverage as a hard requirement of the experiment; web coverage thresholds for `src/lib/**`, `src/data/**`, `src/hooks/**`, and `src/env.ts` stay at 100%.
- Configuration section explains the `.env.local`-at-repo-root + `--env-file` plumbing, the dual-name env vars on the Go side (`WORKOS_CLIENT_ID` falling back to `VITE_WORKOS_CLIENT_ID`, etc.), and the Drizzle-as-schema-source rule.
- Adds a merge-strategy note: default is "Create a merge commit"; don't rebase PR branches without being asked.

### `README.md`

- Adds an Architecture section with the `apps/` tree, a note on the Go binary fronting both static assets and the API, and one-paragraph summaries of auth, db, and the build flow.
- Adds Quick start / common tasks aimed at someone clone-and-running for the first time.

## Test plan

- [x] `just test` — Go 30 + Vitest 54 pass
- [ ] Reviewer: read AGENTS.md and README.md end-to-end; flag anything stale or missing

Closes #206.