### PR TITLE
Port content pages batch A (home, about, events, contact, s, 404)

### DIFF
--- a/apps/web/src/components/copyrighted/AboutContent.astro
+++ b/apps/web/src/components/copyrighted/AboutContent.astro
@@ -1,0 +1,22 @@
+---
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+const joinButtonClass = cn(buttonVariants({ size: "lg" }));
+---
+
+<h1>About Us</h1>
+<p>
+  We organize several tech meetup groups in Berkeley, California with over 5,000
+  members in total. We also organize events around the San Francisco Bay Area.
+</p>
+<p>
+  <a
+    href="https://www.meetup.com/codeselfstudy/"
+    target="_blank"
+    rel="noopener noreferrer nofollow"
+    class={joinButtonClass}
+  >
+    Join the Meetup Group
+  </a>
+</p>

--- a/apps/web/src/components/copyrighted/ContactContent.astro
+++ b/apps/web/src/components/copyrighted/ContactContent.astro
@@ -1,0 +1,10 @@
+---
+
+---
+
+<h1>Contact Us</h1>
+<p>
+  Send us an email: <a href="mailto:contact@codeselfstudy.com"
+    >contact@codeselfstudy.com</a
+  >.
+</p>

--- a/apps/web/src/components/copyrighted/EventsContent.astro
+++ b/apps/web/src/components/copyrighted/EventsContent.astro
@@ -1,0 +1,12 @@
+---
+
+---
+
+<h1>Events</h1>
+<p>
+  Check our <a
+    href="https://www.meetup.com/codeselfstudy/"
+    target="_blank"
+    rel="noopener noreferrer nofollow">Meetup group</a
+  > for upcoming events.
+</p>

--- a/apps/web/src/components/copyrighted/HomeContent.astro
+++ b/apps/web/src/components/copyrighted/HomeContent.astro
@@ -1,0 +1,108 @@
+---
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+const joinButtonClass = cn(
+  buttonVariants({ size: "lg" }),
+  "bg-blue-600 text-lg text-white hover:bg-blue-700"
+);
+---
+
+<div class="bg-circuit-board bg-gray-200 bg-center py-20">
+  <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="w-fit rounded bg-white p-6">
+      <h1>Code Self Study</h1>
+      <p class="text-xl font-bold">
+        Self-study computer programming in a community of like-minded people
+      </p>
+      <p class="mb-8 max-w-2xl text-lg">
+        We're a friendly programming community made up of over 5,000 programmers
+        in Berkeley and the San Francisco Bay Area. All programming languages
+        and levels of experience are welcome!
+      </p>
+      <a
+        href="https://www.meetup.com/codeselfstudy/"
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        class={joinButtonClass}
+      >
+        Join the Community
+      </a>
+    </div>
+  </div>
+</div>
+
+<section class="py-12">
+  <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="grid gap-8 md:grid-cols-3">
+      <div>
+        <h2>Community</h2>
+        <p>
+          Attend our meetups and get out of your room to meet like-minded
+          programmers.
+        </p>
+      </div>
+      <div>
+        <h2>Get Help</h2>
+        <p>
+          The experienced members in the group help the beginners. Bring your
+          programming questions, and don't hesitate to ask. We can also help you
+          design study plans. The model is self-study with mentorship.
+        </p>
+      </div>
+      <div>
+        <h2>Networking</h2>
+        <p>
+          It's easier to get a job when you know people in the industry. Many
+          people in the group have gotten jobs through networking or through
+          tips they've acquired from other group members.
+        </p>
+      </div>
+    </div>
+    <hr class="my-12 border-gray-200" />
+  </div>
+</section>
+
+<section class="pb-12">
+  <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+    <h2>What We Do</h2>
+    <p>
+      There are dozens of local meetup groups that teach people how to code.
+      Here are some ways that we are different from most other groups:
+    </p>
+    <ul>
+      <li>
+        We are building a local community of friendly, creative,
+        highly-motivated programmers in the San Francisco Bay Area.
+      </li>
+      <li>
+        We're open to all programming languages, all levels of ability, and all
+        types of computer programming.
+      </li>
+      <li>
+        The format is self study with advice and mentorship from the more
+        experienced members. We can help you with study plans and guidance
+        &mdash; just let us know at a meetup or in the forum.
+      </li>
+    </ul>
+    <p>
+      Some of the languages our members have been working with are: Python,
+      JavaScript, TypeScript, Go, Rust, WebAssembly, Java, Scheme, Racket,
+      Haskell, Clojure, Common Lisp, C, C++, C#, F#, Lua, Elixir, Erlang, Elm,
+      Purescript, Ruby, Scala, PHP, R, Julia, HTML/CSS, Octave, SQL and more.
+      We're open to anything that is computer-related.
+    </p>
+
+    <h2>Coding Bootcamp Supplement</h2>
+    <p>
+      You can attend our meetings as a self-directed, coding bootcamp supplement
+      or alternative. Experienced programmers in the group can offer mentorship
+      on a project-based approach to learning.
+    </p>
+    <p>
+      This community is self-directed &mdash; if you would like assistance with
+      forming a study plan, let us know in the forum, chatroom, and/or at the
+      meetups.
+    </p>
+  </div>
+</section>

--- a/apps/web/src/components/copyrighted/LICENSE.md
+++ b/apps/web/src/components/copyrighted/LICENSE.md
@@ -1,0 +1,3 @@
+All content in this `copyrighted` directory is copyright © Code Self Study and cannot be reused, because it is unique to this website and the Code Self Study brand.
+
+To reuse code from this repo, be sure to delete all the text content and Code Self Study branding before publishing it.

