### PR TITLE
Tighten AGENTS.md and README.md ahead of the main merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,10 +75,14 @@ Do NOT add the agent name (e.g. Claude, Generated with Claude Code, Co-Authored-
 
 ## Configuration & Environment
 
-- Required env vars (in `.env.local` at the repo root):
-  - **Server-side**: `WORKOS_API_KEY`, `DATABASE_URL`. Optionally `TURSO_AUTH_TOKEN`, `WORKOS_CLIENT_ID`, `WORKOS_API_HOSTNAME`.
-  - **Client-side (Vite)**: `VITE_WORKOS_CLIENT_ID`, `VITE_WORKOS_API_HOSTNAME`. Client-side variables must be prefixed with `VITE_`.
-- `.env.local` lives at the repo root. The root scripts and justfile recipes pass `--env-file=.env.local` into `bun run` so the env propagates through Bun's `--filter` (which `cd`s into `apps/web/` and otherwise wouldn't auto-load it).
-- The Go API also reads `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` (falling back to the `VITE_`-prefixed versions) and `DATABASE_URL`. Both `/api/me` and `/api/todos` are disabled if the relevant env is missing — useful for static-only smoke tests.
-- The schema lives in Drizzle (`apps/web/src/db/schema.ts`). The Go side mirrors it in `apps/api/internal/db/db.go` (`Schema` constant) for tests; production migrations stay JS-side.
+- Copy `env.local.example` to `.env.local` at the repo root and fill in the values.
+- Required vars:
+  - `VITE_WORKOS_CLIENT_ID`, `VITE_WORKOS_API_HOSTNAME` — used by the web client and re-used by the Go API as fallbacks.
+  - `WORKOS_API_KEY` — server-only WorkOS key, validated by `apps/web/src/env.ts`.
+  - `DATABASE_URL` — SQLite path or libsql URL.
+- Optional vars: `TURSO_AUTH_TOKEN` (when DATABASE*URL is a remote libsql URL), `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` (override the `VITE*`-prefixed values for the Go API).
+- Client-side variables must be prefixed with `VITE_` to be exposed to the browser.
+- Env propagation: the root `package.json` scripts and the `justfile` pass `--env-file=.env.local` into `bun run`, since Bun's `--filter` `cd`s into `apps/web/` and would otherwise miss the root file. `just dev-api` sources `.env.local` into the Go process the same way.
+- `/api/me` is disabled if WorkOS env is missing; `/api/todos` is disabled if `DATABASE_URL` is missing. Static serving and `/healthz` always work — useful for barebones smoke tests.
+- The schema lives in Drizzle (`apps/web/src/db/schema.ts`). The Go side mirrors it in `apps/api/internal/db/db.go` (`Schema` constant) for tests; production migrations stay JS-side via `just db_*`.
 - Don't read files or directories ending in `.bak` or that are blocked by `.gitignore`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Do NOT add the agent name (e.g. Claude, Generated with Claude Code, Co-Authored-
   - `VITE_WORKOS_CLIENT_ID`, `VITE_WORKOS_API_HOSTNAME` — used by the web client and re-used by the Go API as fallbacks.
   - `WORKOS_API_KEY` — server-only WorkOS key, validated by `apps/web/src/env.ts`.
   - `DATABASE_URL` — SQLite path or libsql URL.
-- Optional vars: `TURSO_AUTH_TOKEN` (when DATABASE*URL is a remote libsql URL), `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` (override the `VITE*`-prefixed values for the Go API).
+- Optional vars: `TURSO_AUTH_TOKEN` (when `DATABASE_URL` is a remote libsql URL), `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` (override the `VITE_`-prefixed values for the Go API).
 - Client-side variables must be prefixed with `VITE_` to be exposed to the browser.
 - Env propagation: the root `package.json` scripts and the `justfile` pass `--env-file=.env.local` into `bun run`, since Bun's `--filter` `cd`s into `apps/web/` and would otherwise miss the root file. `just dev-api` sources `.env.local` into the Go process the same way.
 - `/api/me` is disabled if WorkOS env is missing; `/api/todos` is disabled if `DATABASE_URL` is missing. Static serving and `/healthz` always work — useful for barebones smoke tests.

--- a/README.md
+++ b/README.md
@@ -22,21 +22,23 @@ codeselfstudy/
 └── justfile                  dev / build / test / deploy.
 ```
 
-The Go binary serves the prerendered HTML, the JSON API (`/api/*`), and a future WebSocket endpoint (`/ws`). No JS runtime in production. Targets a single 256 MB Fly machine.
+The Go binary serves the prerendered HTML, the JSON API (`/api/*`), and a future WebSocket endpoint at `/ws`. No JS runtime in production. Targets a single 256 MB Fly machine.
 
-**Auth.** WorkOS AuthKit on the client; the Go middleware validates access tokens against the WorkOS JWKS for protected `/api/*` routes.
+**Auth.** WorkOS AuthKit on the client; an Echo middleware validates access tokens against the WorkOS JWKS for protected `/api/*` routes.
 
-**Database.** SQLite via `modernc.org/sqlite` (pure Go). Drizzle owns the schema in `apps/web/src/db/schema.ts`; the Go side reads/writes through plain SQL. Remote Turso (libsql://) is a follow-up.
+**Database.** SQLite via `modernc.org/sqlite` (pure Go, no CGO). Drizzle owns the schema in `apps/web/src/db/schema.ts` and runs migrations from the web side; the Go API reads and writes through plain SQL. Remote Turso (libsql://) is a follow-up.
 
-**Build.** `bun run build` prerenders all routes; `just build` mirrors the output into `apps/api/static/` so the Go binary picks it up. The Docker build runs locally and ships the prebuilt `dist` in the build context — Fly's remote builder doesn't re-run `bun install`.
+**Build.** `bun run build` prerenders all routes; `just build` mirrors the output into `apps/api/static/` so the Go binary picks it up. The Docker build runs locally and ships the prebuilt artifact in the build context — Fly's remote builder doesn't re-run `bun install`.
 
 ## Quick start
+
+Requires [Bun](https://bun.com/), [Go](https://go.dev/) 1.26+, and [just](https://just.systems/).
 
 ```sh
 # clone, then:
 bun install
 cp env.local.example .env.local   # fill in WorkOS + DATABASE_URL
-just dev                          # web :7001, api :8080, proxied
+just dev                          # web :7001, api :8080 (Vite proxies /api and /ws)
 ```
 
 ```sh


### PR DESCRIPTION
## Summary

- Restructure the env section in AGENTS.md so the required vs optional split matches what the code actually checks (WorkOS opt-in, DB opt-in, `VITE_`-prefixed fallbacks for the Go side).
- Mention `just dev-api` env loading and the `db_*` migration recipes.
- Clarify the database paragraph in the README: Drizzle owns migrations on the web side, the Go API only reads/writes via plain SQL.
- Add prerequisite versions (Bun, Go 1.26+, just) to the README quick start.

## Test plan

- [x] No code changes; docs only.
- [x] Lefthook ran `just test` on push (54 vitest passed, lint clean).