### PR TITLE
Add trailing-slash canonicalization to the Go static handler

### DIFF
--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -162,11 +162,30 @@ func newServer(staticRoot string, v *auth.Verifier) *echo.Echo {
 // handler (which never fires once FileServer writes to the wire).
 func staticHandler(staticRoot string) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		clean := filepath.Clean("/" + c.Request().URL.Path)
+		reqPath := c.Request().URL.Path
+		clean := filepath.Clean("/" + reqPath)
 		if strings.Contains(clean, "..") {
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}
 		rel := strings.TrimPrefix(clean, "/")
+
+		// Canonicalize to the trailing-slash form. An extensionless path with no
+		// trailing slash that resolves to a directory's index.html gets a 301 to
+		// `path + "/"`, so every page has a single canonical URL (the site is
+		// built with trailingSlash "always"). The query string is preserved.
+		// Paths with an extension (assets) and unresolvable paths are left alone
+		// — no redirected assets, and no redirect-then-404 double hop. We avoid
+		// Echo's AddTrailingSlash middleware precisely because it would redirect
+		// asset URLs too.
+		if reqPath != "/" && !strings.HasSuffix(reqPath, "/") && filepath.Ext(reqPath) == "" {
+			if dirIndexExists(staticRoot, rel) {
+				target := reqPath + "/"
+				if q := c.Request().URL.RawQuery; q != "" {
+					target += "?" + q
+				}
+				return c.Redirect(http.StatusMovedPermanently, target)
+			}
+		}
 
 		if path, ok := resolveStatic(staticRoot, rel); ok {
 			return c.File(path)
@@ -177,6 +196,13 @@ func staticHandler(staticRoot string) echo.HandlerFunc {
 		}
 		return echo.NewHTTPError(http.StatusNotFound)
 	}
+}
+
+// dirIndexExists reports whether rel resolves to a directory index.html — the
+// specific candidate that trailing-slash canonicalization applies to.
+func dirIndexExists(staticRoot, rel string) bool {
+	info, err := os.Stat(filepath.Join(staticRoot, rel, "index.html"))
+	return err == nil && !info.IsDir()
 }
 
 // resolveStatic walks the same fallbacks browsers expect from a prerendered

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -179,7 +179,11 @@ func staticHandler(staticRoot string) echo.HandlerFunc {
 		// asset URLs too.
 		if reqPath != "/" && !strings.HasSuffix(reqPath, "/") && filepath.Ext(reqPath) == "" {
 			if dirIndexExists(staticRoot, rel) {
-				target := reqPath + "/"
+				// Build the target from the normalized `clean`, not the raw
+				// request path: a request for `//about` must redirect to
+				// `/about/`, not the protocol-relative `//about/` (which a
+				// browser reads as the off-origin host `about`).
+				target := clean + "/"
 				if q := c.Request().URL.RawQuery; q != "" {
 					target += "?" + q
 				}

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -18,10 +18,11 @@ func fixtureDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	files := map[string]string{
-		"index.html":       "<!doctype html><title>Home</title>home",
-		"about/index.html": "<!doctype html><title>About</title>about",
-		"404.html":         "<!doctype html><title>Not Found</title>missing",
-		"favicon.ico":      "icon-bytes",
+		"index.html":           "<!doctype html><title>Home</title>home",
+		"about/index.html":     "<!doctype html><title>About</title>about",
+		"404.html":             "<!doctype html><title>Not Found</title>missing",
+		"favicon.ico":          "icon-bytes",
+		"blog/post/index.html": "<!doctype html><title>Post</title>post",
 	}
 	for rel, body := range files {
 		full := filepath.Join(dir, rel)
@@ -193,12 +194,16 @@ func TestTrailingSlashCanonicalization(t *testing.T) {
 		wantLoc  string
 	}{
 		{"extensionless page redirects", http.MethodGet, "/about", http.StatusMovedPermanently, "/about/"},
+		{"nested page redirects", http.MethodGet, "/blog/post", http.StatusMovedPermanently, "/blog/post/"},
 		{"slashed page served", http.MethodGet, "/about/", http.StatusOK, ""},
 		{"root not redirected", http.MethodGet, "/", http.StatusOK, ""},
 		{"query string preserved", http.MethodGet, "/about?x=1&y=2", http.StatusMovedPermanently, "/about/?x=1&y=2"},
 		{"asset not redirected", http.MethodGet, "/favicon.ico", http.StatusOK, ""},
 		{"unresolvable not redirected", http.MethodGet, "/nope", http.StatusNotFound, ""},
 		{"head mirrors get redirect", http.MethodHead, "/about", http.StatusMovedPermanently, "/about/"},
+		// A double-slash path must resolve to the on-origin canonical form, not
+		// a protocol-relative Location that points off-site.
+		{"double slash canonicalized on origin", http.MethodGet, "//about", http.StatusMovedPermanently, "/about/"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -21,6 +21,7 @@ func fixtureDir(t *testing.T) string {
 		"index.html":       "<!doctype html><title>Home</title>home",
 		"about/index.html": "<!doctype html><title>About</title>about",
 		"404.html":         "<!doctype html><title>Not Found</title>missing",
+		"favicon.ico":      "icon-bytes",
 	}
 	for rel, body := range files {
 		full := filepath.Join(dir, rel)
@@ -179,5 +180,40 @@ func TestSSGFallbackHandlesMissing404Html(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status: want 404, got %d", rec.Code)
+	}
+}
+
+func TestTrailingSlashCanonicalization(t *testing.T) {
+	e := newServer(fixtureDir(t), nil)
+	cases := []struct {
+		name     string
+		method   string
+		path     string
+		wantCode int
+		wantLoc  string
+	}{
+		{"extensionless page redirects", http.MethodGet, "/about", http.StatusMovedPermanently, "/about/"},
+		{"slashed page served", http.MethodGet, "/about/", http.StatusOK, ""},
+		{"root not redirected", http.MethodGet, "/", http.StatusOK, ""},
+		{"query string preserved", http.MethodGet, "/about?x=1&y=2", http.StatusMovedPermanently, "/about/?x=1&y=2"},
+		{"asset not redirected", http.MethodGet, "/favicon.ico", http.StatusOK, ""},
+		{"unresolvable not redirected", http.MethodGet, "/nope", http.StatusNotFound, ""},
+		{"head mirrors get redirect", http.MethodHead, "/about", http.StatusMovedPermanently, "/about/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status: want %d, got %d", tc.wantCode, rec.Code)
+			}
+			if tc.wantLoc != "" {
+				if got := rec.Header().Get("Location"); got != tc.wantLoc {
+					t.Fatalf("Location: want %q, got %q", tc.wantLoc, got)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Implements #242 (parent #234). The Astro site is built with `trailingSlash: "always"`, but the Go static handler served both `/about` and `/about/` with 200 — duplicate content. This adds a 301 to the canonical slashed form.

## What changed (`apps/api/main.go`)
- In `staticHandler`: an extensionless GET/HEAD request with no trailing slash that resolves to a directory `index.html` now returns **301** to `path + "/"`, preserving the raw query string.
- New `dirIndexExists` helper gates the redirect on the directory-index candidate specifically.
- `/` is untouched; paths with an extension (assets) and unresolvable paths are never redirected — no redirected assets, no redirect-then-404 double hop.
- Deliberately **not** using Echo's `AddTrailingSlash` middleware (it would redirect asset URLs too).
- HEAD mirrors GET (the route is registered for both).

## Verification
- `go test -race ./...` and `go vet ./...` → all green (existing 22 tests untouched + new table test)
- New `TestTrailingSlashCanonicalization` covers: `/about`→301 `/about/`; `/about/`→200; `/`→200; `/about?x=1&y=2`→301 `/about/?x=1&y=2`; `/favicon.ico`→200; `/nope`→404; `HEAD /about`→301
- End-to-end against the real built site (`just build` + `go run .`): `/about`→301→`/about/`, `/about/`→200, `/favicon.svg`→200, `/nope`→404, `/about?x=1`→301→`/about/?x=1`