### PR TITLE
Mount the WorkOS sign-in button in the navbar

### DIFF
--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -10,6 +10,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { SignInButton } from "@/components/workos-user";
 
 const LINKS = [
   { href: "/", label: "Home" },
@@ -34,7 +35,7 @@ export function Navbar() {
               Code Self Study
             </Link>
           </div>
-          <div className="hidden sm:flex sm:space-x-4">
+          <div className="hidden sm:flex sm:items-center sm:space-x-4">
             {LINKS.map((link) => (
               <Link
                 key={link.label}
@@ -47,6 +48,7 @@ export function Navbar() {
                 {link.label}
               </Link>
             ))}
+            <SignInButton />
           </div>
           <div className="sm:hidden">
             <Sheet open={isOpen} onOpenChange={setIsOpen}>
@@ -69,6 +71,9 @@ export function Navbar() {
                       {link.label}
                     </Link>
                   ))}
+                  <div className="pt-2">
+                    <SignInButton large />
+                  </div>
                 </div>
               </SheetContent>
             </Sheet>

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,7 +17,10 @@ pre-push:
       run: bun run test
     lint:
       glob: "*.{ts,js,mjs,cjs,jsx,tsx,astro}"
-      run: bun run eslint {push_files}
+      # bunx finds eslint via apps/web's hoisted node_modules. `bun run eslint`
+      # used to work pre-workspace but stopped after Phase 1 since eslint moved
+      # out of the root package.
+      run: bunx eslint {push_files}
     stylelint:
       glob: "*.{css,scss}"
-      run: bun run stylelint {push_files}
+      run: bunx stylelint {push_files}


### PR DESCRIPTION
Targets `claude/elastic-lamarr-1af992`. Wires up the missing entry point for the existing WorkOS auth flow.

## Why

The AuthKit provider was already mounted at the root and the `<SignInButton>` component (in `apps/web/src/components/workos-user.tsx`) already existed — but nothing imported it, so clicking around the running app you'd never reach the WorkOS hosted sign-in. That made it impossible to manually exercise the Go-side auth middleware end-to-end.

## Changes

- Render `<SignInButton>` next to the desktop nav links.
- Render `<SignInButton large>` at the bottom of the mobile menu sheet.

The component already swaps between "Sign In" (when signed out) and avatar + name + "Sign Out" (when signed in). I'm not redesigning it here — minimum-scope wiring so the flow is reachable.

## Test plan

- [x] `bun run --filter web test` — 54/54 pass
- [x] `bun run --filter web build` — 13 pages prerendered
- [ ] Reviewer: `just dev` with WorkOS env vars set, click "Sign In" in the navbar, complete the WorkOS hosted flow, confirm the button swaps to your profile + sign-out

## Bundled commit

Includes the lefthook lint hook fix from #216 (`a37bb18`). The pre-push hook fires on `.tsx` changes and was broken until that fix landed; bundling it here was the only way to push this PR. If #216 merges first, this commit becomes a no-op on merge.