### PR TITLE
Point build pipeline at Astro output dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
-# Only the prebuilt apps/web/.output/public ships in the build context;
-# the Go binary serves it. Source / installs aren't needed at build time.
+# Only the prebuilt apps/web/dist ships in the build context; the Go binary
+# serves it. Source / installs aren't needed at build time. The dist dir is
+# matched by the defensive `**/dist` glob below and re-included at the end.
 
 .git
 .github
@@ -39,7 +40,6 @@ apps/web/public
 apps/web/test
 apps/web/node_modules
 apps/web/.tanstack
-apps/web/dist
 apps/web/.cta.json
 apps/web/components.json
 apps/web/drizzle.config.ts
@@ -185,3 +185,9 @@ package.json
 **/*.class
 **/out
 **/.gradle
+
+# Re-include the one build artifact that must ship: the prerendered Astro
+# output that the Go binary serves. This negation must stay last so it wins
+# over the `**/dist` defensive glob above (last matching pattern wins).
+!apps/web/dist
+!apps/web/dist/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.7
 #
-# The web app is built locally (see `just deploy`) and apps/web/.output/public
-# ships in the build context. That avoids re-running `bun install` on Fly's
-# remote builder, which was ~10min on a cold cache.
+# The web app is built locally (see `just deploy`) and apps/web/dist ships in
+# the build context. That avoids re-running `bun install` on Fly's remote
+# builder, which was ~10min on a cold cache.
 
 # 1. Build the Go binary, copying the prebuilt static site as ./static.
 FROM golang:1.26-alpine AS api
@@ -10,7 +10,7 @@ WORKDIR /src
 COPY apps/api/go.mod apps/api/go.sum ./
 RUN go mod download
 COPY apps/api ./
-COPY apps/web/.output/public ./static
+COPY apps/web/dist ./static
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/server .
 
 # 2. Distroless runtime. CA certs + nonroot user + BusyBox shell (debug

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ default:
 dev:
   just dev-api & just dev-web && wait
 
-# Web (TanStack Start) dev server only
+# Web (Astro) dev server only
 dev-web:
   bun run --env-file=.env.local --filter web dev
 
@@ -23,7 +23,7 @@ build: clean
   @echo '\nBuilding the project...\n'
   bun run --env-file=.env.local --filter web build
   /bin/rm -rf apps/api/static
-  /bin/cp -R apps/web/.output/public apps/api/static
+  /bin/cp -R apps/web/dist apps/api/static
   @echo '\nDone with building.\n'
 
 # Run unit tests across the whole repo (Go race tests + Vitest)
@@ -94,7 +94,7 @@ mockups:
 manual:
   cd manual && mdbook serve -p 8001 --open
 
-# Remove build artifacts (web .output/.tanstack, api ./static, root node_modules cache)
+# Remove build artifacts (web dist, api ./static, root node_modules cache)
 clean:
   @echo '\nCleaning project...\n'
   ./scripts/clean.sh

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -5,12 +5,10 @@
 
 set -euo pipefail
 
-# Web build outputs (TanStack Start + Vite + Nitro).
-/bin/rm -rfv apps/web/.output
-/bin/rm -rfv apps/web/.tanstack
+# Web build output (Astro).
 /bin/rm -rfv apps/web/dist
 
-# Go static-asset mirror (populated by `just build` from .output/public).
+# Go static-asset mirror (populated by `just build` from apps/web/dist).
 /bin/rm -rfv apps/api/static
 
 # Local Go binaries from `go build .` if anyone runs them.


### PR DESCRIPTION
Implements #236 (parent #234). Makes `just build`, the Dockerfile, and `clean.sh` reference the Astro output directory instead of the old TanStack Start/Nitro path, so the Go server actually serves the built site.

## What changed
- **justfile `build`**: copies the Astro `dist` dir into `apps/api/static` (was `apps/web/.output/public`).
- **Dockerfile**: `COPY` the Astro `dist` dir to `./static`.
- **scripts/clean.sh**: removed the `.output` and `.tanstack` cleanup lines (those dirs don't exist under Astro); the `dist` dir and `apps/api/static` are still cleaned.
- Updated the stale "TanStack Start" / ".output/public" comments in all three files.
- Did not rename existing kebab-case recipes (`dev-web`, `test-watch`) — out of scope.

## Verification
- `grep -rn '\.output|\.tanstack' justfile Dockerfile scripts/clean.sh` → no matches
- `just clean && just build` → builds the web app and mirrors the output into the Go static dir
- `cd apps/api && go run .` then `curl localhost:8080/` → **HTTP 200**, body has `<title>Code Self Study</title>`; `/healthz` → 204
- `go test -race ./...` (via `apps/api`) → all packages pass
