### PR TITLE
Add an Auth (dev) panel to TanStackDevtools

### DIFF
--- a/apps/web/src/integrations/auth-devtools/panel.tsx
+++ b/apps/web/src/integrations/auth-devtools/panel.tsx
@@ -54,7 +54,7 @@ function AuthDevPanel() {
         {isLoading
           ? "loading"
           : user
-            ? `signed in as ${user.email ?? user.id}`
+            ? `signed in as ${user.email}`
             : "signed out"}
       </section>
 

--- a/apps/web/src/integrations/auth-devtools/panel.tsx
+++ b/apps/web/src/integrations/auth-devtools/panel.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useState } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
+
+import { useApiFetch } from "@/lib/api";
+
+/**
+ * Dev-only TanStack Devtools panel that shows the current WorkOS auth
+ * state, lets you copy the access token to the clipboard, and pings
+ * /api/me to verify the Go-side validator round-trips. Mounted from
+ * `apps/web/src/routes/__root.tsx`. Only loads when TanStackDevtools
+ * itself is rendered, which the existing config already gates to dev.
+ */
+function AuthDevPanel() {
+  const { user, isLoading, getAccessToken } = useAuth();
+  const apiFetch = useApiFetch();
+
+  const [tokenStatus, setTokenStatus] = useState<string>("");
+  const [meStatus, setMeStatus] = useState<string>("");
+  const [meBody, setMeBody] = useState<string>("");
+
+  const copyToken = useCallback(async () => {
+    const token = await getAccessToken();
+    if (!token) {
+      setTokenStatus("no token (not signed in or session expired)");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(token);
+      setTokenStatus(`copied (${token.length} chars)`);
+    } catch (err) {
+      setTokenStatus(`clipboard write failed: ${(err as Error).message}`);
+    }
+  }, [getAccessToken]);
+
+  const probeMe = useCallback(async () => {
+    setMeStatus("…");
+    setMeBody("");
+    try {
+      const res = await apiFetch("/api/me");
+      setMeStatus(`${res.status} ${res.statusText}`);
+      const text = await res.text();
+      setMeBody(text);
+    } catch (err) {
+      setMeStatus(`fetch threw: ${(err as Error).message}`);
+    }
+  }, [apiFetch]);
+
+  return (
+    <div style={{ padding: 12, fontFamily: "monospace", fontSize: 12 }}>
+      <h3 style={{ marginTop: 0 }}>WorkOS auth (dev)</h3>
+
+      <section style={{ marginBottom: 12 }}>
+        <strong>state:</strong>{" "}
+        {isLoading
+          ? "loading"
+          : user
+            ? `signed in as ${user.email ?? user.id}`
+            : "signed out"}
+      </section>
+
+      <section style={{ marginBottom: 12 }}>
+        <button onClick={copyToken} type="button">
+          Copy access token
+        </button>
+        {tokenStatus && (
+          <span style={{ marginLeft: 8, color: "#555" }}>{tokenStatus}</span>
+        )}
+      </section>
+
+      <section>
+        <button onClick={probeMe} type="button">
+          GET /api/me
+        </button>
+        {meStatus && (
+          <div style={{ marginTop: 6 }}>
+            <strong>{meStatus}</strong>
+            {meBody && (
+              <pre
+                style={{
+                  marginTop: 4,
+                  padding: 6,
+                  background: "#f4f4f4",
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-all",
+                }}
+              >
+                {meBody}
+              </pre>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default {
+  name: "Auth (dev)",
+  render: <AuthDevPanel />,
+};

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -14,6 +14,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { findRedirect } from "@/lib/redirects";
 import WorkOSProvider from "@/integrations/workos/provider";
 import TanStackQueryDevtools from "@/integrations/tanstack-query/devtools";
+import AuthDevtools from "@/integrations/auth-devtools/panel";
 import appCss from "@/styles.css?url";
 import { Analytics } from "@/components/analytics";
 import { ErrorPage } from "@/components/error-page";
@@ -90,6 +91,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
                 render: <TanStackRouterDevtoolsPanel />,
               },
               TanStackQueryDevtools,
+              AuthDevtools,
             ]}
           />
         </WorkOSProvider>


### PR DESCRIPTION
Targets `claude/elastic-lamarr-1af992`.

## What

A third plugin in the existing TanStackDevtools chrome alongside Router and Query, so manual auth testing has a fixed home next to the other dev surfaces. Lives in `apps/web/src/integrations/auth-devtools/` to mirror the existing `tanstack-query/` integration shape.

The panel shows three things:

- **Current sign-in state** — loading / signed-in-as-<email> / signed-out, driven by `useAuth()`
- **Copy access token** button — calls `getAccessToken()` and writes the token to the clipboard. Status feedback for "no token", byte count on success, or clipboard error
- **GET /api/me** button — calls `useApiFetch()` and renders the status line + response body inline

This makes the round-trip easy to exercise in one click: confirms token attach (web), JWKS validation (Go), and JSON shape, all in the same UI you're already using.

The TanStackDevtools wrapper is already gated to dev by the bundler, so this panel is not in the production bundle.

## Test plan

- [x] `bun run --filter web test` — 54/54 pass
- [x] `bun run --filter web build` — 13 pages prerendered
- [x] `bunx eslint apps/web/src/integrations/auth-devtools/panel.tsx` clean
- [ ] Reviewer: with #218 also merged, `just dev`, sign in via the navbar, click the TanStack devtools floating dock → "Auth (dev)" → "GET /api/me" → expect 200 with `sub`/`iss`/`exp`/`email`

## Related

Pairs with #218 (Go env loading). Without #218, the Go side returns 404 on `/api/me` because auth is disabled at startup; with both merged, the round-trip works end-to-end.