### PR TITLE
Add a minify string utility, flatten the GA snippet

### DIFF
--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import "@/styles/global.css";
 import Navbar from "@/components/Navbar.tsx";
 import Footer from "@/components/Footer.astro";
 import { createMetadata } from "@/lib/metadata";
+import { minify } from "@/lib/minify";
 
 interface Props {
   title: string;
@@ -38,9 +39,10 @@ const pageTitle = titleEntry?.title ?? title;
 // e.g. https://codeselfstudy.com/about/ — a single stable form per page.
 const canonical = new URL(Astro.url.pathname, Astro.site);
 
-// Google Analytics config snippet, injected verbatim in production only (see
-// the head below). Kept as a string because raw `{}` in an inline <script>
-// inside a JSX expression would be parsed as Astro expressions.
+// Google Analytics config snippet, injected in production only (see the head
+// below), flattened to one line by minify() at the injection point. Kept as a
+// string because raw `{}` in an inline <script> inside a JSX expression would
+// be parsed as Astro expressions.
 const gaSnippet = `
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
@@ -75,7 +77,7 @@ const gaSnippet = `
             async
             src="https://www.googletagmanager.com/gtag/js?id=G-99DC6WSRWL"
           />
-          <script is:inline set:html={gaSnippet} />
+          <script is:inline set:html={minify(gaSnippet)} />
         </>
       )
     }

--- a/apps/web/src/lib/minify.test.ts
+++ b/apps/web/src/lib/minify.test.ts
@@ -19,6 +19,10 @@ describe("minify", () => {
     expect(minify("a\n\n   \nb")).toBe("a b");
   });
 
+  test("handles CRLF line endings (trim strips the trailing \\r)", () => {
+    expect(minify("a\r\nb")).toBe("a b");
+  });
+
   test("leaves a single line unchanged (aside from trimming)", () => {
     expect(minify("  one line  ")).toBe("one line");
   });

--- a/apps/web/src/lib/minify.test.ts
+++ b/apps/web/src/lib/minify.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { minify } from "./minify";
+
+describe("minify", () => {
+  test("flattens an indented multi-line string to one line", () => {
+    const input = `
+      a
+        b
+      c
+    `;
+    expect(minify(input)).toBe("a b c");
+  });
+
+  test("trims leading and trailing whitespace on each line", () => {
+    expect(minify("  a  \n\tb\t")).toBe("a b");
+  });
+
+  test("drops blank and whitespace-only lines", () => {
+    expect(minify("a\n\n   \nb")).toBe("a b");
+  });
+
+  test("leaves a single line unchanged (aside from trimming)", () => {
+    expect(minify("  one line  ")).toBe("one line");
+  });
+
+  test("returns an empty string for empty or whitespace-only input", () => {
+    expect(minify("")).toBe("");
+    expect(minify("\n  \n\t\n")).toBe("");
+  });
+
+  test("flattens the Google Analytics snippet to one line", () => {
+    const snippet = `
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-99DC6WSRWL');
+`;
+    expect(minify(snippet)).toBe(
+      "window.dataLayer = window.dataLayer || []; " +
+        "function gtag(){dataLayer.push(arguments);} " +
+        "gtag('js', new Date()); " +
+        "gtag('config', 'G-99DC6WSRWL');"
+    );
+  });
+});

--- a/apps/web/src/lib/minify.ts
+++ b/apps/web/src/lib/minify.ts
@@ -1,0 +1,16 @@
+/**
+ * Collapse a multi-line string to one line: trim each line, drop blank lines,
+ * and join with a single space. Handy for inlining snippets like the Google
+ * Analytics config into a one-line <script>.
+ *
+ * This is a whitespace flattener, not a real minifier: it assumes the input has
+ * no single-line `//` comments, which would swallow the following code once
+ * everything is on one line.
+ */
+export function minify(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line)
+    .join(" ");
+}


### PR DESCRIPTION
Follow-up to the Astro migration. Adds a small `minify` helper and applies it to the Google Analytics snippet.

## What changed
- **`apps/web/src/lib/minify.ts`**: `minify(text)` collapses a multi-line string to one line — trims each line, drops blank lines, joins with a single space. Documented as a whitespace flattener, not a real minifier (assumes no single-line `//` comments, which would swallow following code once flattened).
- **`apps/web/src/lib/minify.test.ts`**: 6 cases — indented multi-line → one line, per-line trim, blank/whitespace-only lines dropped, single line unchanged, empty input → `""`, and the real GA snippet → its one-line form. Keeps `src/lib/**` at 100% coverage.
- **`apps/web/src/layouts/Layout.astro`**: import `minify` and inject the GA config as `set:html={minify(gaSnippet)}`. `gaSnippet` stays a readable multi-line literal; flattening happens at injection. The footer year script is intentionally left as-is (it has a `//` comment).

## Verification
- `bun run --filter web test:coverage` → 22 tests pass; `src/lib/**` stays 100%
- `bun run --filter web build` → 0 errors; `bunx eslint .` / stylelint → 0
- Prod build (`astro preview`): the GA `<script>` body renders on **one line** (`window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-99DC6WSRWL');`), id intact