### PR TITLE
Add mailparse and htmltext packages

### DIFF
--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/pressly/goose/v3 v3.27.1
 	golang.org/x/net v0.53.0
+	golang.org/x/text v0.36.0
 	modernc.org/sqlite v1.50.0
 )
 
@@ -34,7 +35,6 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	modernc.org/libc v1.72.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/apps/api/internal/htmltext/htmltext.go
+++ b/apps/api/internal/htmltext/htmltext.go
@@ -1,0 +1,149 @@
+// Package htmltext converts HTML email bodies to plain text suitable for LLM
+// deal extraction. It is intentionally small and framework-free.
+//
+// Unlike a generic html-to-text library it renders anchors as "text (href)" so
+// that deal URLs survive into the text the model sees, drops <style>/<script>/
+// <head>, maps block elements and <br> to line breaks, and collapses runs of
+// whitespace.
+package htmltext
+
+import (
+	"strings"
+	"unicode"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+var blockElements = map[atom.Atom]bool{
+	atom.P: true, atom.Div: true, atom.Br: true, atom.Hr: true,
+	atom.H1: true, atom.H2: true, atom.H3: true, atom.H4: true, atom.H5: true, atom.H6: true,
+	atom.Ul: true, atom.Ol: true, atom.Li: true,
+	atom.Table: true, atom.Tr: true, atom.Td: true, atom.Th: true,
+	atom.Section: true, atom.Article: true, atom.Header: true, atom.Footer: true,
+	atom.Nav: true, atom.Aside: true, atom.Blockquote: true,
+}
+
+var skipElements = map[atom.Atom]bool{
+	atom.Script: true, atom.Style: true, atom.Head: true,
+	atom.Noscript: true, atom.Title: true,
+}
+
+// Convert renders HTML source as plain text. It never returns an error for
+// malformed HTML — html.Parse is tolerant — but the signature keeps an error for
+// forward compatibility and reader failures.
+func Convert(htmlSource string) (string, error) {
+	doc, err := html.Parse(strings.NewReader(htmlSource))
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	walk(doc, &b)
+	return collapse(b.String()), nil
+}
+
+func walk(n *html.Node, b *strings.Builder) {
+	switch n.Type {
+	case html.CommentNode:
+		return
+	case html.TextNode:
+		// Collapse text-node whitespace (including source newlines) to single
+		// spaces; only block elements and <br> produce actual line breaks.
+		b.WriteString(spacify(n.Data))
+		return
+	case html.ElementNode:
+		if skipElements[n.DataAtom] {
+			return
+		}
+		if n.DataAtom == atom.A {
+			writeAnchor(n, b)
+			return
+		}
+		if blockElements[n.DataAtom] {
+			b.WriteByte('\n')
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		walk(c, b)
+	}
+	if n.Type == html.ElementNode && blockElements[n.DataAtom] {
+		b.WriteByte('\n')
+	}
+}
+
+// writeAnchor renders <a> as "text (href)" when the href is an http(s) URL and
+// differs from the link text. A link with no text but an http href emits the
+// bare URL so it is not lost (common for image buttons).
+func writeAnchor(n *html.Node, b *strings.Builder) {
+	var inner strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		walk(c, &inner)
+	}
+	text := collapseInline(inner.String())
+
+	href := ""
+	for _, a := range n.Attr {
+		if a.Key == "href" {
+			href = strings.TrimSpace(a.Val)
+			break
+		}
+	}
+	lowerHref := strings.ToLower(href)
+	isHTTP := strings.HasPrefix(lowerHref, "http://") || strings.HasPrefix(lowerHref, "https://")
+
+	b.WriteByte(' ')
+	switch {
+	case text == "" && isHTTP:
+		b.WriteString(href)
+	case isHTTP && href != text:
+		b.WriteString(text)
+		b.WriteString(" (")
+		b.WriteString(href)
+		b.WriteByte(')')
+	default:
+		b.WriteString(text)
+	}
+	b.WriteByte(' ')
+}
+
+// spacify collapses whitespace runs in a text node to single spaces. A single
+// leading or trailing space is preserved when the source had one, so words in
+// adjacent inline elements stay separated across text-node boundaries. Any
+// leading space that ends up at the very start of a line is removed later by
+// collapse.
+func spacify(s string) string {
+	joined := strings.Join(strings.Fields(s), " ")
+	if joined == "" {
+		if s == "" {
+			return ""
+		}
+		// A whitespace-only text node (common between inline tags in source HTML)
+		// must still separate its neighbors, or "<b>50%</b> <i>off</i>" merges to
+		// "50%off". collapse() trims any space that lands at a line edge.
+		return " "
+	}
+	if strings.TrimLeftFunc(s, unicode.IsSpace) != s {
+		joined = " " + joined
+	}
+	if strings.TrimRightFunc(s, unicode.IsSpace) != s {
+		joined += " "
+	}
+	return joined
+}
+
+// collapseInline collapses all whitespace (including newlines) to single spaces.
+func collapseInline(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// collapse trims each line, collapses intra-line whitespace runs, and drops empty
+// lines, yielding one logical block per line.
+func collapse(s string) string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if j := strings.Join(strings.Fields(line), " "); j != "" {
+			out = append(out, j)
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/apps/api/internal/htmltext/htmltext_test.go
+++ b/apps/api/internal/htmltext/htmltext_test.go
@@ -1,0 +1,37 @@
+package htmltext
+
+import "testing"
+
+func TestConvert(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"anchor with text", `<a href="https://x.com/deal">Buy</a>`, "Buy (https://x.com/deal)"},
+		{"anchor equals href", `<a href="https://x.com">https://x.com</a>`, "https://x.com"},
+		{"anchor image only", `<a href="https://x.com/img"><img src="a.png"></a>`, "https://x.com/img"},
+		{"anchor mailto keeps text only", `<a href="mailto:a@b.com">Email us</a>`, "Email us"},
+		{"paragraphs break", `<p>One</p><p>Two</p>`, "One\nTwo"},
+		{"br breaks", `a<br>b`, "a\nb"},
+		{"heading then block", `<h1>Title</h1><div>Body</div>`, "Title\nBody"},
+		{"whitespace collapses", "<p>  lots   of\n\n  space  </p>", "lots of space"},
+		{"style and script dropped", `<style>.x{color:red}</style><script>bad()</script><p>Keep</p>`, "Keep"},
+		{"inline elements flow", `<p>Hello <b>bold</b> world</p>`, "Hello bold world"},
+		{"whitespace-only node separates", `<strong>50%</strong> <em>off</em>`, "50% off"},
+		{"newline between inline tags", "<b>Big</b>\n<b>Sale</b>", "Big Sale"},
+		{"uppercase scheme kept", `<a href="HTTPS://x.com/deal">Buy</a>`, "Buy (HTTPS://x.com/deal)"},
+		{"list items break", `<ul><li>First</li><li>Second</li></ul>`, "First\nSecond"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Convert(tt.in)
+			if err != nil {
+				t.Fatalf("Convert: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Convert(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/api/internal/mailparse/mailparse.go
+++ b/apps/api/internal/mailparse/mailparse.go
@@ -1,0 +1,222 @@
+// Package mailparse turns raw RFC 822 MIME (as delivered by the Cloudflare Email
+// Worker) into a normalized Email ready for LLM extraction. It is framework-free
+// and uses only the standard library plus golang.org/x/text for charset decoding.
+package mailparse
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"mime/quotedprintable"
+	"net/mail"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/htmlindex"
+
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/htmltext"
+)
+
+const (
+	// maxBodyBytes caps the stored/returned normalized text.
+	maxBodyBytes = 64 * 1024
+	// stubThreshold: a text/plain part shorter than this, when an HTML part also
+	// exists, is treated as a "view in browser" stub and the HTML is preferred.
+	stubThreshold = 200
+	truncSentinel = "\n[truncated]"
+)
+
+// Email is the normalized result of parsing a raw message.
+type Email struct {
+	MessageID string
+	From      string
+	To        string
+	Subject   string
+	SentAt    *time.Time
+	Text      string
+}
+
+// Parse parses raw MIME bytes. Headers are decoded (RFC 2047 encoded-words are
+// resolved); the body is reduced to a single normalized text part, preferring
+// text/plain but falling back to text/html (converted to text). A missing
+// Message-ID falls back to "sha256:<hex of raw>". Attachments are ignored.
+func Parse(raw []byte) (Email, error) {
+	msg, err := mail.ReadMessage(bytes.NewReader(raw))
+	if err != nil {
+		return Email{}, fmt.Errorf("read message: %w", err)
+	}
+
+	dec := &mime.WordDecoder{
+		// Decode encoded-words in any charset x/text knows, matching the body path
+		// (the default decoder only handles utf-8/iso-8859-1/us-ascii).
+		CharsetReader: func(charset string, input io.Reader) (io.Reader, error) {
+			enc, err := htmlindex.Get(charset)
+			if err != nil {
+				return nil, err
+			}
+			return enc.NewDecoder().Reader(input), nil
+		},
+	}
+	decodeHeader := func(key string) string {
+		v, err := dec.DecodeHeader(msg.Header.Get(key))
+		if err != nil {
+			return msg.Header.Get(key)
+		}
+		return v
+	}
+
+	e := Email{
+		MessageID: strings.TrimSpace(msg.Header.Get("Message-Id")),
+		From:      decodeHeader("From"),
+		To:        decodeHeader("To"),
+		Subject:   decodeHeader("Subject"),
+	}
+	if e.MessageID == "" {
+		sum := sha256.Sum256(raw)
+		e.MessageID = "sha256:" + hex.EncodeToString(sum[:])
+	}
+	if d, err := msg.Header.Date(); err == nil {
+		du := d.UTC()
+		e.SentAt = &du
+	}
+
+	contentType := msg.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "text/plain"
+	}
+	var p parts
+	if err := p.walk(msg.Body, contentType,
+		msg.Header.Get("Content-Transfer-Encoding"),
+		msg.Header.Get("Content-Disposition")); err != nil {
+		return Email{}, fmt.Errorf("walk body: %w", err)
+	}
+	// Guarantee valid UTF-8 even when a body mislabels its charset (e.g. declares
+	// utf-8 but carries Latin-1) — a common sender misconfiguration.
+	e.Text = truncate(strings.ToValidUTF8(p.choose(), ""))
+	return e, nil
+}
+
+// parts accumulates the first text/plain and text/html leaves encountered.
+type parts struct {
+	plain string
+	html  string
+}
+
+func (p *parts) walk(r io.Reader, contentType, cte, disposition string) error {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType, params = "text/plain", map[string]string{}
+	}
+
+	if strings.HasPrefix(mediaType, "multipart/") {
+		boundary := params["boundary"]
+		if boundary == "" {
+			return nil
+		}
+		mr := multipart.NewReader(r, boundary)
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			perr := p.walk(part,
+				part.Header.Get("Content-Type"),
+				part.Header.Get("Content-Transfer-Encoding"),
+				part.Header.Get("Content-Disposition"))
+			part.Close()
+			if perr != nil {
+				return perr
+			}
+		}
+	}
+
+	// Leaf part. Skip attachments and any non-text content (images, PDFs) without
+	// reading their bodies into memory.
+	if d, _, _ := mime.ParseMediaType(disposition); strings.EqualFold(d, "attachment") {
+		return nil
+	}
+	if !strings.HasPrefix(mediaType, "text/") {
+		return nil
+	}
+
+	body, err := decodeBody(r, cte)
+	if err != nil {
+		return err
+	}
+	text := transcode(body, params["charset"])
+	switch {
+	case strings.HasPrefix(mediaType, "text/plain") && p.plain == "":
+		p.plain = text
+	case strings.HasPrefix(mediaType, "text/html") && p.html == "":
+		p.html = text
+	}
+	return nil
+}
+
+// choose returns the best text: the plain part, unless it is a short stub and an
+// HTML part exists, in which case the HTML is converted to text.
+func (p *parts) choose() string {
+	plain := strings.TrimSpace(p.plain)
+	if plain != "" && !(len(plain) < stubThreshold && p.html != "") {
+		return plain
+	}
+	if p.html != "" {
+		if txt, err := htmltext.Convert(p.html); err == nil && strings.TrimSpace(txt) != "" {
+			return txt
+		}
+	}
+	return plain
+}
+
+func decodeBody(r io.Reader, cte string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(cte)) {
+	case "base64":
+		b, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, r))
+		return string(b), err
+	case "quoted-printable":
+		b, err := io.ReadAll(quotedprintable.NewReader(r))
+		return string(b), err
+	default:
+		b, err := io.ReadAll(r)
+		return string(b), err
+	}
+}
+
+// transcode converts a body to UTF-8 based on its declared charset. Unknown or
+// already-UTF-8 charsets pass through unchanged.
+func transcode(body, charset string) string {
+	switch strings.ToLower(strings.TrimSpace(charset)) {
+	case "", "utf-8", "utf8", "us-ascii", "ascii":
+		return body
+	}
+	enc, err := htmlindex.Get(charset)
+	if err != nil {
+		return body
+	}
+	out, err := enc.NewDecoder().String(body)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// truncate caps s at maxBodyBytes on a UTF-8 rune boundary, appending a sentinel.
+func truncate(s string) string {
+	if len(s) <= maxBodyBytes {
+		return s
+	}
+	cut := maxBodyBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + truncSentinel
+}

--- a/apps/api/internal/mailparse/mailparse_test.go
+++ b/apps/api/internal/mailparse/mailparse_test.go
@@ -1,0 +1,205 @@
+package mailparse
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return raw
+}
+
+func TestParseFixtures(t *testing.T) {
+	tests := []struct {
+		file            string
+		messageID       string // exact; "" means expect a "sha256:" fallback
+		subject         string
+		fromContains    string
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			file:         "multipart_alternative.eml",
+			messageID:    "<week1@humblebundle.com>",
+			subject:      "This Week's Deals", // RFC 2047 encoded-word decoded
+			fromContains: "deals@humblebundle.com",
+			wantContains: []string{"Humble Programming Bundle", "Pay what you want", "https://humblebundle.com/books/programming"},
+		},
+		{
+			file:            "html_only.eml",
+			messageID:       "<html-only@indiedeals.io>",
+			subject:         "HTML Only Newsletter",
+			fromContains:    "news@indiedeals.io",
+			wantContains:    []string{"GameDev Asset Sale", "50% off", "Browse assets (https://indiedeals.io/gamedev)"},
+			wantNotContains: []string{"color:red", "trackOpen", "ignore me"},
+		},
+		{
+			file:         "quoted_printable.eml",
+			messageID:    "<qp@bookstore.example>",
+			subject:      "QP Encoded",
+			fromContains: "deals@bookstore.example",
+			wantContains: []string{"Big Sale — 50% off", "https://bookstore.example/sale", "the full list"},
+		},
+		{
+			file:         "base64_html.eml",
+			messageID:    "<base64@courses.example>",
+			subject:      "Base64 HTML",
+			fromContains: "deals@courses.example",
+			wantContains: []string{"Course Bootcamp Sale", "Half price bootcamp", "Enroll now (https://courses.example/deal)"},
+		},
+		{
+			file:         "latin1.eml",
+			messageID:    "<latin1@cafe.example>",
+			subject:      "Latin1 Charset",
+			fromContains: "deals@cafe.example",
+			wantContains: []string{"Café résumé workshop", "30% off", "https://cafe.example/deal"},
+		},
+		{
+			file:         "no_message_id.eml",
+			messageID:    "", // sha256 fallback
+			subject:      "No Message ID Header",
+			fromContains: "hello@nomessageid.example",
+			wantContains: []string{"sha256 fallback"},
+		},
+		{
+			file:            "stub_plain.eml",
+			messageID:       "<stub@courses.example>",
+			subject:         "Stub Plain Part",
+			fromContains:    "deals@courses.example",
+			wantContains:    []string{"Python Mega Course Sale", "Lifetime access", "Enroll now (https://courses.example/python)"},
+			wantNotContains: []string{"View this email in your browser"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			e, err := Parse(loadFixture(t, tt.file))
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if tt.messageID == "" {
+				if !strings.HasPrefix(e.MessageID, "sha256:") {
+					t.Errorf("MessageID = %q, want sha256: fallback", e.MessageID)
+				}
+			} else if e.MessageID != tt.messageID {
+				t.Errorf("MessageID = %q, want %q", e.MessageID, tt.messageID)
+			}
+			if e.Subject != tt.subject {
+				t.Errorf("Subject = %q, want %q", e.Subject, tt.subject)
+			}
+			if !strings.Contains(e.From, tt.fromContains) {
+				t.Errorf("From = %q, want to contain %q", e.From, tt.fromContains)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(e.Text, want) {
+					t.Errorf("Text missing %q\n---\n%s\n---", want, e.Text)
+				}
+			}
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(e.Text, notWant) {
+					t.Errorf("Text should not contain %q\n---\n%s\n---", notWant, e.Text)
+				}
+			}
+			if !utf8.ValidString(e.Text) {
+				t.Errorf("Text is not valid UTF-8")
+			}
+		})
+	}
+}
+
+func TestParseSentAt(t *testing.T) {
+	e, err := Parse(loadFixture(t, "multipart_alternative.eml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if e.SentAt == nil {
+		t.Fatal("SentAt is nil, want parsed Date")
+	}
+	want := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	if !e.SentAt.Equal(want) {
+		t.Errorf("SentAt = %v, want %v", e.SentAt, want)
+	}
+}
+
+func TestParseMislabeledUTF8(t *testing.T) {
+	// Declares utf-8 but the body byte 0xE9 ("é" in Latin-1) is invalid UTF-8.
+	raw := "From: x@example.com\nSubject: Mislabeled\nMessage-Id: <mis@x>\n" +
+		"Date: Mon, 20 Jul 2026 10:00:00 +0000\n" +
+		"Content-Type: text/plain; charset=utf-8\n\n" +
+		"Caf\xe9 deal 30% off"
+
+	e, err := Parse([]byte(raw))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !utf8.ValidString(e.Text) {
+		t.Errorf("Text is not valid UTF-8: %q", e.Text)
+	}
+	if !strings.Contains(e.Text, "deal 30% off") {
+		t.Errorf("Text = %q, want to contain the ASCII remainder", e.Text)
+	}
+}
+
+func TestParseNonLatin1EncodedWordSubject(t *testing.T) {
+	// windows-1252 encoded-word; 0xE9 = "é". Requires the CharsetReader wiring.
+	raw := "From: x@example.com\nSubject: =?windows-1252?Q?Caf=E9_Sale?=\n" +
+		"Message-Id: <w1252@x>\nDate: Mon, 20 Jul 2026 10:00:00 +0000\n" +
+		"Content-Type: text/plain; charset=utf-8\n\nbody"
+
+	e, err := Parse([]byte(raw))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if e.Subject != "Café Sale" {
+		t.Errorf("Subject = %q, want %q", e.Subject, "Café Sale")
+	}
+}
+
+func TestParseTruncatesLongBody(t *testing.T) {
+	body := strings.Repeat("a", 70000)
+	raw := "From: x@example.com\nSubject: Big\nMessage-Id: <big@x>\n" +
+		"Date: Mon, 20 Jul 2026 10:00:00 +0000\n" +
+		"Content-Type: text/plain; charset=utf-8\n\n" + body
+
+	e, err := Parse([]byte(raw))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(e.Text) >= len(body) {
+		t.Errorf("Text not truncated: len=%d", len(e.Text))
+	}
+	if !strings.HasSuffix(e.Text, truncSentinel) {
+		t.Errorf("Text missing truncation sentinel")
+	}
+	if len(e.Text) > maxBodyBytes+len(truncSentinel) {
+		t.Errorf("Text length %d exceeds cap", len(e.Text))
+	}
+}
+
+func TestParseTruncatesOnRuneBoundary(t *testing.T) {
+	// Multibyte runes so the byte cap is likely to land mid-rune.
+	body := strings.Repeat("é", 40000) // 80000 bytes
+	raw := "From: x@example.com\nSubject: Runes\nMessage-Id: <r@x>\n" +
+		"Date: Mon, 20 Jul 2026 10:00:00 +0000\n" +
+		"Content-Type: text/plain; charset=utf-8\n\n" + body
+
+	e, err := Parse([]byte(raw))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !utf8.ValidString(e.Text) {
+		t.Error("truncated text is not valid UTF-8 (cut mid-rune)")
+	}
+	if !strings.HasSuffix(e.Text, truncSentinel) {
+		t.Error("Text missing truncation sentinel")
+	}
+}

--- a/apps/api/internal/mailparse/testdata/base64_html.eml
+++ b/apps/api/internal/mailparse/testdata/base64_html.eml
@@ -1,0 +1,10 @@
+From: Course Deals <deals@courses.example>
+To: me@example.com
+Subject: Base64 HTML
+Message-Id: <base64@courses.example>
+Date: Mon, 20 Jul 2026 15:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/html; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+PGh0bWw+PGJvZHk+PGgzPkNvdXJzZSBCb290Y2FtcCBTYWxlPC9oMz48cD5IYWxmIHByaWNlIGJvb3RjYW1wIHRoaXMgd2Vlay48L3A+PGEgaHJlZj0iaHR0cHM6Ly9jb3Vyc2VzLmV4YW1wbGUvZGVhbCI+RW5yb2xsIG5vdzwvYT48L2JvZHk+PC9odG1sPg==

--- a/apps/api/internal/mailparse/testdata/html_only.eml
+++ b/apps/api/internal/mailparse/testdata/html_only.eml
@@ -1,0 +1,9 @@
+From: Indie Deals <news@indiedeals.io>
+To: me@example.com
+Subject: HTML Only Newsletter
+Message-Id: <html-only@indiedeals.io>
+Date: Mon, 20 Jul 2026 11:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/html; charset="utf-8"
+
+<html><head><style>.promo{color:red}</style><title>ignore me</title></head><body><h2>GameDev Asset Sale</h2><p>50% off this week only.</p><a href="https://indiedeals.io/gamedev">Browse assets</a><script>trackOpen()</script></body></html>

--- a/apps/api/internal/mailparse/testdata/latin1.eml
+++ b/apps/api/internal/mailparse/testdata/latin1.eml
@@ -1,0 +1,9 @@
+From: Cafe News <deals@cafe.example>
+To: me@example.com
+Subject: Latin1 Charset
+Message-Id: <latin1@cafe.example>
+Date: Mon, 20 Jul 2026 16:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset="iso-8859-1"
+
+Café résumé workshop 30% off. Details: https://cafe.example/deal

--- a/apps/api/internal/mailparse/testdata/multipart_alternative.eml
+++ b/apps/api/internal/mailparse/testdata/multipart_alternative.eml
@@ -1,0 +1,20 @@
+From: Humble Bundle <deals@humblebundle.com>
+To: me@example.com
+Subject: =?utf-8?q?This_Week=27s_Deals?=
+Message-Id: <week1@humblebundle.com>
+Date: Mon, 20 Jul 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="BOUNDARY1"
+
+--BOUNDARY1
+Content-Type: text/plain; charset="utf-8"
+
+Humble Programming Bundle
+Pay what you want for 15 programming ebooks.
+https://humblebundle.com/books/programming
+
+--BOUNDARY1
+Content-Type: text/html; charset="utf-8"
+
+<html><body><h1>Humble Programming Bundle</h1><p>Pay what you want for 15 programming ebooks.</p><a href="https://humblebundle.com/books/programming">Get the bundle</a></body></html>
+--BOUNDARY1--

--- a/apps/api/internal/mailparse/testdata/no_message_id.eml
+++ b/apps/api/internal/mailparse/testdata/no_message_id.eml
@@ -1,0 +1,8 @@
+From: Random Sender <hello@nomessageid.example>
+To: me@example.com
+Subject: No Message ID Header
+Date: Mon, 20 Jul 2026 13:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+This email has no Message-Id header, so a sha256 fallback is used.

--- a/apps/api/internal/mailparse/testdata/quoted_printable.eml
+++ b/apps/api/internal/mailparse/testdata/quoted_printable.eml
@@ -1,0 +1,11 @@
+From: Book Store <deals@bookstore.example>
+To: me@example.com
+Subject: QP Encoded
+Message-Id: <qp@bookstore.example>
+Date: Mon, 20 Jul 2026 12:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+Big Sale =E2=80=94 50=25 off all programming titles.
+Visit https://bookstore.example/sale for the=20full list.

--- a/apps/api/internal/mailparse/testdata/stub_plain.eml
+++ b/apps/api/internal/mailparse/testdata/stub_plain.eml
@@ -1,0 +1,18 @@
+From: Course Platform <deals@courses.example>
+To: me@example.com
+Subject: Stub Plain Part
+Message-Id: <stub@courses.example>
+Date: Mon, 20 Jul 2026 14:00:00 +0000
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="BOUNDARY2"
+
+--BOUNDARY2
+Content-Type: text/plain; charset="utf-8"
+
+View this email in your browser.
+
+--BOUNDARY2
+Content-Type: text/html; charset="utf-8"
+
+<html><body><h1>Python Mega Course Sale</h1><p>Lifetime access for 12 dollars.</p><a href="https://courses.example/python">Enroll now</a></body></html>
+--BOUNDARY2--


### PR DESCRIPTION
Implements #263.

Ports `internal/mailparse` (MIME → normalized `Email`) and its `internal/htmltext` helper (HTML → text) from the email_processor reference into `apps/api/internal/{mailparse,htmltext}`, verbatim except rewriting mailparse's `htmltext` import to the module path. Includes the 7 `.eml` fixtures and their tests.

## Testing
- `go test -race ./internal/mailparse/... ./internal/htmltext/...` — pass (fixtures, sent-at, mislabeled-UTF8, non-Latin1 encoded-word subject, rune-boundary truncation, htmltext conversions).
- `go vet ./...` clean; `CGO_ENABLED=0` build OK; gofmt clean.
- `go mod tidy` promoted `golang.org/x/text` to direct (htmlindex).