### PR TITLE
Fix: load .env.local into just dev-api

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,9 +11,11 @@ dev:
 dev-web:
   bun run --env-file=.env.local --filter web dev
 
-# Go API dev server only
+# Go API dev server only. Loads .env.local into the shell so /api/me and
+# /api/todos can wire themselves up — Go has no built-in .env support.
+# Skipped silently when the file is absent (smoke-test mode).
 dev-api:
-  cd apps/api && go run .
+  set -a; [ -f .env.local ] && . ./.env.local; set +a; cd apps/api && go run .
 
 # Build the prerendered web app, then mirror dist into apps/api/static so the
 # Go binary can serve it locally and so the Dockerfile picks it up directly.


### PR DESCRIPTION
Targets `claude/elastic-lamarr-1af992`.

## Why

\`just dev-api\` runs \`go run .\` without exporting anything from \`.env.local\`. Go has no built-in \`.env\` loader, so on your machine the API logged:

\`\`\`
auth: WORKOS_CLIENT_ID / WORKOS_API_HOSTNAME not set; /api/me disabled
db: DATABASE_URL not set; /api/todos disabled
\`\`\`

…even with a fully populated \`.env.local\` at the repo root. \`/api/me\` then returned 404 (the \`/api/*\` catchall) instead of validating tokens, so the auth round-trip couldn't be tested end-to-end.

## Change

One-line update to the \`dev-api\` recipe:

\`\`\`make
dev-api:
  set -a; [ -f .env.local ] && . ./.env.local; set +a; cd apps/api && go run .
\`\`\`

- \`set -a\` auto-exports each variable that gets set.
- \`. ./.env.local\` (POSIX-style) sources the file from repo root before \`cd apps/api\`.
- The existence check keeps the static-only smoke-test path working when \`.env.local\` is absent.
- Production (Fly) is unaffected — Fly secrets are injected as process env, no \`.env.local\` involved.

## Verification

- [x] Without \`.env.local\`: recipe runs, server logs the "disabled" lines, \`/healthz\` works
- [x] With \`.env.local\`: server reads \`VITE_WORKOS_CLIENT_ID\` and \`VITE_WORKOS_API_HOSTNAME\` (falls back from non-prefixed names), tries to prime the JWKS. With fake creds it fails cleanly with a non-200 from WorkOS; with your real creds it should succeed and mount \`/api/me\`.
- [ ] Reviewer: \`just dev\`, sign in, \`curl -H "Authorization: Bearer <token>" http://localhost:8080/api/me\` → 200 with claims

## Out of scope

- Adding godotenv to the Go binary itself. Considered, but: it'd require a relative path (\`../../.env.local\`) that's fragile, adds a runtime dep that's only useful in dev, and Fly already injects env vars natively in prod. The justfile fix is the lighter touch.