### PR TITLE
Correct the /credits/ framework name to Astro

### DIFF
--- a/apps/web/src/components/copyrighted/CreditsContent.astro
+++ b/apps/web/src/components/copyrighted/CreditsContent.astro
@@ -21,6 +21,6 @@
   The website framework is <a
     target="_blank"
     rel="noopener noreferrer"
-    href="https://tanstack.com/">TanStack Start</a
+    href="https://astro.build/">Astro</a
   >.
 </p>


### PR DESCRIPTION
## What

Update the `/credits/` page to name **Astro** as the site framework instead of TanStack Start, and point the link at https://astro.build/ (was https://tanstack.com/).

## Why

The credits prose was ported verbatim from the old app during the Astro migration (the rule was "port prose verbatim, don't rewrite"). That left the framework credit factually wrong — the site now runs on Astro, and this file is itself a `.astro` component. A credits page exists to give accurate attribution, so a stale framework name defeats its purpose.

This is the site's own brand copy: the `copyrighted/` directory's `LICENSE.md` says the content is © Code Self Study and can't be *reused* by others — it does not bar the owner from editing it. So the verbatim-port rule was migration discipline to avoid drift, not a legal constraint. The site owner confirmed the update.

## Reviewer notes

- **Base is `astro-experiment`, not `main`** — this is part of the ongoing Astro migration.
- One-line content change; no logic touched. The other credits (Hero Patterns, CC BY 4.0) are untouched.
- Both frameworks are MIT and require no attribution, so dropping the line entirely was an option; an accurate credit was kept instead.
