### PR TITLE
Wire the email_receiver worker into just, CI, and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,6 +49,11 @@ apps/web/tsconfig.json
 apps/web/vite.config.ts
 apps/web/vitest.config.ts
 
+# Worker workspace — deploys to Cloudflare, never ships in the Go image
+# (the Dockerfile only copies apps/api + apps/web/dist). Excluding the whole
+# dir keeps its source and large wrangler node_modules out of the build context.
+apps/email_receiver
+
 # Root JS install artifacts
 node_modules
 bun.lock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,15 @@ jobs:
         run: go vet ./...
         working-directory: apps/api
 
+      - name: ESLint (worker)
+        run: bunx eslint .
+        working-directory: apps/email_receiver
+
+      # `test` runs `bunx tsc --noEmit && bun test` — typecheck + tests with the
+      # worker's bunfig coverage gate.
+      - name: Test worker (typecheck + coverage)
+        run: bun run --filter email_receiver test
+
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4

--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ dev-web:
 dev-api:
   set -a; [ -f .env.local ] && . ./.env.local; set +a; cd apps/api && go run .
 
+# Cloudflare Worker (email_receiver) dev server via wrangler
+dev_worker:
+  bun run --filter email_receiver dev
+
 # Build the prerendered web app, then mirror dist into apps/api/static so the
 # Go binary can serve it locally and so the Dockerfile picks it up directly.
 build: clean
@@ -26,10 +30,15 @@ build: clean
   /bin/cp -R apps/web/dist apps/api/static
   @echo '\nDone with building.\n'
 
-# Run unit tests across the whole repo (Go race tests + Vitest)
+# Run unit tests across the whole repo (Go race tests + Vitest + Worker)
 test:
   cd apps/api && go test -race ./...
   bun run --filter web test
+  bun run --filter email_receiver test
+
+# Worker (email_receiver) tests only: tsc typecheck + bun test
+test_worker:
+  bun run --filter email_receiver test
 
 # Run web tests in watch mode
 test-watch:
@@ -68,6 +77,14 @@ status:
 # SSH into a live Fly machine
 ssh:
   fly ssh console
+
+# Deploy the Cloudflare Worker (email_receiver) via wrangler
+deploy_worker:
+  bun run --filter email_receiver deploy
+
+# Tail the deployed Cloudflare Worker's logs
+tail_worker:
+  cd apps/email_receiver && bunx wrangler tail
 
 # Apply pending migrations against DATABASE_URL. The server also runs this
 # on startup, so this is mainly for ad-hoc dev runs.


### PR DESCRIPTION
Implements #269.

Wires the `apps/email_receiver` worker into the repo's tooling.

- **justfile**: snake_case `dev_worker` / `test_worker` / `deploy_worker` / `tail_worker` recipes, and `just test` now runs the worker's `tsc --noEmit && bun test` alongside the Go race tests and web vitest.
- **CI** (`.github/workflows/test.yml`): an `ESLint (worker)` step and a `Test worker (typecheck + coverage)` step (`bun run --filter email_receiver test`). `bun install --frozen-lockfile` already installs the worker workspace, so no extra install. This PR modifies the workflow, so its own CI run exercises the new steps.
- **.dockerignore**: exclude `apps/email_receiver`. The Dockerfile only copies `apps/api` + `apps/web/dist`, so the image is byte-for-byte unchanged; this just keeps the worker's source and its large wrangler `node_modules` (miniflare/workerd/sharp) out of the build context.

## Testing
- `just --list` shows the four new recipes; `just test_worker` → 11 pass, 100% coverage.
- `just build && docker build -t css-wiring-verify .` succeeds; `docker run` serves `/healthz` (204), `/` (200), `/about/` (200) with the worker excluded from the context. Image + container cleaned up.
- Existing web + Go CI steps unchanged.
