### PR TITLE
Port content pages batch B (codewars, credits, discounts, forum, jobs, learn, puzzles, tools)

### DIFF
--- a/apps/web/src/components/copyrighted/CodewarsContent.astro
+++ b/apps/web/src/components/copyrighted/CodewarsContent.astro
@@ -1,0 +1,22 @@
+---
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+const joinButtonClass = cn(buttonVariants({ size: "lg" }));
+---
+
+<h1>Codewars Clan</h1>
+<p>
+  Click the button below to join our Codewars clan. If you aren't logged into
+  Codewars, it will ask you to log in.
+</p>
+<p>
+  <a
+    href="https://www.codewars.com/r/0JGb7w"
+    class={joinButtonClass}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    Join our Codewars Clan
+  </a>
+</p>

--- a/apps/web/src/components/copyrighted/CreditsContent.astro
+++ b/apps/web/src/components/copyrighted/CreditsContent.astro
@@ -1,0 +1,26 @@
+---
+
+---
+
+<h1>Credits</h1>
+<p>
+  Please support us by using our <a href="/discounts/">our discount links</a>.
+</p>
+<p>
+  SVG backgrounds are from <a
+    target="_blank"
+    rel="noopener noreferrer"
+    href="https://www.heropatterns.com/">Hero Patterns</a
+  > and used under the <a
+    target="_blank"
+    rel="noopener noreferrer"
+    href="https://creativecommons.org/licenses/by/4.0/">CC by 4.0 license</a
+  >.
+</p>
+<p>
+  The website framework is <a
+    target="_blank"
+    rel="noopener noreferrer"
+    href="https://tanstack.com/">TanStack Start</a
+  >.
+</p>

--- a/apps/web/src/components/copyrighted/DiscountsContent.astro
+++ b/apps/web/src/components/copyrighted/DiscountsContent.astro
@@ -1,0 +1,29 @@
+---
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+const signupButtonClass = cn(buttonVariants({ size: "lg" }));
+---
+
+<h1>Discounts</h1>
+<p>
+  These companies offer discounts to our members. We may make small commissions
+  or discounts when you use these links, which helps offset the expenses of
+  running the group.
+</p>
+
+<h2>DigitalOcean</h2>
+
+<p>
+  Digital Ocean hosts parts of our website and offers $50 credit on their
+  hosting plans. Sign up with the link below to claim your $50 credit.
+</p>
+<blockquote>"Simple Cloud Hosting, Built for Developers."</blockquote>
+<a
+  href="https://m.do.co/c/974e5be9397c"
+  class={signupButtonClass}
+  target="_blank"
+  rel="noopener noreferrer nofollow"
+>
+  Sign up for $200 hosting credit
+</a>

--- a/apps/web/src/components/copyrighted/ForumContent.astro
+++ b/apps/web/src/components/copyrighted/ForumContent.astro
@@ -1,0 +1,10 @@
+---
+
+---
+
+<h1>Forum</h1>
+<p>
+  The forum is at <a href="https://forum.codeselfstudy.com/"
+    >forum.codeselfstudy.com</a
+  >.
+</p>

--- a/apps/web/src/components/copyrighted/JobsContent.astro
+++ b/apps/web/src/components/copyrighted/JobsContent.astro
@@ -1,0 +1,14 @@
+---
+
+---
+
+<h1>Programming Jobs</h1>
+<p>
+  This page is for tech jobs in the San Francisco Bay Area and elsewhere (if the
+  employees are able to work remotely from the SF Bay Area).
+</p>
+<p>
+  It's free to list a job here &mdash; just <a href="/contact/"
+    >send us a message</a
+  >.
+</p>

--- a/apps/web/src/components/copyrighted/LearnContent.astro
+++ b/apps/web/src/components/copyrighted/LearnContent.astro
@@ -1,0 +1,6 @@
+---
+
+---
+
+<h1>Learn</h1>
+<p>Coming soon&hellip;</p>

--- a/apps/web/src/components/copyrighted/PuzzlesContent.astro
+++ b/apps/web/src/components/copyrighted/PuzzlesContent.astro
@@ -1,0 +1,6 @@
+---
+
+---
+
+<h1>Puzzles</h1>
+<p>A page of coding puzzles is coming soon!</p>

--- a/apps/web/src/components/copyrighted/ToolsContent.astro
+++ b/apps/web/src/components/copyrighted/ToolsContent.astro
@@ -1,0 +1,6 @@
+---
+
+---
+
+<h1>Tools</h1>
+<p>Coming soon&hellip;</p>

