### PR TITLE
Port the legacy redirect map to Go

### DIFF
--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -169,6 +169,18 @@ func staticHandler(staticRoot string) echo.HandlerFunc {
 		}
 		rel := strings.TrimPrefix(clean, "/")
 
+		// Legacy redirects run first — before trailing-slash canonicalization
+		// and before static resolution. This ordering matters: `/index.html` is
+		// both a real file in the static root and a legacy redirect to `/`, so
+		// resolving first would serve it 200 instead of redirecting.
+		if r, ok := findRedirect(clean); ok {
+			target := r.to
+			if q := c.Request().URL.RawQuery; q != "" {
+				target += "?" + q
+			}
+			return c.Redirect(r.status, target)
+		}
+
 		// Canonicalize to the trailing-slash form. An extensionless path with no
 		// trailing slash that resolves to a directory's index.html gets a 301 to
 		// `path + "/"`, so every page has a single canonical URL (the site is

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -18,11 +18,11 @@ func fixtureDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	files := map[string]string{
-		"index.html":           "<!doctype html><title>Home</title>home",
-		"about/index.html":     "<!doctype html><title>About</title>about",
-		"404.html":             "<!doctype html><title>Not Found</title>missing",
-		"favicon.ico":          "icon-bytes",
-		"blog/post/index.html": "<!doctype html><title>Post</title>post",
+		"index.html":            "<!doctype html><title>Home</title>home",
+		"about/index.html":      "<!doctype html><title>About</title>about",
+		"404.html":              "<!doctype html><title>Not Found</title>missing",
+		"favicon.ico":           "icon-bytes",
+		"team/alice/index.html": "<!doctype html><title>Alice</title>alice",
 	}
 	for rel, body := range files {
 		full := filepath.Join(dir, rel)
@@ -194,7 +194,7 @@ func TestTrailingSlashCanonicalization(t *testing.T) {
 		wantLoc  string
 	}{
 		{"extensionless page redirects", http.MethodGet, "/about", http.StatusMovedPermanently, "/about/"},
-		{"nested page redirects", http.MethodGet, "/blog/post", http.StatusMovedPermanently, "/blog/post/"},
+		{"nested page redirects", http.MethodGet, "/team/alice", http.StatusMovedPermanently, "/team/alice/"},
 		{"slashed page served", http.MethodGet, "/about/", http.StatusOK, ""},
 		{"root not redirected", http.MethodGet, "/", http.StatusOK, ""},
 		{"query string preserved", http.MethodGet, "/about?x=1&y=2", http.StatusMovedPermanently, "/about/?x=1&y=2"},

--- a/apps/api/redirects.go
+++ b/apps/api/redirects.go
@@ -83,6 +83,12 @@ var exactRedirects = map[string]legacyRedirect{
 	"/b/":             {to: "/learn/", status: http.StatusPermanentRedirect},
 	"/tools/unicode":  {to: "/tools/", status: http.StatusPermanentRedirect},
 	"/tools/unicode/": {to: "/tools/", status: http.StatusPermanentRedirect},
+	// These two legacy paths exist only in trailing-slash form in the source
+	// data. The caller looks up the slash-normalized path (filepath.Clean
+	// strips the trailing slash), and neither is covered by a wildcard, so each
+	// needs a bare-form key to match.
+	"/support-us":             {to: "/", status: http.StatusPermanentRedirect},
+	"/programming-notes-wiki": {to: "/learn/", status: http.StatusPermanentRedirect},
 }
 
 // wildcardRedirects is matched only after exactRedirects. A pattern "/blog/*"

--- a/apps/api/redirects.go
+++ b/apps/api/redirects.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+// legacyRedirect maps a legacy URL to its new destination and status. Ported
+// from the old app's src/data/redirects.ts. Two deliberate upgrades over the
+// TypeScript version: targets carry the trailing slash the site now uses (so a
+// legacy hit is a single hop, not redirect-then-canonicalization), and the
+// caller preserves the query string. "/" targets stay "/".
+type legacyRedirect struct {
+	to     string
+	status int
+}
+
+// exactRedirects is matched first, by exact path. All statuses are 308
+// (permanent) as in the source data.
+var exactRedirects = map[string]legacyRedirect{
+	"/book":                              {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/book/":                             {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/apps":                              {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/apps/":                             {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/autism":                            {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/autism/":                           {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/contribute":                        {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/contribute/":                       {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/sponsors":                          {to: "/credits/", status: http.StatusPermanentRedirect},
+	"/sponsors/":                         {to: "/credits/", status: http.StatusPermanentRedirect},
+	"/parking":                           {to: "/events/", status: http.StatusPermanentRedirect},
+	"/parking/":                          {to: "/events/", status: http.StatusPermanentRedirect},
+	"/school":                            {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/school/":                           {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/support-free-software":             {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/support-free-software/":            {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/tutorials":                         {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/tutorials/":                        {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/featured":                          {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/featured/":                         {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/hire-programmers":                  {to: "/jobs/", status: http.StatusPermanentRedirect},
+	"/hire-programmers/":                 {to: "/jobs/", status: http.StatusPermanentRedirect},
+	"/wiki":                              {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/wiki/":                             {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/discounts/algoexpert":              {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/discounts/algoexpert/":             {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/discounts/digitalocean":            {to: "/discounts/", status: http.StatusPermanentRedirect},
+	"/discounts/digitalocean/":           {to: "/discounts/", status: http.StatusPermanentRedirect},
+	"/sponsors/digitalocean":             {to: "/discounts/", status: http.StatusPermanentRedirect},
+	"/sponsors/digitalocean/":            {to: "/discounts/", status: http.StatusPermanentRedirect},
+	"/sponsors/thplibrary":               {to: "/discounts/", status: http.StatusPermanentRedirect},
+	"/sponsors/thplibrary/":              {to: "/discounts/", status: http.StatusPermanentRedirect},
+	"/home":                              {to: "/", status: http.StatusPermanentRedirect},
+	"/home/":                             {to: "/", status: http.StatusPermanentRedirect},
+	"/index.html":                        {to: "/", status: http.StatusPermanentRedirect},
+	"/support-us/":                       {to: "/", status: http.StatusPermanentRedirect},
+	"/support/":                          {to: "/", status: http.StatusPermanentRedirect},
+	"/support":                           {to: "/", status: http.StatusPermanentRedirect},
+	"/presentations":                     {to: "/events/", status: http.StatusPermanentRedirect},
+	"/presentations/":                    {to: "/events/", status: http.StatusPermanentRedirect},
+	"/presentations-schedule":            {to: "/events/", status: http.StatusPermanentRedirect},
+	"/c":                                 {to: "/forum/", status: http.StatusPermanentRedirect},
+	"/c/":                                {to: "/forum/", status: http.StatusPermanentRedirect},
+	"/bbs":                               {to: "/forum/", status: http.StatusPermanentRedirect},
+	"/join":                              {to: "/forum/", status: http.StatusPermanentRedirect},
+	"/welcome":                           {to: "/events/", status: http.StatusPermanentRedirect},
+	"/checkin":                           {to: "/forum/", status: http.StatusPermanentRedirect},
+	"/edu":                               {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/edu/":                              {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/comment/63":                        {to: "/", status: http.StatusPermanentRedirect},
+	"/forms/feedback":                    {to: "/contact/", status: http.StatusPermanentRedirect},
+	"/wiki/Main_Page":                    {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/w":                                 {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/w/":                                {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/programming-notes-wiki/":           {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/python-web-scraping-selenium.html": {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/Array":                             {to: "/learn/", status: http.StatusPermanentRedirect},
+	// The encoded form from the source; a decoded /wiki/C++ request is also
+	// covered by the /wiki/* wildcard below.
+	"/wiki/C%2B%2B":   {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/b/page/6/":      {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/b":              {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/b/":             {to: "/learn/", status: http.StatusPermanentRedirect},
+	"/tools/unicode":  {to: "/tools/", status: http.StatusPermanentRedirect},
+	"/tools/unicode/": {to: "/tools/", status: http.StatusPermanentRedirect},
+}
+
+// wildcardRedirects is matched only after exactRedirects. A pattern "/blog/*"
+// in the source becomes prefix "/blog"; it matches any path under prefix + "/"
+// with a non-empty remainder (so "/blog/x" matches but "/blog/" and "/blogpost"
+// do not) — identical to the old findRedirect semantics.
+var wildcardRedirects = []struct {
+	prefix   string
+	redirect legacyRedirect
+}{
+	{prefix: "/blog", redirect: legacyRedirect{to: "/learn/", status: http.StatusPermanentRedirect}},
+	{prefix: "/wiki", redirect: legacyRedirect{to: "/learn/", status: http.StatusPermanentRedirect}},
+	{prefix: "/b", redirect: legacyRedirect{to: "/learn/", status: http.StatusPermanentRedirect}},
+}
+
+// findRedirect looks up a legacy redirect for pathname: exact match first, then
+// wildcard prefixes. Mirrors src/lib/redirects.ts.
+func findRedirect(pathname string) (legacyRedirect, bool) {
+	if r, ok := exactRedirects[pathname]; ok {
+		return r, true
+	}
+	for _, w := range wildcardRedirects {
+		if strings.HasPrefix(pathname, w.prefix+"/") && len(pathname) > len(w.prefix)+1 {
+			return w.redirect, true
+		}
+	}
+	return legacyRedirect{}, false
+}

--- a/apps/api/redirects_test.go
+++ b/apps/api/redirects_test.go
@@ -74,6 +74,10 @@ func TestLegacyRedirectServedOverHTTP(t *testing.T) {
 		{"query preserved", http.MethodGet, "/book?a=1&b=2", "/learn/?a=1&b=2"},
 		{"wildcard redirect", http.MethodGet, "/blog/anything", "/learn/"},
 		{"head mirrors get", http.MethodHead, "/book", "/learn/"},
+		// The incoming path is slash-normalized before lookup, so a legacy path
+		// that only existed in trailing-slash form must still redirect.
+		{"trailing-slash-only legacy path", http.MethodGet, "/support-us/", "/"},
+		{"trailing-slash-only to learn", http.MethodGet, "/programming-notes-wiki/", "/learn/"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/api/redirects_test.go
+++ b/apps/api/redirects_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Ports the 13 cases from the old src/lib/redirects.test.ts. Targets carry the
+// trailing slash the Go port adds; the matching semantics are unchanged.
+func TestFindRedirect(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		wantTo  string
+		wantHit bool
+	}{
+		{"exact match", "/book", "/learn/", true},
+		{"exact match with trailing slash", "/book/", "/learn/", true},
+		{"non-existent path", "/nonexistent", "", false},
+		{"wildcard /blog/*", "/blog/some-article", "/learn/", true},
+		{"wildcard /blog/* nested", "/blog/2024/01/article", "/learn/", true},
+		{"wildcard /wiki/*", "/wiki/some-page", "/learn/", true},
+		{"wildcard /b/*", "/b/some-post", "/learn/", true},
+		{"exact preferred over wildcard (/wiki)", "/wiki", "/learn/", true},
+		{"exact preferred over wildcard (/wiki/Main_Page)", "/wiki/Main_Page", "/learn/", true},
+		{"wildcard fallback (/wiki/something-else)", "/wiki/something-else", "/learn/", true},
+		{"exact match not wildcard (/b)", "/b", "/learn/", true},
+		{"partial prefix does not match (/blogpost)", "/blogpost", "", false},
+		{"exact trailing slash not wildcard (/wiki/)", "/wiki/", "/learn/", true},
+		{"wildcard needs content after slash (/blog/)", "/blog/", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := findRedirect(tc.path)
+			if ok != tc.wantHit {
+				t.Fatalf("hit: want %v, got %v", tc.wantHit, ok)
+			}
+			if ok && got.to != tc.wantTo {
+				t.Fatalf("to: want %q, got %q", tc.wantTo, got.to)
+			}
+			if ok && got.status != http.StatusPermanentRedirect {
+				t.Fatalf("status: want 308, got %d", got.status)
+			}
+		})
+	}
+}
+
+// The legacy map must run before static resolution: /index.html is both a real
+// file in the static root and a mapped redirect to /.
+func TestLegacyRedirectPrecedesStaticFile(t *testing.T) {
+	e := newServer(fixtureDir(t), nil)
+	req := httptest.NewRequest(http.MethodGet, "/index.html", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPermanentRedirect {
+		t.Fatalf("status: want 308, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/" {
+		t.Fatalf("Location: want %q, got %q", "/", got)
+	}
+}
+
+func TestLegacyRedirectServedOverHTTP(t *testing.T) {
+	e := newServer(fixtureDir(t), nil)
+	cases := []struct {
+		name    string
+		method  string
+		path    string
+		wantLoc string
+	}{
+		{"exact redirect", http.MethodGet, "/book", "/learn/"},
+		{"query preserved", http.MethodGet, "/book?a=1&b=2", "/learn/?a=1&b=2"},
+		{"wildcard redirect", http.MethodGet, "/blog/anything", "/learn/"},
+		{"head mirrors get", http.MethodHead, "/book", "/learn/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusPermanentRedirect {
+				t.Fatalf("status: want 308, got %d", rec.Code)
+			}
+			if got := rec.Header().Get("Location"); got != tc.wantLoc {
+				t.Fatalf("Location: want %q, got %q", tc.wantLoc, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements #243 (parent #234). Moves the ~70 legacy path redirects from the old SPA-runtime map into the Go server so they emit real 308s.

## What changed
- **`apps/api/redirects.go`** (new): exact-match map + wildcard-prefix slice + `findRedirect`, ported from `src/data/redirects.ts` + the exact-then-wildcard logic in `src/lib/redirects.ts`. Targets upgraded to trailing-slash form (`/learn/`, `/credits/`, …; `/` stays `/`) so a hit is a single hop. Statuses preserved (all 308).
- **`apps/api/main.go`**: `findRedirect` runs in `staticHandler` **before** trailing-slash canonicalization and static resolution. Matching uses the normalized path; the query string is preserved.
- **`apps/api/redirects_test.go`** (new): the 13 cases from `redirects.test.ts` as `findRedirect` unit tests, plus HTTP-level precedence, query-preservation, wildcard, and HEAD tests.
- **`apps/api/main_test.go`**: the #242 nested-canonicalization test moves from `/blog/post` to `/team/alice`, because `/blog/*` is now a legacy redirect that correctly takes precedence over canonicalization (this was the one pre-existing test the new behavior invalidated).

## Precedence (tested)
Legacy redirect → trailing-slash canonicalization → static resolution. `/index.html` is both a real file in the static root **and** a mapped redirect to `/`; the redirect wins.

## Verification
- `go test -race ./...` + `go vet ./...` → green (13 ported cases + precedence/query/wildcard/HEAD + all existing tests)
- End-to-end against the real built site (`just build` + `go run .`): `/book`→308 `/learn/`; `/index.html`→308 `/`; `/blog/anything`→308 `/learn/`; `/sponsors/`→308 `/credits/`; `/wiki/Foo`→308 `/learn/`; `/tools/unicode`→308 `/tools/`; `/book?a=1`→308 `/learn/?a=1`; targets (`/learn/`, `/about/`) resolve 200 — single hop, no redirect chains.