### PR TITLE
Fix: HEAD support on every GET endpoint + lefthook lint hook

### DIFF
--- a/apps/api/api_me_test.go
+++ b/apps/api/api_me_test.go
@@ -141,6 +141,35 @@ func TestApiMeRejectsMissingToken(t *testing.T) {
 	}
 }
 
+func TestApiMeHeadHonorsAuth(t *testing.T) {
+	f := newMeFixture(t)
+	v := startedVerifierFor(t, f)
+	e := newServer(fixtureDir(t), v, nil)
+
+	cases := []struct {
+		name       string
+		header     string
+		wantStatus int
+	}{
+		{"missing token", "", http.StatusUnauthorized},
+		{"valid token", "Bearer " + f.sign(t), http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodHead, "/api/me", nil)
+			if tc.header != "" {
+				req.Header.Set(echo.HeaderAuthorization, tc.header)
+			}
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status: want %d got %d body=%s", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestApiMeIsDisabledWithoutVerifier(t *testing.T) {
 	// /api/me without a verifier should fall through to the /api/* JSON 404,
 	// not return 401 — that's the smoke-test ergonomics we lean on for

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -170,7 +170,12 @@ func newServer(staticRoot string, v *auth.Verifier, todos *db.Todos) *echo.Echo 
 		},
 	}))
 
-	e.GET("/healthz", func(c echo.Context) error {
+	// Every read endpoint accepts both GET and HEAD. HEAD is GET-without-body
+	// per RFC 9110; declaring only GET makes Echo return 405 to HEAD probes
+	// from curl -I, monitoring agents, and load balancers, which is wrong.
+	getOrHead := []string{http.MethodGet, http.MethodHead}
+
+	e.Match(getOrHead, "/healthz", func(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	})
 
@@ -178,15 +183,15 @@ func newServer(staticRoot string, v *auth.Verifier, todos *db.Todos) *echo.Echo 
 	// paths win over the JSON-404 fallback.
 	if v != nil {
 		api := e.Group("/api", auth.Middleware(v))
-		api.GET("/me", handleMe)
+		api.Match(getOrHead, "/me", handleMe)
 		if todos != nil {
-			api.GET("/todos", handleListTodos(todos))
+			api.Match(getOrHead, "/todos", handleListTodos(todos))
 			api.POST("/todos", handleCreateTodo(todos))
 		}
 	}
 
 	// Reserve /api/* and /ws so unrecognized requests there reach Echo's
-	// default 404 (JSON, no SSG fallback).
+	// default 404 (JSON, no SSG fallback). Any() already covers HEAD.
 	e.Any("/api/*", func(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound)
 	})
@@ -194,7 +199,7 @@ func newServer(staticRoot string, v *auth.Verifier, todos *db.Todos) *echo.Echo 
 		return echo.NewHTTPError(http.StatusNotFound)
 	})
 
-	e.GET("/*", staticHandler(staticRoot))
+	e.Match(getOrHead, "/*", staticHandler(staticRoot))
 	return e
 }
 

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -74,6 +74,35 @@ func TestStaticFileServed(t *testing.T) {
 	}
 }
 
+// HEAD must work everywhere GET works (RFC 9110 §9.3.2). Curl -I, fly's
+// healthcheck probes, and ad-hoc monitoring all use HEAD; without explicit
+// support Echo returns 405 instead of mirroring the GET status.
+func TestHeadMirrorsGet(t *testing.T) {
+	e := newServer(fixtureDir(t), nil, nil)
+	cases := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{"healthz", "/healthz", http.StatusNoContent},
+		{"root index", "/", http.StatusOK},
+		{"about index", "/about/", http.StatusOK},
+		{"missing page", "/nonexistent/", http.StatusNotFound},
+		{"missing api", "/api/missing", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodHead, tc.path, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status: want %d got %d body=%q", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestSSGFallbackOnUnknownPageRoute(t *testing.T) {
 	e := newServer(fixtureDir(t), nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/nonexistent/", nil)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,7 +17,10 @@ pre-push:
       run: bun run test
     lint:
       glob: "*.{ts,js,mjs,cjs,jsx,tsx,astro}"
-      run: bun run eslint {push_files}
+      # bunx finds eslint via apps/web's hoisted node_modules. `bun run eslint`
+      # used to work pre-workspace but stopped after Phase 1 since eslint moved
+      # out of the root package.
+      run: bunx eslint {push_files}
     stylelint:
       glob: "*.{css,scss}"
-      run: bun run stylelint {push_files}
+      run: bunx stylelint {push_files}


### PR DESCRIPTION
Targets `claude/elastic-lamarr-1af992`. Two small fixes you noticed during local smoke testing.

## HEAD on GET endpoints (eee1d2a)

`curl -I http://localhost:8080/about/` was returning 405 Method Not Allowed. Echo treats HEAD as a separate method and only GET handlers were registered. RFC 9110 §9.3.2 says HEAD must work wherever GET works (HEAD = GET without body), and curl `-I`, monitoring agents, and load balancers all rely on it.

`apps/api/main.go` now uses `e.Match([]string{GET, HEAD}, ...)` for `/healthz`, `/api/me`, GET `/api/todos`, and the static `/*` handler. POST `/api/todos` is unchanged. The `/api/*` and `/ws` catchalls already used `e.Any` so they covered HEAD.

Go's `net/http` strips response bodies on HEAD automatically — it wraps the `ResponseWriter` so `Write` is a no-op — so `c.File` / `c.JSON` / `c.HTMLBlob` set the right headers without sending bytes.

Tests:
- `TestHeadMirrorsGet` — 5 cases: `/healthz`, `/`, `/about/`, an SSG 404, the api JSON 404
- `TestApiMeHeadHonorsAuth` — confirms HEAD goes through the auth middleware: 401 without token, 200 with valid token

## Lefthook lint hook (4bd2ec8)

The pre-push hook ran `bun run eslint {push_files}` but Phase 1 moved eslint from the root package into `apps/web`. After that, any push touching `.ts/.tsx` files failed with `Script not found \"eslint\"`. Switching to `bunx eslint` (and `bunx stylelint` for consistency) finds the binary via `apps/web`'s hoisted `node_modules`. Pre-existing breakage from Phase 1 — surfaced when this PR's push tripped it.

## Test plan

- [x] `cd apps/api && go test -race ./...` — 32 tests pass (7 new HEAD cases)
- [x] `bunx eslint apps/web/src/lib/api.ts` clean
- [x] Pre-push hook passes on this push
- [ ] Reviewer: \`curl -I http://localhost:8080/about/\` returns 200 once it's running locally