### PR TITLE
Update mdBook for the Go-backend architecture

### DIFF
--- a/manual/src/SUMMARY.md
+++ b/manual/src/SUMMARY.md
@@ -2,9 +2,10 @@
 
 - [The Manual](./index.md)
 - [Getting Started](./getting-started.md)
+- [Architecture](./architecture.md)
+- [Project Structure](./project-structure.md)
 - [Development](./development.md)
 - [Scripts](./scripts.md)
-- [Project Structure](./project-structure.md)
 - [Routing & Data](./routing-and-data.md)
 - [Tooling & Quality](./tooling-and-quality.md)
 - [Deployment](./deployment.md)

--- a/manual/src/architecture.md
+++ b/manual/src/architecture.md
@@ -1,0 +1,60 @@
+# Architecture
+
+The repo is a Bun workspace with a TanStack Start frontend and a Go + Echo backend. In production a single Go binary fronts both — there is no JavaScript runtime on the server.
+
+## Top-level shape
+
+```
+codeselfstudy/
+├── apps/
+│   ├── web/                    TanStack Start (Vite + React + TS)
+│   │   ├── src/                routes, components, content, lib, integrations
+│   │   ├── public/             static assets
+│   │   ├── test/               Vitest setup + MSW handlers
+│   │   └── .output/public/     prerendered HTML/CSS/JS (build output)
+│   └── api/                    Go + Echo backend
+│       ├── main.go             Echo bootstrap, static serving, route wiring
+│       ├── cmd/migrate/        thin goose CLI for ad-hoc migration runs
+│       ├── internal/auth/      WorkOS JWKS verifier + Echo middleware
+│       ├── internal/db/        SQLite access (modernc.org/sqlite)
+│       ├── internal/db/migrations/   goose .sql migrations (embedded)
+│       └── static/             populated at build time from web's .output/public
+├── manual/                     this mdBook
+├── mockups/                    HTML mockups
+├── Dockerfile                  multi-stage: Go build + distroless runtime
+├── fly.toml                    256 MB shared-cpu-1x
+└── justfile                    dev / build / test / deploy recipes
+```
+
+## Request flow in production
+
+1. The Go binary listens on `:8080`.
+2. `/healthz` → 204 (Fly health check).
+3. `/api/*` → JSON handlers, gated by the WorkOS JWKS middleware where applicable. Unknown `/api/*` paths return a JSON 404, never the static fallback.
+4. `/ws` → reserved for the future WebSocket hub.
+5. Anything else → static handler. Resolves `/foo` against `static/foo`, then `static/foo/index.html`, then `static/foo.html`. If nothing matches it serves `static/404.html` with a 404 status.
+
+`http.FileServer` is **not** used because it commits a 404 to the wire before Echo's error handler can run. The custom handler in `apps/api/main.go` owns that path.
+
+## Auth
+
+- **Client:** `@workos-inc/authkit-react` provides the sign-in flow and access tokens. `useApiFetch` (in `apps/web/src/lib/api.ts`) attaches the bearer token to `/api/*` requests.
+- **Server:** `apps/api/internal/auth/jwks.go` fetches the WorkOS JWKS on startup and refreshes periodically. `apps/api/internal/auth/middleware.go` validates signature, issuer, and expiry on every protected request. Validated claims are stashed in the Echo context for handlers to read.
+
+The Go-side auth is opt-in: if `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` (or their `VITE_`-prefixed fallbacks) are missing, `/api/me` is not mounted. Static serving and `/healthz` keep working — useful for barebones smoke tests.
+
+## Database
+
+- Pure-Go SQLite via `modernc.org/sqlite` (no CGO) so the distroless image stays static.
+- **Schema is owned by Go.** Migrations live in `apps/api/internal/db/migrations/` as goose `.sql` files, are embedded into the binary via `//go:embed`, and apply on every startup. Goose tracks state in its own table, so re-running is a no-op.
+- For dev: `just db_migrate`, `just db_status`, `just db_down`, `just db_create <name>` wrap a small CLI in `apps/api/cmd/migrate`.
+- Remote Turso (`libsql://`) is a planned follow-up; the current `Open()` rejects libsql/http schemes up front so misconfigurations fail fast.
+
+## Build and deploy
+
+- `bun run build` (or `just build`) prerenders all routes to `apps/web/.output/public/`.
+- `just build` mirrors that directory into `apps/api/static/` so `go run .` serves the same content locally.
+- The Dockerfile copies the prebuilt `apps/web/.output/public` into the Go build stage. Fly's remote builder never runs `bun install`.
+- `just deploy` chains `just build` and `fly deploy`.
+
+See [Deployment](./deployment.md) for image and Fly details.

