### PR TITLE
Add head-metadata parity to Layout

### DIFF
--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -2,14 +2,52 @@
 import "@/styles/global.css";
 import Navbar from "@/components/Navbar.tsx";
 import Footer from "@/components/Footer.astro";
+import { createMetadata } from "@/lib/metadata";
 
 interface Props {
   title: string;
   description: string;
+  image?: string;
+  isHome?: boolean;
+  isNoIndex?: boolean;
   lang?: string;
 }
 
-const { title, description, lang = "en" } = Astro.props;
+const {
+  title,
+  description,
+  image,
+  isHome,
+  isNoIndex,
+  lang = "en",
+} = Astro.props;
+
+const metadata = createMetadata({
+  title,
+  description,
+  image,
+  isHome,
+  isNoIndex,
+});
+const titleEntry = metadata.find(
+  (entry): entry is { title: string } => "title" in entry
+);
+const pageTitle = titleEntry?.title ?? title;
+
+// Canonical URL for the current page. With trailingSlash "always" this yields
+// e.g. https://codeselfstudy.com/about/ — a single stable form per page.
+const canonical = new URL(Astro.url.pathname, Astro.site);
+
+// Google Analytics config snippet, injected verbatim in production only (see
+// the head below). Kept as a string because raw `{}` in an inline <script>
+// inside a JSX expression would be parsed as Astro expressions.
+const gaSnippet = `
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-99DC6WSRWL');
+`;
 ---
 
 <html lang={lang}>
@@ -18,8 +56,37 @@ const { title, description, lang = "en" } = Astro.props;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width" />
-    <title>{title}</title>
-    <meta name="description" content={description} />
+    <title>{pageTitle}</title>
+    {
+      metadata.map((entry) =>
+        "name" in entry ? (
+          <meta name={entry.name} content={entry.content} />
+        ) : "property" in entry ? (
+          <meta property={entry.property} content={entry.content} />
+        ) : null
+      )
+    }
+    <link rel="canonical" href={canonical} />
+    {
+      /*
+        Google Analytics — production builds only. This was a TODO in the old
+        app ("double-check that this works, I don't know how TanStack handles
+        page changes"). Moot now: this is a static MPA, so every navigation is
+        a full page load and gtag fires on each page automatically.
+      */
+    }
+    {
+      import.meta.env.PROD && (
+        <>
+          <script
+            is:inline
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-99DC6WSRWL"
+          />
+          <script is:inline set:html={gaSnippet} />
+        </>
+      )
+    }
   </head>
   <body>
     <Navbar />

--- a/apps/web/src/lib/metadata.test.ts
+++ b/apps/web/src/lib/metadata.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import { createMetadata } from "./metadata";
+
+const TITLE = "Page";
+const DESCRIPTION = "A description";
+
+describe("createMetadata", () => {
+  test("appends site name to title by default", () => {
+    const meta = createMetadata({ title: TITLE, description: DESCRIPTION });
+    expect(meta[0]).toEqual({ title: "Page | Code Self Study" });
+  });
+
+  test("uses bare title when isHome is true", () => {
+    const meta = createMetadata({
+      title: TITLE,
+      description: DESCRIPTION,
+      isHome: true,
+    });
+    expect(meta[0]).toEqual({ title: TITLE });
+  });
+
+  test("includes the description and og:description", () => {
+    const meta = createMetadata({ title: TITLE, description: DESCRIPTION });
+    expect(meta).toContainEqual({ name: "description", content: DESCRIPTION });
+    expect(meta).toContainEqual({
+      property: "og:description",
+      content: DESCRIPTION,
+    });
+  });
+
+  test("uses og title without site suffix even when not home", () => {
+    const meta = createMetadata({ title: TITLE, description: DESCRIPTION });
+    expect(meta).toContainEqual({ property: "og:title", content: TITLE });
+  });
+
+  test("sets robots to max-image-preview by default", () => {
+    const meta = createMetadata({ title: TITLE, description: DESCRIPTION });
+    expect(meta).toContainEqual({
+      name: "robots",
+      content: "max-image-preview:large",
+    });
+  });
+
+  test("sets robots to noindex when isNoIndex is true", () => {
+    const meta = createMetadata({
+      title: TITLE,
+      description: DESCRIPTION,
+      isNoIndex: true,
+    });
+    expect(meta).toContainEqual({ name: "robots", content: "noindex" });
+  });
+
+  test("sets og:type to website", () => {
+    const meta = createMetadata({ title: TITLE, description: DESCRIPTION });
+    expect(meta).toContainEqual({ property: "og:type", content: "website" });
+  });
+
+  test("omits og:image entry when no image provided", () => {
+    const meta = createMetadata({ title: TITLE, description: DESCRIPTION });
+    expect(
+      meta.some((entry) => "property" in entry && entry.property === "og:image")
+    ).toBe(false);
+  });
+
+  test("appends og:image entry when image provided", () => {
+    const image = "https://example.com/og.png";
+    const meta = createMetadata({
+      title: TITLE,
+      description: DESCRIPTION,
+      image,
+    });
+    expect(meta).toContainEqual({ property: "og:image", content: image });
+  });
+});