--- a/apps/web/src/pages/codewars.astro
+++ b/apps/web/src/pages/codewars.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import CodewarsContent from "@/components/copyrighted/CodewarsContent.astro";
+---
+
+<Layout title="Join our Codewars Group" description="Join our Codewars Group">
+  <PageWrapper>
+    <CodewarsContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/credits.astro
+++ b/apps/web/src/pages/credits.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import CreditsContent from "@/components/copyrighted/CreditsContent.astro";
+---
+
+<Layout title="Website Credits" description="Website credits">
+  <PageWrapper>
+    <CreditsContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/discounts.astro
+++ b/apps/web/src/pages/discounts.astro
@@ -1,0 +1,14 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import DiscountsContent from "@/components/copyrighted/DiscountsContent.astro";
+---
+
+<Layout
+  title="Discounts for the Group"
+  description="Discounts for Code Self Study group members"
+>
+  <PageWrapper>
+    <DiscountsContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/forum.astro
+++ b/apps/web/src/pages/forum.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import ForumContent from "@/components/copyrighted/ForumContent.astro";
+---
+
+<Layout title="Programming Forum" description="Join our free programming forum">
+  <PageWrapper>
+    <ForumContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/jobs.astro
+++ b/apps/web/src/pages/jobs.astro
@@ -1,0 +1,14 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import JobsContent from "@/components/copyrighted/JobsContent.astro";
+---
+
+<Layout
+  title="Job Opportunities"
+  description="Find job opportunities in the San Francisco Bay Area and elsewhere"
+>
+  <PageWrapper>
+    <JobsContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/learn.astro
+++ b/apps/web/src/pages/learn.astro
@@ -1,0 +1,14 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import LearnContent from "@/components/copyrighted/LearnContent.astro";
+---
+
+<Layout
+  title="Learn How to Code"
+  description="Learn how to code with the Code Self Study community"
+>
+  <PageWrapper>
+    <LearnContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/puzzles.astro
+++ b/apps/web/src/pages/puzzles.astro
@@ -1,0 +1,14 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import PuzzlesContent from "@/components/copyrighted/PuzzlesContent.astro";
+---
+
+<Layout
+  title="Programming Puzzles"
+  description="Programming puzzles for the Code Self Study group"
+>
+  <PageWrapper>
+    <PuzzlesContent />
+  </PageWrapper>
+</Layout>

--- a/apps/web/src/pages/tools.astro
+++ b/apps/web/src/pages/tools.astro
@@ -1,0 +1,14 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import ToolsContent from "@/components/copyrighted/ToolsContent.astro";
+---
+
+<Layout
+  title="Tools"
+  description="Tools built by the Code Self Study community"
+>
+  <PageWrapper>
+    <ToolsContent />
+  </PageWrapper>
+</Layout>


### PR DESCRIPTION
Implements #241 (parent #234). Ports the remaining 8 content pages, completing the site's page set (13 pages + 404).

## What changed
- 8 content components under `src/components/copyrighted/` + 8 thin `Layout`+`PageWrapper` pages. Same rules as batch A (#240): licensed prose ported verbatim (syntax-only transforms), `cn()`/`buttonVariants` evaluated in frontmatter.
- Internal links trailing-slashed: credits → `/discounts/`, jobs → `/contact/`. External links (Codewars, DigitalOcean `m.do.co`, Hero Patterns, CC license, `forum.codeselfstudy.com`, TanStack) left exactly as-is.
- Titles/descriptions copied verbatim from the old route files.

## ⚠️ Content note for the owner (flagged, not changed)
The credits page still reads **"The website framework is TanStack Start"** (linking tanstack.com). Ported verbatim because it's licensed content and rewriting prose is out of scope for a verbatim port — but it's now inaccurate (the site runs on Astro). A background task chip was raised so you can decide whether to update it to Astro. Not changed in this PR.

## Verification
- `bun run --filter web build` → 0 errors; all 13 pages + 404 generate
- `bunx eslint .` / stylelint → 0
- Rendered text (via preview) confirmed verbatim incl. tricky inline spacing: credits ("...using our our discount links.", "...Hero Patterns and used under the CC by 4.0 license.", "...TanStack Start."), jobs ("It's free to list a job here &mdash; just send us a message."), forum, discounts blockquote/button, stubs keep `&hellip;`
- Titles verified per page (e.g. `Programming Puzzles | Code Self Study`)