--- a/manual/src/deployment.md
+++ b/manual/src/deployment.md
@@ -1,25 +1,43 @@
 # Deployment
 
-## Docker
+The deployed app is a single Go binary that serves the prerendered web app, the JSON API at `/api/*`, and (in future) a WebSocket endpoint at `/ws`. There is no JavaScript runtime in production — the bundle is built locally and shipped as static files alongside the binary.
 
-The application is containerized using Docker. The `Dockerfile` is optimized for production builds, utilizing multi-stage builds to minimize image size and speed up build times.
+## Architecture in production
 
-### Build Process
+- `apps/web/.output/public/` — prerendered HTML/CSS/JS produced by `bun run build`. Built locally so Fly's remote builder doesn't re-run `bun install` (~10 min on a cold cache).
+- `apps/api/static/` — copy of `apps/web/.output/public/` mirrored by `just build` so the Go binary serves it.
+- `server` (the Go binary) — Echo + middleware + auth + DB; embeds goose migrations and applies them on startup.
 
-1.  **Base Image**: Uses `oven/bun:alpine` as the base image.
-2.  **Dependencies**: Separates production dependencies (`prod-deps`) from build dependencies to optimize caching.
-3.  **Build**: Compiles the application using `bun run build`.
-4.  **Final Image**: Copies only the necessary artifacts (`.output`, `node_modules`, `public`, `package.json`) to the final image.
+## Docker image
 
-### Deployment on Fly.io
+`Dockerfile` is multi-stage:
 
