### PR TITLE
Add end-to-end smoke test and just recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,6 +39,11 @@ test-watch:
 test-coverage:
   bun run --filter web test:coverage
 
+# Build the site, then smoke-test it end to end through the Go server
+# (pages, redirects, trailing-slash canonicalization, 404, sitemap).
+smoke_test: build
+  ./scripts/smoke.sh
+
 # Format the whole repo with prettier
 format:
   bun run format

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# End-to-end smoke test for the built site served by the Go server.
+#
+# Assumes `just build` has already populated apps/api/static/ (the `just
+# smoke_test` recipe runs the build first). Builds the Go binary, starts it on a
+# test port, curls the served site, and tears the server down. Exits non-zero if
+# any check fails. Kept simple so it runs under bash 3.2 (macOS default).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PORT="${SMOKE_PORT:-8091}"
+BASE="http://localhost:${PORT}"
+
+if [ ! -f "$ROOT/apps/api/static/index.html" ]; then
+  echo "apps/api/static/index.html not found — run 'just build' first." >&2
+  exit 1
+fi
+
+BIN="$(mktemp -t smoke-server.XXXXXX)"
+LOG="$(mktemp -t smoke-server-log.XXXXXX)"
+( cd "$ROOT/apps/api" && go build -o "$BIN" . )
+( cd "$ROOT/apps/api" && PORT="$PORT" exec "$BIN" ) >"$LOG" 2>&1 &
+SERVER_PID=$!
+
+cleanup() {
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+  /bin/rm -f "$BIN" "$LOG"
+}
+trap cleanup EXIT
+
+# Wait for the server to answer /healthz.
+ready=0
+for _ in $(seq 1 40); do
+  if curl -fsS -o /dev/null "${BASE}/healthz" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [ "$ready" -ne 1 ]; then
+  echo "server did not become ready on ${BASE}; log:" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+
+FAILURES=0
+
+check_status() { # path want-status
+  local got
+  got="$(curl -s -o /dev/null -w "%{http_code}" "${BASE}$1")"
+  if [ "$got" = "$2" ]; then
+    echo "  ok    $1 -> $got"
+  else
+    echo "  FAIL  $1 -> $got (want $2)"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+check_redirect() { # path want-status want-location-suffix
+  local out code loc
+  out="$(curl -s -o /dev/null -w "%{http_code} %{redirect_url}" "${BASE}$1")"
+  code="${out%% *}"
+  loc="${out#* }"
+  case "$loc" in
+  *"$3")
+    if [ "$code" = "$2" ]; then
+      echo "  ok    $1 -> $code $loc"
+      return
+    fi
+    ;;
+  esac
+  echo "  FAIL  $1 -> $code $loc (want $2 ...$3)"
+  FAILURES=$((FAILURES + 1))
+}
+
+check_body_contains() { # path needle
+  if curl -s "${BASE}$1" | grep -q "$2"; then
+    echo "  ok    $1 contains '$2'"
+  else
+    echo "  FAIL  $1 missing '$2'"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "Pages (200 at trailing-slash URLs):"
+for p in / /about/ /codewars/ /contact/ /credits/ /discounts/ /events/ \
+  /forum/ /jobs/ /learn/ /puzzles/ /s/ /tools/; do
+  check_status "$p" 200
+done
+
+echo "Trailing-slash canonicalization:"
+check_redirect /about 301 /about/
+
+echo "Legacy redirects:"
+check_redirect /book 308 /learn/          # exact
+check_redirect /blog/anything 308 /learn/ # wildcard
+check_redirect /index.html 308 /          # precedence over the real file
+
+echo "Other:"
+check_body_contains /s/ noindex
+check_status /nonexistent-page-xyz/ 404
+check_body_contains /nonexistent-page-xyz/ "Page not found"
+check_status /healthz 204
+check_status /sitemap-index.xml 200
+
+echo
+if [ "$FAILURES" -ne 0 ]; then
+  echo "SMOKE FAILED: $FAILURES check(s) failed."
+  exit 1
+fi
+echo "SMOKE OK"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -59,21 +59,20 @@ check_status() { # path want-status
   fi
 }
 
-check_redirect() { # path want-status want-location-suffix
-  local out code loc
+check_redirect() { # path want-status want-location-path
+  local out code loc path
   out="$(curl -s -o /dev/null -w "%{http_code} %{redirect_url}" "${BASE}$1")"
   code="${out%% *}"
   loc="${out#* }"
-  case "$loc" in
-  *"$3")
-    if [ "$code" = "$2" ]; then
-      echo "  ok    $1 -> $code $loc"
-      return
-    fi
-    ;;
-  esac
-  echo "  FAIL  $1 -> $code $loc (want $2 ...$3)"
-  FAILURES=$((FAILURES + 1))
+  # Strip scheme://host to compare the Location path (+ query) exactly, so a
+  # redirect to the wrong page can't slip through a loose suffix match.
+  path="/${loc#*://*/}"
+  if [ "$code" = "$2" ] && [ "$path" = "$3" ]; then
+    echo "  ok    $1 -> $code $path"
+  else
+    echo "  FAIL  $1 -> $code $path (want $2 $3)"
+    FAILURES=$((FAILURES + 1))
+  fi
 }
 
 check_body_contains() { # path needle


### PR DESCRIPTION
Implements #246 (parent #234). Final task — an end-to-end smoke test proving the whole pipeline (Astro build → `just build` copy → Go serve → redirects/canonicalization) works, plus the parity audit.

## What changed
- **`scripts/smoke.sh`**: builds the Go binary, serves the built site on a test port, curls the full contract, tears the server down, exits non-zero on any failure.
- **`justfile`**: new `smoke_test` recipe (snake_case) — depends on `build`, then runs the script.

## `just smoke_test` output (all pass)
```
Pages (200 at trailing-slash URLs): / /about/ /codewars/ /contact/ /credits/
  /discounts/ /events/ /forum/ /jobs/ /learn/ /puzzles/ /s/ /tools/  → all 200
Trailing-slash canonicalization: /about → 301 /about/
Legacy redirects: /book → 308 /learn/ ; /blog/anything → 308 /learn/ ;
  /index.html → 308 / (precedence over the real file)
Other: /s/ contains noindex ; /nonexistent-page-xyz/ → 404 + "Page not found" ;
  /healthz → 204 ; /sitemap-index.xml → 200
SMOKE OK
```

## Parity audit (Astro vs the old TanStack site)

| Route | `<title>` | isNoIndex | Notes |
|---|---|---|---|
| `/` | `Code Self Study` | — | `isHome` (single title, fixes old doubled suffix); circuit-board hero |
| `/about/` | `About \| Code Self Study` | — | |
| `/codewars/` | `Join our Codewars Group \| …` | — | |
| `/contact/` | `Contact \| …` | — | |
| `/credits/` | `Website Credits \| …` | — | framework credit corrected to Astro (#9edabbb) |
| `/discounts/` | `Discounts for the Group \| …` | — | DigitalOcean referral preserved |
| `/events/` | `Events for Programmers \| …` | — | |
| `/forum/` | `Programming Forum \| …` | — | |
| `/jobs/` | `Job Opportunities \| …` | — | |
| `/learn/` | `Learn How to Code \| …` | — | stub |
| `/puzzles/` | `Programming Puzzles \| …` | — | stub |
| `/s/` | `Join our Slack \| …` | **yes** | excluded from sitemap |
| `/tools/` | `Tools \| …` | — | stub |
| `404` | `Page not found \| …` | **yes** | served by Go as the not-found fallback |

- **Canonical**: every page emits `<link rel="canonical" href="https://codeselfstudy.com/<path>/">` (trailing slash); verified in #238.
- **Google Analytics** (`G-99DC6WSRWL`): present in the production build only, absent in dev; verified in #238.
- **Descriptions**: copied verbatim from the old route files (verified in #240/#241).

## Notes
- The old plan's "dist ships zero JS" check is intentionally **not** asserted — React was kept (the navbar is a hydrated island), so `dist/` ships the island's JS by design.
- `smoke_test` is a manual/local recipe; it is not added to CI (no code change, existing CI stays green).