--- a/apps/web/src/components/copyrighted/SContent.astro
+++ b/apps/web/src/components/copyrighted/SContent.astro
@@ -1,0 +1,18 @@
+---
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+const joinButtonClass = cn(buttonVariants({ size: "lg" }));
+---
+
+<h1>Join our Slack</h1>
+<p>
+  <a
+    target="_blank"
+    rel="noopener noreferrer nofollow"
+    class={joinButtonClass}
+    href="https://join.slack.com/t/codeselfstudy/shared_invite/enQtNTgzNDg3MjYyNTgyLTZiYzQ0OTU0NDA1OTA1NjljZGRkYmYxZDVhNGE4YzM0NTVmMTBjYjEyNmFiZmFmYjBiNzczOGIyYzNjZjkxMDY"
+  >
+    Join our Slack
+  </a>
+</p>

--- a/apps/web/src/pages/404.astro
+++ b/apps/web/src/pages/404.astro
@@ -1,0 +1,35 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import { buttonVariants } from "@/components/ui/button";
+
+const homeButtonClass = buttonVariants();
+const contactButtonClass = buttonVariants({ variant: "outline" });
+---
+
+<Layout
+  title="Page not found"
+  description="The page you were looking for could not be found."
+  isNoIndex
+>
+  <PageWrapper>
+    <div class="mx-auto max-w-2xl text-center">
+      <p
+        class="text-muted-foreground text-sm font-semibold tracking-widest uppercase"
+      >
+        404
+      </p>
+      <h1 class="mt-2 text-4xl font-bold tracking-tight sm:text-5xl">
+        Page not found
+      </h1>
+      <p class="text-muted-foreground mt-4 text-base">
+        We couldn't find the page you were looking for. It may have been moved
+        or no longer exists.
+      </p>
+      <div class="mt-8 flex items-center justify-center gap-3">
+        <a href="/" class={homeButtonClass}>Go home</a>
+        <a href="/contact/" class={contactButtonClass}>Contact us</a>
+      </div>
+    </div>
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/about.astro
+++ b/apps/web/src/pages/about.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import AboutContent from "@/components/copyrighted/AboutContent.astro";
+---
+
+<Layout title="About" description="About the Code Self Study website">
+  <PageWrapper>
+    <AboutContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/contact.astro
+++ b/apps/web/src/pages/contact.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import ContactContent from "@/components/copyrighted/ContactContent.astro";
+---
+
+<Layout title="Contact" description="Contact Code Self Study group">
+  <PageWrapper>
+    <ContactContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/events.astro
+++ b/apps/web/src/pages/events.astro
@@ -1,0 +1,14 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import EventsContent from "@/components/copyrighted/EventsContent.astro";
+---
+
+<Layout
+  title="Events for Programmers"
+  description="Code Self Study organizes events for Programmers"
+>
+  <PageWrapper>
+    <EventsContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,7 +1,12 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+import HomeContent from "@/components/copyrighted/HomeContent.astro";
 ---
 
-<Layout title="Code Self Study" description="Home page">
-  <h1>Home</h1>
+<Layout
+  title="Code Self Study"
+  description="Welcome to Code Self Study: programming meetup group in the San Francisco Bay Area"
+  isHome
+>
+  <HomeContent />
 </Layout>

--- a/apps/web/src/pages/s.astro
+++ b/apps/web/src/pages/s.astro
@@ -1,0 +1,15 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import SContent from "@/components/copyrighted/SContent.astro";
+---
+
+<Layout
+  title="Join our Slack"
+  description="Join our Slack to get started"
+  isNoIndex
+>
+  <PageWrapper>
+    <SContent />
+  </PageWrapper>
+</Layout>


### PR DESCRIPTION
Implements #240 (parent #234). Ports the first batch of content pages — home, about, events, contact, Slack invite, and 404.

## What changed
- Content components under `src/components/copyrighted/` (HomeContent, AboutContent, EventsContent, ContactContent, SContent), with the content `LICENSE.md` carried over. Pages in `src/pages/` are thin `Layout` wrappers, mirroring the old route/content split.
- **Licensed copy** ported with syntax-only transforms only: `className` → `class`, TanStack `<Link to>` → `<a href>`, JSX `{" "}` → literal spaces, entities kept. Prose is byte-unchanged. `cn()`/`buttonVariants` are evaluated in Astro frontmatter so the emitted class strings match the old app exactly.
- **Home** passes `isHome`, fixing the old doubled `Code Self Study | Code Self Study` title. It renders full-bleed (no PageWrapper) with the `bg-circuit-board` hero; the others use `PageWrapper`.
- **/s/** keeps `robots: noindex`. Internal links are trailing-slashed (404's "Contact us" → `/contact/`).
- **404.astro** builds to `dist/404.html`, which the Go static handler already serves as its not-found fallback; it's marked `isNoIndex`.

## Exact head values (from the old route files)
| Page | title | isHome/isNoIndex |
|---|---|---|
| / | Code Self Study | isHome |
| /about/ | About | — |
| /events/ | Events for Programmers | — |
| /contact/ | Contact | — |
| /s/ | Join our Slack | isNoIndex |
| 404 | Page not found | isNoIndex |

## Verification
- `bun run --filter web build` → 0 errors; generates `/index.html`, `/about/`, `/events/`, `/contact/`, `/s/`, and `404.html`
- `bunx eslint .` / stylelint → 0
- Prod build (preview): home `<title>` is exactly `Code Self Study` (no doubling); `/about/` is `About | Code Self Study`; `/s/` has `<meta name="robots" content="noindex">`; home has the circuit-board hero + "Join the Community" CTA
- Browser: home renders with full parity — circuit-board hero card, Anton headings, blue CTA, three-column value props (screenshot captured)