-The `Dockerfile` is specifically configured for deployment on [Fly.io](https://fly.io).
+1. **Build stage** (`golang:1.26-alpine`): copy `apps/api/`, copy the prebuilt `apps/web/.output/public` into `./static`, then `go build -trimpath -ldflags="-s -w" -o /out/server .` with `CGO_ENABLED=0`.
+2. **Runtime stage** (`gcr.io/distroless/static-debian12:debug-nonroot`): copy `/server` and `/static`. Distroless gives CA certs, a nonroot user, and a BusyBox shell for `fly ssh console` — about 2 MB on disk and zero steady-state RAM beyond the binary itself.
 
-- **Runtime**: Bun
-- **Port**: 8080
+The image runs as `nonroot`, exposes `8080`, and `ENTRYPOINT ["/server"]`.
+
+## Fly.io
+
+- `fly.toml` targets a 256 MB shared-cpu-1x machine with auto-stop enabled.
+- `/healthz` returns 204 — used by Fly's health checks.
 
 To deploy:
 
 ```bash
 just deploy
+```
+
+`just deploy` runs `just build` first (so the prerendered site is up to date), then `fly deploy`. Fly's remote builder pulls the prebuilt `apps/web/.output/public` from the build context — no JS install on the remote side.
+
+## Migrations
+
+Goose migrations live in `apps/api/internal/db/migrations/` and are embedded into the binary via `//go:embed`. The server applies pending migrations on startup, so a deploy that introduces a new migration applies it automatically the first time the new binary boots. There is no separate migration step in the deploy pipeline.
+
+For ad-hoc runs against a local DB:
+
+```bash
+just db_status
+just db_migrate
+just db_create add_some_table   # scaffolds a new .sql file
 ```

--- a/manual/src/development.md
+++ b/manual/src/development.md
@@ -1,22 +1,57 @@
 # Development
 
-This page contains information on managing the site in development.
+Notes for working on the codebase day-to-day.
 
-## Updating Dependencies
+## Running the app
 
 ```bash
+just dev
+```
+
+Boots two servers in parallel:
+
+- `apps/web/` (TanStack Start dev server) on `http://localhost:7001`.
+- `apps/api/` (Go + Echo) on `http://localhost:8080`.
+
+The Vite dev server proxies `/api` and `/ws` to `:8080`, so you hit the same paths in dev as in production.
+
+To run only one side:
+
+```bash
+just dev-web   # Vite only
+just dev-api   # Go only — sources .env.local so /api/me and /api/todos mount
+```
+
+## Updating dependencies
+
+```bash
+# JS dependencies (apps/web)
 bun update --interactive
+
+# Go dependencies (apps/api)
+cd apps/api && go get -u ./... && go mod tidy
 ```
 
-## Running Tests
+## Running tests
 
 ```bash
-just test
-just test_watch
-just test_coverage
+just test            # Go race tests + Vitest
+just test-watch      # Vitest in watch mode (web only)
+just test-coverage   # Vitest with coverage report
 ```
 
-## See Available Scripts
+Backend changes require Go test coverage — that's a hard rule of the stack. Add tests under `apps/api/` next to the code under test (`*_test.go`).
+
+## Linting and formatting
+
+```bash
+just format    # Prettier across the repo
+just lint      # ESLint + Stylelint on the web side
+```
+
+`lefthook` runs Prettier on staged files in `pre-commit` and `just test` + lint in `pre-push`.
+
+## See available recipes
 
 ```bash
 just

--- a/manual/src/index.md
+++ b/manual/src/index.md
@@ -2,6 +2,8 @@
 
 Welcome to the Code Self Study website codebase. This mdBook manual is a short guide for getting the app running and understanding how the project is organized.
 
+The repo is a Bun workspace with a TanStack Start frontend (`apps/web/`) and a Go + Echo backend (`apps/api/`). In production a single Go binary serves the prerendered site, the JSON API, and a future WebSocket endpoint — there is no JavaScript runtime on the server.
+
 ## Project Goals
 
 - Help members find something in common to work on.
@@ -12,5 +14,6 @@ Current ideas include authentication, daily puzzles, marking completed puzzles, 
 ## Start Here
 
 - Read "Getting Started" to set up your environment and run the app.
+- Skim "Architecture" for the high-level shape of the two apps and how they fit together.
 - Use "Project Structure" to find features and data quickly.
 - Check "Routing & Data" for TanStack Router conventions.

--- a/manual/src/routing-and-data.md
+++ b/manual/src/routing-and-data.md
@@ -1,9 +1,13 @@
 # Routing & Data
 
+> All paths in this section are relative to `apps/web/`.
+
 ## Routing (TanStack Router)
 
 Routes are file-based in `src/routes/`. The layout lives in
-`src/routes/__root.tsx`. Run the dev server and create a new route by adding a new file to `src/routes/`. For example, `src/routes/my-page.tsx`. TanStack Router will automatically generate some boilerplate in the file for you.
+`src/routes/__root.tsx` and wraps the app in `WorkOSProvider` plus the TanStack devtools harness. Run the dev server and create a new route by adding a new file to `src/routes/`. For example, `src/routes/my-page.tsx`. TanStack Router will automatically generate some boilerplate in the file for you.
+
+Server-side data fetching from the Go API uses `useApiFetch` from `src/lib/api.ts`, which attaches the WorkOS access token to `/api/*` requests. Vite proxies those calls to `http://localhost:8080` in dev.
 
 ### Adding Links
 

--- a/manual/src/tooling-and-quality.md
+++ b/manual/src/tooling-and-quality.md
@@ -2,34 +2,46 @@
 
 ## Scripts
 
+Most day-to-day work goes through `just` — see [Scripts](./scripts.md). The
+underlying commands:
+
 ```bash
-bun run test            # Vitest
-bun run test:watch      # Vitest in watch mode
-bun run test:coverage   # Vitest with coverage report
-bun run lint            # ESLint + Stylelint
-bun run format          # Prettier
-bun run check           # Prettier + ESLint
+# Web (apps/web)
+bun run --filter web test            # Vitest
+bun run --filter web test:watch      # Vitest in watch mode
+bun run --filter web test:coverage   # Vitest with coverage report
+bun run --filter web lint            # ESLint + Stylelint
+
+# API (apps/api)
+go test -race ./...                  # Go race tests
+go vet ./...                         # static analysis
+
+# Repo-wide
+bun run format                       # Prettier
+bun run check                        # Prettier + ESLint
 ```
 
 ## Linting and Formatting
 
-- ESLint uses `@tanstack/eslint-config`.
+- ESLint uses `@tanstack/eslint-config` (web side).
 - Stylelint checks CSS and Tailwind usage.
 - Prettier is the standard formatter.
 - Styling is done with Tailwind CSS.
+- Go follows `gofmt` and `go vet`.
 
 ## Tests and Coverage
 
-Tests run with [Vitest](https://vitest.dev/). `bun run test:coverage`
-produces an HTML report under `coverage/`.
+- **Web:** Vitest (`apps/web/vitest.config.ts`). `just test-coverage` produces an HTML report under `apps/web/coverage/`. `apps/web/src/lib/**`, `apps/web/src/data/**`, `apps/web/src/hooks/**`, and `apps/web/src/env.ts` enforce 100% line/function/statement coverage.
+- **API:** stdlib `testing` + `httptest`. All Go code requires test coverage — this is a hard rule of the stack experiment. Tests live next to the code as `*_test.go`.
 
 ## Continuous Integration
 
-`.github/workflows/test.yml` runs `bun run test:coverage` on every pull
-request and on pushes to `main`. The coverage HTML report is uploaded as a
-build artifact (`coverage-html`) and retained for 14 days.
+`.github/workflows/test.yml` runs both sides on every pull request and on pushes to `main`:
+
+- `bun install` + `bun run --filter web test`
+- `cd apps/api && go test -race ./... && go vet ./...`
+- ESLint and Stylelint via `bunx` against `apps/web`.
 
 ## Git Hooks
 
-`lefthook.yml` runs formatting on staged files and validates lint/test on push.
-If hooks block you, fix the reported files and re-run the command.
+`lefthook.yml` runs Prettier on staged files in `pre-commit` and `just test` + lint in `pre-push`. If hooks block you, fix the reported files and re-run the command — never bypass them with `--no-verify`.


### PR DESCRIPTION
## Summary

The mdBook still described the old Bun-only runtime. Bringing it in line with what's actually shipping ahead of merging #194 to \`main\`.

- **New** [\`manual/src/architecture.md\`](https://github.com/codeselfstudy/codeselfstudy/blob/claude/elastic-lamarr-1af992-docs-pass/manual/src/architecture.md) — high-level shape: workspace layout, request flow in production, auth, DB ownership, build/deploy. Single page a new contributor can read before drilling into source.
- **Rewrote** \`deployment.md\` — was claiming \`oven/bun:alpine\` and a Bun runtime. Now describes the multi-stage Go + distroless image, the embedded goose migrations, and Fly's 256 MB target.
- **Fixed** \`development.md\` — \`just test_watch\` / \`test_coverage\` (underscores) were broken recipe names; the actual ones use dashes. Added the \`just dev-web\` / \`dev-api\` split and the Go test-coverage requirement.
- **Updated** \`tooling-and-quality.md\` — split scripts by workspace, added \`go test\` / \`go vet\`, refreshed the CI section so it matches what \`.github/workflows/test.yml\` actually does.
- **Tweaked** \`routing-and-data.md\` — clarified paths are relative to \`apps/web/\` and pointed at \`useApiFetch\` for \`/api/*\` calls.
- **Tweaked** \`index.md\` — short intro paragraph and a pointer to Architecture from the \"Start Here\" list.
- **Updated** \`SUMMARY.md\` — Architecture inserted between Getting Started and Project Structure.

\`README.md\` was already accurate after #220 / #221 — no changes needed there.

## Test plan

- [x] Doc-only changes; lefthook pre-push ran \`just test\` (52 vitest + Go race tests, all green) and lint.
- [x] \`mdbook build manual\` locally to spot-check rendering before merging.