--- a/apps/web/src/lib/metadata.ts
+++ b/apps/web/src/lib/metadata.ts
@@ -1,0 +1,51 @@
+interface MetadataProps {
+  title: string;
+  description: string;
+  image?: string;
+  isHome?: boolean;
+  isNoIndex?: boolean;
+}
+
+export function createMetadata({
+  title,
+  description,
+  image,
+  isHome = false,
+  isNoIndex = false,
+}: MetadataProps) {
+  const fullTitle = isHome ? title : `${title} | Code Self Study`;
+
+  return [
+    {
+      title: fullTitle,
+    },
+    {
+      name: "description",
+      content: description,
+    },
+    {
+      name: "robots",
+      content: isNoIndex ? "noindex" : "max-image-preview:large",
+    },
+    {
+      property: "og:title",
+      content: title,
+    },
+    {
+      property: "og:description",
+      content: description,
+    },
+    {
+      property: "og:type",
+      content: "website",
+    },
+    ...(image
+      ? [
+          {
+            property: "og:image",
+            content: image,
+          },
+        ]
+      : []),
+  ];
+}


### PR DESCRIPTION
Implements #238 (parent #234). Gives `Layout.astro` full `<head>` parity with the old app: per-page title/description/robots/Open Graph tags, a canonical link, and production-only Google Analytics.

## What changed
- **`src/lib/metadata.ts`** + **`metadata.test.ts`**: ported verbatim from the old app (pure TS, no import changes). `createMetadata({ title, description, image?, isHome?, isNoIndex? })` returns the head-tag array (title with " | Code Self Study" suffix unless `isHome`, description, robots, `og:*`).
- **`Layout.astro`**:
  - Props now `title`, `description` (both required), plus optional `image`, `isHome`, `isNoIndex`, `lang`.
  - Renders `createMetadata` output — `<title>` from the title entry, `<meta name>`/`<meta property>` for the rest.
  - `<link rel="canonical" href={new URL(Astro.url.pathname, Astro.site)}>` → e.g. `https://codeselfstudy.com/about/` with trailingSlash "always".
  - Google Analytics `G-99DC6WSRWL` as `is:inline` scripts, gated on `import.meta.env.PROD`. The old `analytics.tsx` TODO comment is carried over and updated to note the MPA makes SPA route-change tracking moot.
- Required `title`/`description` make `astro check` fail any page that omits them — the structural replacement for the old `enforce-route-metadata` ESLint rule (not ported, per plan).

## Verification
- `bun run --filter web test:coverage` → 9 tests pass; `src/lib/**` at 100% (threshold gate green)
- `bun run --filter web build` → 0 errors; `bunx eslint .` / stylelint → 0
- Prod build (`astro preview`): `<link rel="canonical" href="https://codeselfstudy.com/">`, gtag present, `<meta name="robots" content="max-image-preview:large">`
- Dev server (`astro dev`): **zero** gtag occurrences (GA prod-only confirmed)
- Negative test: a page omitting `description` fails `astro check` with `Property 'description' is missing ... but required in type 'Props'`

## Note
No Subresource Integrity on the gtag `<script>` — Google's gtag.js has no stable published hash and SRI would break it; this matches the old app.
