### PR TITLE
Wire the email-ingest pipeline into the server

### DIFF
--- a/apps/api/api_me_test.go
+++ b/apps/api/api_me_test.go
@@ -101,7 +101,7 @@ func startedVerifierFor(t *testing.T, f *meFixture) *auth.Verifier {
 func TestApiMeReturnsClaims(t *testing.T) {
 	f := newMeFixture(t)
 	v := startedVerifierFor(t, f)
-	e := newServer(fixtureDir(t), v)
+	e := newServer(fixtureDir(t), v, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	req.Header.Set(echo.HeaderAuthorization, "Bearer "+f.sign(t))
@@ -130,7 +130,7 @@ func TestApiMeReturnsClaims(t *testing.T) {
 func TestApiMeRejectsMissingToken(t *testing.T) {
 	f := newMeFixture(t)
 	v := startedVerifierFor(t, f)
-	e := newServer(fixtureDir(t), v)
+	e := newServer(fixtureDir(t), v, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	rec := httptest.NewRecorder()
@@ -144,7 +144,7 @@ func TestApiMeRejectsMissingToken(t *testing.T) {
 func TestApiMeHeadHonorsAuth(t *testing.T) {
 	f := newMeFixture(t)
 	v := startedVerifierFor(t, f)
-	e := newServer(fixtureDir(t), v)
+	e := newServer(fixtureDir(t), v, nil)
 
 	cases := []struct {
 		name       string
@@ -174,7 +174,7 @@ func TestApiMeIsDisabledWithoutVerifier(t *testing.T) {
 	// /api/me without a verifier should fall through to the /api/* JSON 404,
 	// not return 401 — that's the smoke-test ergonomics we lean on for
 	// runs without WorkOS env config.
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	rec := httptest.NewRecorder()

--- a/apps/api/internal/digest/poster.go
+++ b/apps/api/internal/digest/poster.go
@@ -3,9 +3,11 @@ package digest
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -37,6 +39,13 @@ func (p *HTTPPoster) Post(ctx context.Context, payload []byte) error {
 
 	resp, err := p.Client.Do(req)
 	if err != nil {
+		// http.Client.Do wraps failures as *url.Error, whose Error() embeds the
+		// full request URL — but the Slack webhook URL is a secret (a bearer
+		// credential). Report only the underlying cause so it never reaches logs.
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			return fmt.Errorf("post to slack: %w", urlErr.Err)
+		}
 		return fmt.Errorf("post to slack: %w", err)
 	}
 	defer resp.Body.Close()

--- a/apps/api/internal/digest/poster_test.go
+++ b/apps/api/internal/digest/poster_test.go
@@ -48,9 +48,14 @@ func TestHTTPPosterNon2xx(t *testing.T) {
 }
 
 func TestHTTPPosterNetworkError(t *testing.T) {
-	// Nothing listens on port 1; Post must return an error, not hang.
-	err := NewHTTPPoster("http://127.0.0.1:1").Post(context.Background(), []byte(`{}`))
+	// Nothing listens on port 1; Post must return an error, not hang. The webhook
+	// URL is a secret (a bearer credential), so the error must NOT leak it.
+	const secretURL = "http://127.0.0.1:1/services/T00/B00/SUPERSECRETTOKEN"
+	err := NewHTTPPoster(secretURL).Post(context.Background(), []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected network error")
+	}
+	if strings.Contains(err.Error(), "SUPERSECRETTOKEN") || strings.Contains(err.Error(), "/services/") {
+		t.Errorf("error leaks the webhook URL: %v", err)
 	}
 }

--- a/apps/api/internal/ingest/config.go
+++ b/apps/api/internal/ingest/config.go
@@ -1,0 +1,91 @@
+// Package ingest wires the email-deals pipeline into the API server: config
+// loading, the bearer-token middleware, and the HTTP handlers that turn a
+// forwarded email into stored, extracted, and digested deals. All domain logic
+// lives in the framework-free internal packages (mailparse, store, extract,
+// digest); this package is the only email-pipeline code that touches Echo.
+package ingest
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config holds the email-ingest pipeline's runtime configuration, loaded from
+// the environment. Durations (DigestInterval, RepostAfter) use Go's
+// time.ParseDuration syntax — hours/minutes/seconds only, no "d" unit; express
+// 45 days as "1080h". PORT and the WorkOS vars are read elsewhere (main.go).
+type Config struct {
+	DatabaseURL     string
+	IngestToken     string
+	GeminiAPIKey    string
+	GeminiModel     string
+	SlackWebhookURL string
+	DigestInterval  time.Duration
+	RepostAfter     time.Duration
+}
+
+// Load builds a Config from getenv (normally os.Getenv). GeminiModel and the two
+// durations get defaults; the rest default to empty. It errors only on a
+// malformed value (an unparseable or non-positive duration); a missing value is
+// not an error, so the server still boots static-only when the pipeline is not
+// configured. The Slack webhook comes from SLACK_WEBHOOK_FOR_DEALS_CHANNEL.
+func Load(getenv func(string) string) (Config, error) {
+	cfg := Config{
+		GeminiModel:    "gemini-2.5-flash-lite",
+		DigestInterval: 24 * time.Hour,
+		RepostAfter:    45 * 24 * time.Hour,
+	}
+	cfg.DatabaseURL = getenv("DATABASE_URL")
+	cfg.IngestToken = getenv("INGEST_TOKEN")
+	cfg.GeminiAPIKey = getenv("GEMINI_API_KEY")
+	if v := getenv("GEMINI_MODEL"); v != "" {
+		cfg.GeminiModel = v
+	}
+	cfg.SlackWebhookURL = getenv("SLACK_WEBHOOK_FOR_DEALS_CHANNEL")
+	if v := getenv("DIGEST_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid DIGEST_INTERVAL %q: %w", v, err)
+		}
+		cfg.DigestInterval = d
+	}
+	if v := getenv("REPOST_AFTER"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid REPOST_AFTER %q: %w", v, err)
+		}
+		cfg.RepostAfter = d
+	}
+	// Both durations feed time-window math that misbehaves on non-positive
+	// values; reject them at load time.
+	if cfg.DigestInterval <= 0 {
+		return Config{}, fmt.Errorf("DIGEST_INTERVAL must be positive, got %v", cfg.DigestInterval)
+	}
+	if cfg.RepostAfter <= 0 {
+		return Config{}, fmt.Errorf("REPOST_AFTER must be positive, got %v", cfg.RepostAfter)
+	}
+	return cfg, nil
+}
+
+// Enabled reports whether the pipeline has the minimum configuration to run: a
+// database to store into and a shared token to authenticate the Worker. When it
+// is false the server runs static-only and the /api/ingest routes are not
+// registered.
+func (c Config) Enabled() bool {
+	return c.DatabaseURL != "" && c.IngestToken != ""
+}
+
+// String redacts secret fields so a Config is safe to log with %v/%s/%+v.
+func (c Config) String() string {
+	redact := func(s string) string {
+		if s == "" {
+			return ""
+		}
+		return "***"
+	}
+	return fmt.Sprintf(
+		"ingest.Config{DatabaseURL:%s IngestToken:%s GeminiAPIKey:%s GeminiModel:%s SlackWebhookURL:%s DigestInterval:%v RepostAfter:%v}",
+		redact(c.DatabaseURL), redact(c.IngestToken), redact(c.GeminiAPIKey),
+		c.GeminiModel, redact(c.SlackWebhookURL), c.DigestInterval, c.RepostAfter,
+	)
+}

--- a/apps/api/internal/ingest/config_test.go
+++ b/apps/api/internal/ingest/config_test.go
@@ -1,0 +1,128 @@
+package ingest
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func envFrom(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestLoadDefaults(t *testing.T) {
+	cfg, err := Load(envFrom(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.GeminiModel != "gemini-2.5-flash-lite" {
+		t.Errorf("GeminiModel = %q, want gemini-2.5-flash-lite", cfg.GeminiModel)
+	}
+	if cfg.DigestInterval != 24*time.Hour {
+		t.Errorf("DigestInterval = %v, want 24h", cfg.DigestInterval)
+	}
+	if cfg.RepostAfter != 45*24*time.Hour {
+		t.Errorf("RepostAfter = %v, want 1080h", cfg.RepostAfter)
+	}
+	// No defaults for DatabaseURL or the secrets; the pipeline is disabled.
+	if cfg.DatabaseURL != "" || cfg.IngestToken != "" || cfg.GeminiAPIKey != "" || cfg.SlackWebhookURL != "" {
+		t.Errorf("expected empty DatabaseURL/secrets by default, got %+v", cfg)
+	}
+	if cfg.Enabled() {
+		t.Error("Enabled() = true with no DATABASE_URL/INGEST_TOKEN, want false")
+	}
+}
+
+func TestLoadOverrides(t *testing.T) {
+	cfg, err := Load(envFrom(map[string]string{
+		"DATABASE_URL":                    "libsql://x.turso.io?authToken=t",
+		"INGEST_TOKEN":                    "secret",
+		"GEMINI_API_KEY":                  "key",
+		"GEMINI_MODEL":                    "gemini-2.5-pro",
+		"SLACK_WEBHOOK_FOR_DEALS_CHANNEL": "https://hooks.slack.com/services/x",
+		"DIGEST_INTERVAL":                 "12h",
+		"REPOST_AFTER":                    "720h",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := Config{
+		DatabaseURL:     "libsql://x.turso.io?authToken=t",
+		IngestToken:     "secret",
+		GeminiAPIKey:    "key",
+		GeminiModel:     "gemini-2.5-pro",
+		SlackWebhookURL: "https://hooks.slack.com/services/x",
+		DigestInterval:  12 * time.Hour,
+		RepostAfter:     720 * time.Hour,
+	}
+	if cfg != want {
+		t.Errorf("Load() = %+v, want %+v", cfg, want)
+	}
+	if !cfg.Enabled() {
+		t.Error("Enabled() = false with DATABASE_URL+INGEST_TOKEN set, want true")
+	}
+}
+
+func TestEnabledRequiresBoth(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"neither", nil, false},
+		{"only db", map[string]string{"DATABASE_URL": "file:x"}, false},
+		{"only token", map[string]string{"INGEST_TOKEN": "t"}, false},
+		{"both", map[string]string{"DATABASE_URL": "file:x", "INGEST_TOKEN": "t"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := Load(envFrom(tc.env))
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Enabled() != tc.want {
+				t.Errorf("Enabled() = %v, want %v", cfg.Enabled(), tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadBadDuration(t *testing.T) {
+	for _, key := range []string{"DIGEST_INTERVAL", "REPOST_AFTER"} {
+		if _, err := Load(envFrom(map[string]string{key: "notaduration"})); err == nil {
+			t.Errorf("expected error for bad %s", key)
+		}
+	}
+}
+
+func TestLoadNonPositiveDuration(t *testing.T) {
+	for _, key := range []string{"DIGEST_INTERVAL", "REPOST_AFTER"} {
+		for _, v := range []string{"0", "-5h"} {
+			if _, err := Load(envFrom(map[string]string{key: v})); err == nil {
+				t.Errorf("expected error for %s=%q", key, v)
+			}
+		}
+	}
+}
+
+func TestConfigStringRedactsSecrets(t *testing.T) {
+	cfg, err := Load(envFrom(map[string]string{
+		"INGEST_TOKEN":                    "supersecrettoken",
+		"GEMINI_API_KEY":                  "supersecretkey",
+		"SLACK_WEBHOOK_FOR_DEALS_CHANNEL": "https://hooks.slack.com/services/secret",
+		"DATABASE_URL":                    "libsql://db.turso.io?authToken=secrettoken",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s := cfg.String()
+	for _, secret := range []string{"supersecrettoken", "supersecretkey", "secrettoken", "hooks.slack.com"} {
+		if strings.Contains(s, secret) {
+			t.Errorf("String() leaked secret %q: %s", secret, s)
+		}
+	}
+	// Non-secret fields remain visible.
+	if !strings.Contains(s, "gemini-2.5-flash-lite") {
+		t.Errorf("String() dropped GeminiModel: %s", s)
+	}
+}

--- a/apps/api/internal/ingest/ingest.go
+++ b/apps/api/internal/ingest/ingest.go
@@ -1,0 +1,168 @@
+package ingest
+
+import (
+	"crypto/subtle"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/digest"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/extract"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/mailparse"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
+)
+
+// defaultMaxIngestBytes caps the raw email body accepted at /api/ingest.
+// Cloudflare Email Routing tops out well under this; the Worker also guards on
+// size.
+const defaultMaxIngestBytes = 25 * 1024 * 1024
+
+// Handlers holds the email-ingest pipeline dependencies and exposes the Echo
+// handlers + middleware. Construct with New and mount with Register.
+type Handlers struct {
+	cfg       Config
+	store     *store.Store
+	extractor extract.Extractor
+	poster    digest.WebhookPoster
+
+	// MaxIngestBytes bounds the /api/ingest body; overridable in tests.
+	MaxIngestBytes int64
+}
+
+// New builds the ingest Handlers over an already-open store, an extractor, and a
+// Slack poster.
+func New(cfg Config, st *store.Store, extractor extract.Extractor, poster digest.WebhookPoster) *Handlers {
+	return &Handlers{
+		cfg:            cfg,
+		store:          st,
+		extractor:      extractor,
+		poster:         poster,
+		MaxIngestBytes: defaultMaxIngestBytes,
+	}
+}
+
+// Register mounts the ingest routes on e, each behind the bearer-token
+// middleware. Both are POST, so they never collide with the GET/HEAD static
+// catch-all; mount before the /api/* JSON-404 reservation so the concrete paths
+// win over the wildcard.
+func (h *Handlers) Register(e *echo.Echo) {
+	e.POST("/api/ingest", h.Ingest, h.BearerAuth)
+	e.POST("/api/admin/digest", h.AdminDigest, h.BearerAuth)
+}
+
+// BearerAuth checks the Authorization header against the configured token using
+// a constant-time comparison. An unset token rejects everything.
+func (h *Handlers) BearerAuth(next echo.HandlerFunc) echo.HandlerFunc {
+	const prefix = "Bearer "
+	return func(c echo.Context) error {
+		hdr := c.Request().Header.Get("Authorization")
+		if !strings.HasPrefix(hdr, prefix) {
+			return echo.NewHTTPError(http.StatusUnauthorized, "missing bearer token")
+		}
+		token := strings.TrimPrefix(hdr, prefix)
+		if h.cfg.IngestToken == "" ||
+			subtle.ConstantTimeCompare([]byte(token), []byte(h.cfg.IngestToken)) != 1 {
+			return echo.NewHTTPError(http.StatusUnauthorized, "invalid token")
+		}
+		return next(c)
+	}
+}
+
+type ingestResult struct {
+	EmailID        int64 `json:"email_id"`
+	DealsExtracted int   `json:"deals_extracted"`
+	DigestPosted   bool  `json:"digest_posted"`
+	Duplicate      bool  `json:"duplicate,omitempty"`
+}
+
+// Ingest parses a raw email, stores it, extracts deals, and (best-effort) posts
+// a digest. It is idempotent: a re-POST of an already-extracted email does
+// nothing.
+func (h *Handlers) Ingest(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	raw, err := io.ReadAll(http.MaxBytesReader(c.Response(), c.Request().Body, h.MaxIngestBytes))
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			return echo.NewHTTPError(http.StatusRequestEntityTooLarge, "email too large")
+		}
+		return echo.NewHTTPError(http.StatusBadRequest, "read body")
+	}
+
+	email, err := mailparse.Parse(raw)
+	if err != nil {
+		c.Logger().Errorf("parse email: %v", err)
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid email")
+	}
+
+	stored, isNew, err := h.store.InsertEmail(ctx, store.Email{
+		MessageID: email.MessageID,
+		From:      email.From,
+		To:        email.To,
+		Subject:   email.Subject,
+		SentAt:    email.SentAt,
+		BodyText:  email.Text,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Idempotent re-POST: an already-extracted email is done. A prior
+	// extract_failed (or an interrupted attempt) falls through and retries.
+	if !isNew && stored.Status == store.StatusExtracted {
+		return c.JSON(http.StatusOK, ingestResult{EmailID: stored.ID, Duplicate: true})
+	}
+
+	deals, err := h.extractor.Extract(ctx, email)
+	if err != nil {
+		_ = h.store.SetEmailStatus(ctx, stored.ID, store.StatusExtractFailed, err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, "extract deals")
+	}
+
+	repostCutoff := h.store.Now().Add(-h.cfg.RepostAfter)
+	for _, d := range deals {
+		if err := h.store.UpsertDeal(ctx, store.Deal{
+			EmailID:     stored.ID,
+			DedupeKey:   store.DedupeKey(email.From, d.Title),
+			Source:      d.Source,
+			Title:       d.Title,
+			URL:         d.URL,
+			Price:       d.Price,
+			EndsAt:      d.EndsAt,
+			Description: d.Description,
+		}, repostCutoff); err != nil {
+			return err
+		}
+	}
+	if err := h.store.SetEmailStatus(ctx, stored.ID, store.StatusExtracted, ""); err != nil {
+		return err
+	}
+
+	// The email is safely ingested; a digest failure must not fail the request
+	// (the deals are queued and a later ingest retries).
+	posted, derr := digest.Run(ctx, h.store, h.poster, h.cfg.DigestInterval, store.DefaultStaleWindow, false)
+	if derr != nil {
+		c.Logger().Errorf("digest run: %v", derr)
+	}
+
+	return c.JSON(http.StatusOK, ingestResult{
+		EmailID:        stored.ID,
+		DealsExtracted: len(deals),
+		DigestPosted:   posted,
+	})
+}
+
+// AdminDigest forces a digest post (skips the interval check, still race-safe).
+func (h *Handlers) AdminDigest(c echo.Context) error {
+	posted, err := digest.Run(c.Request().Context(), h.store, h.poster, h.cfg.DigestInterval, store.DefaultStaleWindow, true)
+	if err != nil {
+		// Do not echo err: it can contain the Slack webhook URL (a secret).
+		c.Logger().Errorf("admin digest: %v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "digest failed")
+	}
+	return c.JSON(http.StatusOK, map[string]bool{"posted": posted})
+}

--- a/apps/api/internal/ingest/ingest_test.go
+++ b/apps/api/internal/ingest/ingest_test.go
@@ -1,0 +1,316 @@
+package ingest_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/db"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/extract"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/ingest"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/mailparse"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
+)
+
+const token = "secret-token"
+
+type spyExtractor struct {
+	calls int32
+	mu    sync.Mutex
+	deals []extract.Deal
+	err   error
+}
+
+func (s *spyExtractor) Extract(_ context.Context, _ mailparse.Email) ([]extract.Deal, error) {
+	atomic.AddInt32(&s.calls, 1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.deals, s.err
+}
+
+func (s *spyExtractor) set(deals []extract.Deal, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deals, s.err = deals, err
+}
+
+type fakePoster struct {
+	mu  sync.Mutex
+	n   int
+	err error
+}
+
+func (f *fakePoster) Post(_ context.Context, _ []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.n++
+	return nil
+}
+
+func (f *fakePoster) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.n
+}
+
+type env struct {
+	e      *echo.Echo
+	h      *ingest.Handlers
+	st     *store.Store
+	ex     *spyExtractor
+	poster *fakePoster
+}
+
+func setup(t *testing.T) *env {
+	t.Helper()
+	d, err := db.Open("file:" + filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	if err := db.Migrate(context.Background(), d); err != nil {
+		t.Fatalf("db.Migrate: %v", err)
+	}
+	st := store.New(d)
+
+	ex := &spyExtractor{deals: []extract.Deal{
+		{Source: "Humble", Title: "Bundle A", URL: "https://h/a"},
+		{Source: "Humble", Title: "Bundle B"},
+	}}
+	poster := &fakePoster{}
+	cfg := ingest.Config{IngestToken: token, DigestInterval: 24 * time.Hour, RepostAfter: 45 * 24 * time.Hour}
+	h := ingest.New(cfg, st, ex, poster)
+
+	e := echo.New()
+	e.HideBanner = true
+	h.Register(e)
+	return &env{e: e, h: h, st: st, ex: ex, poster: poster}
+}
+
+func rawEmail(messageID, subject, body string) []byte {
+	return []byte("From: Humble Bundle <deals@humblebundle.com>\r\n" +
+		"To: me@example.com\r\nSubject: " + subject + "\r\nMessage-Id: " + messageID + "\r\n" +
+		"Date: Mon, 20 Jul 2026 10:00:00 +0000\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n" + body)
+}
+
+func (e *env) post(t *testing.T, path, authToken string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	req.Header.Set("Content-Type", "message/rfc822")
+	rec := httptest.NewRecorder()
+	e.e.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeResult(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode body %q: %v", rec.Body.String(), err)
+	}
+	return m
+}
+
+func TestIngestHappyPath(t *testing.T) {
+	e := setup(t)
+	rec := e.post(t, "/api/ingest", token, rawEmail("<a@x>", "Deals", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+	res := decodeResult(t, rec)
+	if res["deals_extracted"].(float64) != 2 {
+		t.Errorf("deals_extracted = %v, want 2", res["deals_extracted"])
+	}
+	if res["digest_posted"] != true {
+		t.Errorf("digest_posted = %v, want true", res["digest_posted"])
+	}
+	if got := atomic.LoadInt32(&e.ex.calls); got != 1 {
+		t.Errorf("extractor calls = %d, want 1", got)
+	}
+	if e.poster.count() != 1 {
+		t.Errorf("poster count = %d, want 1", e.poster.count())
+	}
+	got, err := e.st.GetEmailByMessageID(context.Background(), "<a@x>")
+	if err != nil {
+		t.Fatalf("GetEmailByMessageID: %v", err)
+	}
+	if got.Status != store.StatusExtracted {
+		t.Errorf("email status = %q, want extracted", got.Status)
+	}
+}
+
+func TestIngestDuplicateSkipsExtraction(t *testing.T) {
+	e := setup(t)
+	if rec := e.post(t, "/api/ingest", token, rawEmail("<dup@x>", "Deals", "body")); rec.Code != 200 {
+		t.Fatalf("first: %d", rec.Code)
+	}
+	rec := e.post(t, "/api/ingest", token, rawEmail("<dup@x>", "Deals", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second status = %d", rec.Code)
+	}
+	if res := decodeResult(t, rec); res["duplicate"] != true {
+		t.Errorf("duplicate = %v, want true", res["duplicate"])
+	}
+	if got := atomic.LoadInt32(&e.ex.calls); got != 1 {
+		t.Errorf("extractor called %d times, want 1 (no re-extract)", got)
+	}
+}
+
+func TestIngestAuth(t *testing.T) {
+	e := setup(t)
+	if rec := e.post(t, "/api/ingest", "", rawEmail("<n@x>", "s", "b")); rec.Code != http.StatusUnauthorized {
+		t.Errorf("no token: status = %d, want 401", rec.Code)
+	}
+	if rec := e.post(t, "/api/ingest", "wrong", rawEmail("<n@x>", "s", "b")); rec.Code != http.StatusUnauthorized {
+		t.Errorf("bad token: status = %d, want 401", rec.Code)
+	}
+	if got := atomic.LoadInt32(&e.ex.calls); got != 0 {
+		t.Errorf("extractor should not run for unauthorized requests, got %d calls", got)
+	}
+}
+
+func TestIngestOversize(t *testing.T) {
+	e := setup(t)
+	e.h.MaxIngestBytes = 64
+	rec := e.post(t, "/api/ingest", token, rawEmail("<big@x>", "s", strings.Repeat("x", 500)))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", rec.Code)
+	}
+	if got := atomic.LoadInt32(&e.ex.calls); got != 0 {
+		t.Errorf("extractor should not run for oversize body, got %d calls", got)
+	}
+}
+
+func TestIngestMalformedEmail(t *testing.T) {
+	e := setup(t)
+	// A line without a colon is an invalid header; mail.ReadMessage rejects it.
+	rec := e.post(t, "/api/ingest", token, []byte("this is not a valid email"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	if got := atomic.LoadInt32(&e.ex.calls); got != 0 {
+		t.Errorf("extractor should not run for malformed email, got %d calls", got)
+	}
+}
+
+func TestIngestDigestFailureDoesNotFailIngest(t *testing.T) {
+	e := setup(t)
+	e.poster.err = errors.New("slack down") // set before the synchronous request; no concurrency
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<d@x>", "s", "b"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, ingest must succeed even if the digest post fails", rec.Code)
+	}
+	if res := decodeResult(t, rec); res["digest_posted"] != false {
+		t.Errorf("digest_posted = %v, want false", res["digest_posted"])
+	}
+	got, _ := e.st.GetEmailByMessageID(context.Background(), "<d@x>")
+	if got.Status != store.StatusExtracted {
+		t.Errorf("email status = %q, want extracted", got.Status)
+	}
+	// Deals stay queued for a later attempt.
+	if left, _ := e.st.UnpostedDeals(context.Background(), 0); len(left) != 2 {
+		t.Errorf("deals should stay queued, got %d unposted", len(left))
+	}
+}
+
+func TestIngestExtractorErrorThenRetry(t *testing.T) {
+	e := setup(t)
+	e.ex.set(nil, errors.New("gemini down"))
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<r@x>", "s", "b"))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	got, _ := e.st.GetEmailByMessageID(context.Background(), "<r@x>")
+	if got.Status != store.StatusExtractFailed || got.ExtractError == "" {
+		t.Errorf("email status = %q err = %q, want extract_failed", got.Status, got.ExtractError)
+	}
+
+	// Re-POST after the extractor recovers: the failed email retries extraction.
+	e.ex.set([]extract.Deal{{Source: "H", Title: "Recovered"}}, nil)
+	rec = e.post(t, "/api/ingest", token, rawEmail("<r@x>", "s", "b"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("retry status = %d", rec.Code)
+	}
+	got, _ = e.st.GetEmailByMessageID(context.Background(), "<r@x>")
+	if got.Status != store.StatusExtracted {
+		t.Errorf("after retry status = %q, want extracted", got.Status)
+	}
+	if calls := atomic.LoadInt32(&e.ex.calls); calls != 2 {
+		t.Errorf("extractor calls = %d, want 2 (initial + retry)", calls)
+	}
+}
+
+func TestIngestDigestSuppressedWithinInterval(t *testing.T) {
+	e := setup(t)
+	// First email posts a digest.
+	if rec := e.post(t, "/api/ingest", token, rawEmail("<a@x>", "s", "b")); rec.Code != 200 {
+		t.Fatalf("first: %d", rec.Code)
+	}
+	if e.poster.count() != 1 {
+		t.Fatalf("poster count = %d, want 1", e.poster.count())
+	}
+	// A fresh deal arrives within the interval; ingest must not post again.
+	e.ex.set([]extract.Deal{{Source: "H", Title: "Latecomer", URL: "https://h/late"}}, nil)
+	rec := e.post(t, "/api/ingest", token, rawEmail("<b@x>", "s", "b"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second: %d", rec.Code)
+	}
+	if res := decodeResult(t, rec); res["digest_posted"] != false {
+		t.Errorf("digest_posted = %v, want false (suppressed)", res["digest_posted"])
+	}
+	if e.poster.count() != 1 {
+		t.Errorf("poster count = %d, want 1 (no double post)", e.poster.count())
+	}
+}
+
+func TestAdminDigestForces(t *testing.T) {
+	e := setup(t)
+	if rec := e.post(t, "/api/ingest", token, rawEmail("<a@x>", "s", "b")); rec.Code != 200 {
+		t.Fatalf("ingest: %d", rec.Code)
+	}
+	// New deal queued within the interval (ingest won't post it).
+	e.ex.set([]extract.Deal{{Source: "H", Title: "Forced Deal", URL: "https://h/f"}}, nil)
+	if rec := e.post(t, "/api/ingest", token, rawEmail("<b@x>", "s", "b")); rec.Code != 200 {
+		t.Fatalf("ingest b: %d", rec.Code)
+	}
+	if e.poster.count() != 1 {
+		t.Fatalf("poster count = %d, want 1 before force", e.poster.count())
+	}
+
+	rec := e.post(t, "/api/admin/digest", token, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin/digest status = %d", rec.Code)
+	}
+	if res := decodeResult(t, rec); res["posted"] != true {
+		t.Errorf("posted = %v, want true", res["posted"])
+	}
+	if e.poster.count() != 2 {
+		t.Errorf("poster count = %d, want 2 after force", e.poster.count())
+	}
+}
+
+func TestAdminDigestAuth(t *testing.T) {
+	e := setup(t)
+	if rec := e.post(t, "/api/admin/digest", "", nil); rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}

--- a/apps/api/internal/mailparse/mailparse.go
+++ b/apps/api/internal/mailparse/mailparse.go
@@ -30,6 +30,10 @@ const (
 	// exists, is treated as a "view in browser" stub and the HTML is preferred.
 	stubThreshold = 200
 	truncSentinel = "\n[truncated]"
+	// maxMIMEDepth caps multipart nesting. Email bodies come from untrusted
+	// senders; a maliciously deep multipart tree would otherwise recurse until
+	// the goroutine stack is exhausted. Real mail nests only a few levels.
+	maxMIMEDepth = 20
 )
 
 // Email is the normalized result of parsing a raw message.
@@ -93,7 +97,7 @@ func Parse(raw []byte) (Email, error) {
 	var p parts
 	if err := p.walk(msg.Body, contentType,
 		msg.Header.Get("Content-Transfer-Encoding"),
-		msg.Header.Get("Content-Disposition")); err != nil {
+		msg.Header.Get("Content-Disposition"), 0); err != nil {
 		return Email{}, fmt.Errorf("walk body: %w", err)
 	}
 	// Guarantee valid UTF-8 even when a body mislabels its charset (e.g. declares
@@ -108,7 +112,12 @@ type parts struct {
 	html  string
 }
 
-func (p *parts) walk(r io.Reader, contentType, cte, disposition string) error {
+func (p *parts) walk(r io.Reader, contentType, cte, disposition string, depth int) error {
+	if depth > maxMIMEDepth {
+		// Stop descending into pathologically deep multipart nesting (untrusted
+		// input); parts already collected above this point are still used.
+		return nil
+	}
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		mediaType, params = "text/plain", map[string]string{}
@@ -131,7 +140,7 @@ func (p *parts) walk(r io.Reader, contentType, cte, disposition string) error {
 			perr := p.walk(part,
 				part.Header.Get("Content-Type"),
 				part.Header.Get("Content-Transfer-Encoding"),
-				part.Header.Get("Content-Disposition"))
+				part.Header.Get("Content-Disposition"), depth+1)
 			part.Close()
 			if perr != nil {
 				return perr

--- a/apps/api/internal/mailparse/mailparse_test.go
+++ b/apps/api/internal/mailparse/mailparse_test.go
@@ -1,6 +1,7 @@
 package mailparse
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -201,5 +202,40 @@ func TestParseTruncatesOnRuneBoundary(t *testing.T) {
 	}
 	if !strings.HasSuffix(e.Text, truncSentinel) {
 		t.Error("Text missing truncation sentinel")
+	}
+}
+
+// nestedMultipart builds an email whose body is `levels` nested multipart/mixed
+// wrappers around a single text/plain leaf ("deepest"); the leaf sits at walk
+// depth == levels.
+func nestedMultipart(levels int) []byte {
+	part := "Content-Type: text/plain\r\n\r\ndeepest\r\n"
+	for i := levels - 1; i >= 0; i-- {
+		b := fmt.Sprintf("b%d", i)
+		part = "Content-Type: multipart/mixed; boundary=\"" + b + "\"\r\n\r\n" +
+			"--" + b + "\r\n" + part + "\r\n--" + b + "--\r\n"
+	}
+	return []byte("From: x@example.com\r\nSubject: Nested\r\nMessage-Id: <nest@x>\r\n" +
+		"Date: Mon, 20 Jul 2026 10:00:00 +0000\r\n" + part)
+}
+
+func TestParseMIMEDepthCap(t *testing.T) {
+	// Within the cap: a deep-but-bounded message still reaches its leaf.
+	within, err := Parse(nestedMultipart(maxMIMEDepth / 2))
+	if err != nil {
+		t.Fatalf("within-cap Parse: %v", err)
+	}
+	if !strings.Contains(within.Text, "deepest") {
+		t.Errorf("within-cap: leaf not reached, Text = %q", within.Text)
+	}
+
+	// Beyond the cap: recursion stops before the leaf. It must not panic or
+	// error, and the too-deep leaf is not collected.
+	beyond, err := Parse(nestedMultipart(maxMIMEDepth * 2))
+	if err != nil {
+		t.Fatalf("beyond-cap Parse: %v", err)
+	}
+	if strings.Contains(beyond.Text, "deepest") {
+		t.Errorf("beyond-cap: leaf past the depth cap should not be reached, Text = %q", beyond.Text)
 	}
 }

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"io/fs"
 	"log"
@@ -17,6 +18,11 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/auth"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/db"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/digest"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/extract"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/ingest"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
 )
 
 const staticDir = "static"
@@ -37,7 +43,12 @@ func main() {
 		log.Printf("auth: WORKOS_CLIENT_ID / WORKOS_API_HOSTNAME not set; /api/me disabled")
 	}
 
-	e := newServer(staticDir, v)
+	ing, database := newIngestFromEnv(ctx)
+	if database != nil {
+		defer database.Close()
+	}
+
+	e := newServer(staticDir, v, ing)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -88,6 +99,47 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
+// newIngestFromEnv builds the email-ingest handlers from the environment. It
+// returns (nil, nil) when the pipeline is not configured (no DATABASE_URL /
+// INGEST_TOKEN), so the server still runs static-only — mirroring the WorkOS
+// graceful-degrade above. The returned *sql.DB (when non-nil) is owned by the
+// caller, which must Close it on shutdown. Fatal only on a genuinely broken
+// setup (bad duration, unreachable DB, bad Gemini client).
+func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
+	cfg, err := ingest.Load(os.Getenv)
+	if err != nil {
+		log.Fatalf("ingest: %v", err)
+	}
+	if !cfg.Enabled() {
+		log.Printf("ingest: DATABASE_URL / INGEST_TOKEN not set; /api/ingest disabled")
+		return nil, nil
+	}
+
+	database, err := db.Open(cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("ingest: db open: %v", err)
+	}
+	if err := db.Migrate(ctx, database); err != nil {
+		_ = database.Close()
+		log.Fatalf("ingest: db migrate: %v", err)
+	}
+
+	var extractor extract.Extractor = extract.Disabled{}
+	if cfg.GeminiAPIKey != "" {
+		g, err := extract.NewGemini(ctx, cfg.GeminiAPIKey, cfg.GeminiModel, "")
+		if err != nil {
+			_ = database.Close()
+			log.Fatalf("ingest: gemini: %v", err)
+		}
+		extractor = g
+	} else {
+		log.Printf("ingest: GEMINI_API_KEY not set; extraction disabled (/api/ingest will 500)")
+	}
+
+	poster := digest.NewHTTPPoster(cfg.SlackWebhookURL)
+	return ingest.New(cfg, store.New(database), extractor, poster), database
+}
+
 // handleMe returns the validated claims for the authenticated user. Light
 // shape on purpose — tighten the response to whatever the frontend ends up
 // needing.
@@ -111,7 +163,7 @@ func handleMe(c echo.Context) error {
 // staticRoot. When v is non-nil, /api/me is mounted under WorkOS-validated
 // auth; otherwise the route falls through to the /api/* JSON 404. Split out
 // from main so tests can build a server against fixtures.
-func newServer(staticRoot string, v *auth.Verifier) *echo.Echo {
+func newServer(staticRoot string, v *auth.Verifier, ing *ingest.Handlers) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 
@@ -139,6 +191,13 @@ func newServer(staticRoot string, v *auth.Verifier) *echo.Echo {
 	if v != nil {
 		api := e.Group("/api", auth.Middleware(v))
 		api.Match(getOrHead, "/me", handleMe)
+	}
+
+	// Mount the email-ingest routes (POST /api/ingest, /api/admin/digest) when
+	// the pipeline is configured — before the /api/* reservation so the concrete
+	// POST paths win over the JSON-404 wildcard.
+	if ing != nil {
+		ing.Register(e)
 	}
 
 	// Reserve /api/* and /ws so unrecognized requests there reach Echo's

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -99,6 +99,32 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
+// authTokenOf extracts the authToken query value from a libsql DATABASE_URL, or
+// "" if absent. Used to redact the token from database errors before logging.
+func authTokenOf(dbURL string) string {
+	const key = "authToken="
+	i := strings.Index(dbURL, key)
+	if i < 0 {
+		return ""
+	}
+	v := dbURL[i+len(key):]
+	if amp := strings.IndexByte(v, '&'); amp >= 0 {
+		v = v[:amp]
+	}
+	return v
+}
+
+// redactToken replaces every occurrence of token in s with "***". A libsql
+// driver error can embed the full connection URL including ?authToken=<token>;
+// redacting the opaque token keeps the useful cause (dial/connect/auth failure)
+// in the log while keeping the secret out of it. A no-op when token is "".
+func redactToken(s, token string) string {
+	if token == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, token, "***")
+}
+
 // newIngestFromEnv builds the email-ingest handlers from the environment. It
 // returns (nil, nil) when the pipeline is not configured (no DATABASE_URL /
 // INGEST_TOKEN), so the server still runs static-only — mirroring the WorkOS
@@ -115,13 +141,14 @@ func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
 		return nil, nil
 	}
 
+	tok := authTokenOf(cfg.DatabaseURL)
 	database, err := db.Open(cfg.DatabaseURL)
 	if err != nil {
-		log.Fatalf("ingest: db open: %v", err)
+		log.Fatalf("ingest: db open: %s", redactToken(err.Error(), tok))
 	}
 	if err := db.Migrate(ctx, database); err != nil {
 		_ = database.Close()
-		log.Fatalf("ingest: db migrate: %v", err)
+		log.Fatalf("ingest: db migrate: %s", redactToken(err.Error(), tok))
 	}
 
 	var extractor extract.Extractor = extract.Disabled{}

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -239,6 +239,30 @@ func TestIngestRouteWiredWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestRedactToken(t *testing.T) {
+	url := "libsql://db.turso.io?authToken=SUPERSECRET123"
+	tok := authTokenOf(url)
+	if tok != "SUPERSECRET123" {
+		t.Fatalf("authTokenOf = %q, want SUPERSECRET123", tok)
+	}
+	// A driver error embedding the URL must come out with the token redacted but
+	// the useful cause intact.
+	errStr := `db: ping: dial libsql://db.turso.io?authToken=SUPERSECRET123: connection refused`
+	got := redactToken(errStr, tok)
+	if strings.Contains(got, "SUPERSECRET123") {
+		t.Errorf("redactToken left the token: %q", got)
+	}
+	if !strings.Contains(got, "connection refused") {
+		t.Errorf("redactToken dropped the cause: %q", got)
+	}
+	if authTokenOf("file:./dev.db") != "" {
+		t.Error("authTokenOf should be empty for a local file URL")
+	}
+	if redactToken("plain error", "") != "plain error" {
+		t.Error("redactToken with empty token should be a no-op")
+	}
+}
+
 func TestIngestRouteAbsentWhenDisabled(t *testing.T) {
 	// With no ingest handler, POST /api/ingest falls through to the /api/* JSON
 	// 404 reservation (the pipeline is disabled).

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/ingest"
 )
 
 // fixtureDir writes a minimal prerendered static tree to a temp dir and
@@ -37,7 +39,7 @@ func fixtureDir(t *testing.T) string {
 }
 
 func TestHealthzReturns204(t *testing.T) {
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -51,7 +53,7 @@ func TestHealthzReturns204(t *testing.T) {
 }
 
 func TestStaticFileServed(t *testing.T) {
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 	cases := []struct {
 		name string
 		path string
@@ -80,7 +82,7 @@ func TestStaticFileServed(t *testing.T) {
 // healthcheck probes, and ad-hoc monitoring all use HEAD; without explicit
 // support Echo returns 405 instead of mirroring the GET status.
 func TestHeadMirrorsGet(t *testing.T) {
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 	cases := []struct {
 		name       string
 		path       string
@@ -106,7 +108,7 @@ func TestHeadMirrorsGet(t *testing.T) {
 }
 
 func TestSSGFallbackOnUnknownPageRoute(t *testing.T) {
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/nonexistent/", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -123,7 +125,7 @@ func TestSSGFallbackOnUnknownPageRoute(t *testing.T) {
 }
 
 func TestApiAndWsRoutesSkipSSGFallback(t *testing.T) {
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 	cases := []string{"/api/missing", "/ws"}
 	for _, path := range cases {
 		t.Run(path, func(t *testing.T) {
@@ -145,7 +147,7 @@ func TestApiAndWsRoutesSkipSSGFallback(t *testing.T) {
 // connection hijack a WebSocket upgrade needs. The middleware in newServer
 // skips /ws so Phase 4's hub keeps working.
 func TestGzipSkippedOnWebsocketPath(t *testing.T) {
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 	cases := []struct {
 		path     string
 		wantGzip bool
@@ -173,7 +175,7 @@ func TestSSGFallbackHandlesMissing404Html(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("home"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	e := newServer(dir, nil)
+	e := newServer(dir, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/nope/", nil)
 	rec := httptest.NewRecorder()
@@ -185,7 +187,7 @@ func TestSSGFallbackHandlesMissing404Html(t *testing.T) {
 }
 
 func TestTrailingSlashCanonicalization(t *testing.T) {
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 	cases := []struct {
 		name     string
 		method   string
@@ -220,5 +222,31 @@ func TestTrailingSlashCanonicalization(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestIngestRouteWiredWhenEnabled(t *testing.T) {
+	// A non-nil ingest handler mounts POST /api/ingest behind bearer auth; an
+	// unauthenticated request reaches that auth (401), proving the route is wired
+	// and not swallowed by the /api/* JSON-404 reservation.
+	ing := ingest.New(ingest.Config{IngestToken: "t"}, nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, ing)
+	req := httptest.NewRequest(http.MethodPost, "/api/ingest", strings.NewReader("x"))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("POST /api/ingest without token: want 401, got %d", rec.Code)
+	}
+}
+
+func TestIngestRouteAbsentWhenDisabled(t *testing.T) {
+	// With no ingest handler, POST /api/ingest falls through to the /api/* JSON
+	// 404 reservation (the pipeline is disabled).
+	e := newServer(fixtureDir(t), nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/ingest", strings.NewReader("x"))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("POST /api/ingest with pipeline disabled: want 404, got %d", rec.Code)
 	}
 }

--- a/apps/api/redirects_test.go
+++ b/apps/api/redirects_test.go
@@ -49,7 +49,7 @@ func TestFindRedirect(t *testing.T) {
 // The legacy map must run before static resolution: /index.html is both a real
 // file in the static root and a mapped redirect to /.
 func TestLegacyRedirectPrecedesStaticFile(t *testing.T) {
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/index.html", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -63,7 +63,7 @@ func TestLegacyRedirectPrecedesStaticFile(t *testing.T) {
 }
 
 func TestLegacyRedirectServedOverHTTP(t *testing.T) {
-	e := newServer(fixtureDir(t), nil)
+	e := newServer(fixtureDir(t), nil, nil)
 	cases := []struct {
 		name    string
 		method  string


### PR DESCRIPTION
Implements #267.

Wires the email-deals pipeline into the existing Go server.

**New `internal/ingest`:**
- `Config` + `Load` for the pipeline env vars — `DATABASE_URL`, `INGEST_TOKEN`, `GEMINI_API_KEY`, `GEMINI_MODEL`, `SLACK_WEBHOOK_FOR_DEALS_CHANNEL` (renamed from the reference's `SLACK_WEBHOOK_URL`), `DIGEST_INTERVAL`, `REPOST_AFTER`. Durations validated positive; `String()` redacts secrets; `Enabled()` = `DATABASE_URL` + `INGEST_TOKEN` both set.
- Constant-time `BearerAuth` middleware; `Ingest` (read ≤25MB → `mailparse.Parse` → `store.InsertEmail` → idempotent short-circuit → `extract` → `UpsertDeal` → mark extracted → best-effort `digest.Run`) and `AdminDigest` (force). `Register(e)` mounts `POST /api/ingest` + `POST /api/admin/digest` behind the token.

**`main.go`:** `newIngestFromEnv` builds the pipeline when `Enabled()` — opens the DB (Turso or local sqlite via `internal/db`), **runs migrations on boot**, constructs store/extractor(Gemini or `Disabled`)/poster, and `newServer` registers the routes before the `/api/*` JSON-404 reservation. Unconfigured → static-only (logs a warning), mirroring the WorkOS graceful-degrade. The server binary now links the libsql + modernc drivers (previously only `cmd/migrate` did).

**`mailparse`:** adds a MIME recursion depth cap (`maxMIMEDepth = 20`) — flagged in the #263 review — so a maliciously deep multipart email from the untrusted ingest path can't exhaust the stack.

## Testing
- `internal/ingest` httptest suite: happy path, duplicate-skips-extraction, auth (401 no/bad token, extractor not run), oversize (413), malformed (400), digest-failure-doesn't-fail-ingest, extractor-error-then-retry, suppression-within-interval, admin force; config defaults/overrides/Enabled/bad+non-positive duration/redaction.
- `main_test`: route wired (401) when enabled, absent (404) when disabled; all existing static/redirect/gzip/`/api/me` tests updated to the new `newServer` signature and still pass.
- `mailparse`: depth-cap test (within-cap reaches leaf, beyond-cap stops without panic/error).
- **Runtime boot smoke**: fresh `file:` DB migrated on start; `/healthz`→204, missing/bad token→401, valid POST with no Gemini key→500 `{"message":"extract deals"}` and the email row stored as `extract_failed`.
- `go test -race ./...` + `go vet ./...` green; `gofmt` clean (my files); `CGO_ENABLED=0 GOOS=linux go build .` links the drivers; `go mod tidy` no change (no new deps).
