### PR TITLE
Document the email-ingest pipeline and the third app

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -10,10 +10,16 @@ VITE_WORKOS_API_HOSTNAME=api.workos.com
 DATABASE_URL="dev.db"
 WORKOS_API_KEY="sk_test_..."
 
+# Email-ingest pipeline (apps/email_receiver -> /api/ingest -> Turso -> Slack).
+# Enabled only when DATABASE_URL and INGEST_TOKEN are both set.
+INGEST_TOKEN=
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.5-flash-lite
 SLACK_WEBHOOK_FOR_DEALS_CHANNEL=
+DIGEST_INTERVAL=24h
+REPOST_AFTER=1080h
 
 JWT_SECRET=
 
-# Prod
-# DATABASE_URL=
-# TURSO_AUTH_TOKEN=
+# Prod: DATABASE_URL is a Turso URL with the auth token in the query string.
+# DATABASE_URL=libsql://<db>.turso.io?authToken=<token>

--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ See the documentation in [manual](./manual/src/SUMMARY.md). If [just](https://ju
 
 ## Architecture
 
-Bun workspace with two apps and a Go binary that fronts the whole thing in production.
+Bun workspace with three apps: an Astro frontend, a Go + Echo backend that fronts the whole thing in production, and a Cloudflare Worker that receives forwarded email.
 
 ```
 codeselfstudy/
 ├── apps/
 │   ├── web/                  Astro (SSG, React islands).
 │   │   └── dist/             Prerendered static site (build-time output).
-│   └── api/                  Go + Echo backend.
-│       └── static/           Mirrored from web's dist/ at build time.
+│   ├── api/                  Go + Echo backend (serves the site + JSON API).
+│   │   └── static/           Mirrored from web's dist/ at build time.
+│   └── email_receiver/       Cloudflare Worker: forwards "deals" email to /api/ingest.
 ├── Dockerfile                Multi-stage: Go build + distroless runtime.
 ├── fly.toml                  256 MB shared-cpu-1x.
 └── justfile                  dev / build / test / deploy.
@@ -26,7 +27,9 @@ The Go binary serves the prerendered HTML, the JSON API (`/api/*`), and a future
 
 **Auth.** An Echo middleware validates access tokens against the WorkOS JWKS for protected `/api/*` routes. The client-side WorkOS sign-in UI is deferred to the API phase — the current Astro build ships without it.
 
-**Database.** SQLite via `modernc.org/sqlite` (pure Go, no CGO). The Go side owns the schema: goose migrations live in `apps/api/internal/db/migrations/`, are embedded into the binary via `//go:embed`, and apply automatically on server startup. Remote Turso (libsql://) is a follow-up.
+**Database.** SQLite via `modernc.org/sqlite` (pure Go, no CGO) locally; Turso (`libsql://`) in production via the pure-Go `tursodatabase/libsql-client-go` driver — `internal/db.Open` selects the driver by URL scheme, so the distroless image stays static. The Go side owns the schema: goose migrations live in `apps/api/internal/db/migrations/`, are embedded into the binary via `//go:embed`, and apply automatically on server startup.
+
+**Email → deals → Slack.** The `apps/email_receiver` Cloudflare Worker receives forwarded newsletters via Cloudflare Email Routing and POSTs the raw RFC822 to the Go server's `POST /api/ingest` (bearer `INGEST_TOKEN`). The server parses the email, stores it in Turso, extracts deals with the Gemini API, and posts a Block Kit digest to a Slack channel (at most once per `DIGEST_INTERVAL`); `POST /api/admin/digest` forces one. The pipeline is opt-in — it runs only when `DATABASE_URL` and `INGEST_TOKEN` are set, so the server otherwise stays a pure static host.
 
 **Build.** `bun run build` prerenders all routes to `apps/web/dist/`; `just build` mirrors that into `apps/api/static/` so the Go binary picks it up. The Docker build runs locally and ships the prebuilt artifact in the build context — Fly's remote builder doesn't re-run `bun install`.
 

--- a/env.local.example
+++ b/env.local.example
@@ -12,8 +12,29 @@ VITE_WORKOS_API_HOSTNAME=api.workos.com
 
 # PRIVATE SERVER VARS #####################
 
-# Local SQLite file path used by the migrate CLI (apps/api/cmd/migrate)
-# and by tests. The runtime server doesn't open the DB yet — that gets
-# wired up when the first real DB-backed endpoint lands.
+# Local SQLite file for the migrate CLI (apps/api/cmd/migrate), tests, and —
+# when the email-ingest pipeline is enabled (see below) — the runtime server.
+# In production this is a Turso URL: libsql://<db>.turso.io?authToken=<token>.
 DATABASE_URL="dev.db"
 WORKOS_API_KEY=get_this_from_workos
+
+
+# EMAIL-INGEST PIPELINE (optional) ########
+
+# The Cloudflare Worker (apps/email_receiver) POSTs forwarded "deals" emails to
+# the Go server's /api/ingest, which stores them in Turso, extracts deals with
+# Gemini, and posts a Slack digest. Enabled only when DATABASE_URL and
+# INGEST_TOKEN are both set; otherwise the server runs static-only.
+
+# Shared bearer secret between the Worker and the Go server (must match on both).
+INGEST_TOKEN=
+# Google Gemini API key. Empty ⇒ extraction disabled and /api/ingest returns 500.
+GEMINI_API_KEY=
+# Gemini model (optional; defaults to gemini-2.5-flash-lite).
+GEMINI_MODEL=gemini-2.5-flash-lite
+# Slack incoming-webhook URL for the deals channel.
+SLACK_WEBHOOK_FOR_DEALS_CHANNEL=
+# Digest cadence and deal repost window. Go durations (h/m/s only — no "d");
+# 45 days = 1080h.
+DIGEST_INTERVAL=24h
+REPOST_AFTER=1080h

--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,14 @@ primary_region = "iad"
   min_machines_running = 1
   processes = ["app"]
 
+[env]
+  # Non-secret email-ingest config. Secrets (DATABASE_URL with its authToken,
+  # INGEST_TOKEN, GEMINI_API_KEY, SLACK_WEBHOOK_FOR_DEALS_CHANNEL) are set with
+  # `fly secrets set`, never in this file.
+  GEMINI_MODEL = "gemini-2.5-flash-lite"
+  DIGEST_INTERVAL = "24h"
+  REPOST_AFTER = "1080h"
+
 [[vm]]
   cpus = 1
   memory_mb = 256

--- a/manual/src/architecture.md
+++ b/manual/src/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-The repo is a Bun workspace with an Astro frontend and a Go + Echo backend. In production a single Go binary fronts both — there is no JavaScript runtime on the server.
+The repo is a Bun workspace with three apps: an Astro frontend, a Go + Echo backend, and a Cloudflare Worker that receives forwarded email. In production a single Go binary fronts the site and the JSON API — there is no JavaScript runtime on the server — while the Worker runs on Cloudflare.
 
 ## Top-level shape
 
@@ -12,13 +12,19 @@ codeselfstudy/
 │   │   ├── public/             static assets
 │   │   ├── test/               Vitest setup
 │   │   └── dist/               prerendered HTML/CSS/JS (build output)
-│   └── api/                    Go + Echo backend
-│       ├── main.go             Echo bootstrap, static serving, route wiring
-│       ├── cmd/migrate/        thin goose CLI for ad-hoc migration runs
-│       ├── internal/auth/      WorkOS JWKS verifier + Echo middleware
-│       ├── internal/db/        SQLite access (modernc.org/sqlite)
-│       ├── internal/db/migrations/   goose .sql migrations (embedded)
-│       └── static/             populated at build time from web's dist/
+│   ├── api/                    Go + Echo backend
+│   │   ├── main.go             Echo bootstrap, static serving, route wiring
+│   │   ├── cmd/migrate/        thin goose CLI for ad-hoc migration runs
+│   │   ├── internal/auth/      WorkOS JWKS verifier + Echo middleware
+│   │   ├── internal/db/        SQLite / Turso access (driver by URL scheme)
+│   │   ├── internal/db/migrations/   goose .sql migrations (embedded)
+│   │   ├── internal/ingest/    /api/ingest + /api/admin/digest handlers, config
+│   │   ├── internal/store/     emails/deals/digests persistence
+│   │   ├── internal/mailparse/ internal/htmltext/  MIME → normalized text
+│   │   ├── internal/extract/   Gemini deal extraction
+│   │   ├── internal/digest/    Slack Block Kit digest + HTTP poster
+│   │   └── static/             populated at build time from web's dist/
+│   └── email_receiver/         Cloudflare Worker (TS): email → /api/ingest
 ├── manual/                     this mdBook
 ├── mockups/                    HTML mockups
 ├── Dockerfile                  multi-stage: Go build + distroless runtime
@@ -30,7 +36,7 @@ codeselfstudy/
 
 1. The Go binary listens on `:8080`.
 2. `/healthz` → 204 (Fly health check).
-3. `/api/*` → JSON handlers, gated by the WorkOS JWKS middleware where applicable. Unknown `/api/*` paths return a JSON 404, never the static fallback.
+3. `/api/*` → JSON handlers. `/api/me` is gated by the WorkOS JWKS middleware; `POST /api/ingest` and `POST /api/admin/digest` (the email pipeline) are gated by the `INGEST_TOKEN` bearer. Unknown `/api/*` paths return a JSON 404, never the static fallback.
 4. `/ws` → reserved for the future WebSocket hub.
 5. Anything else → static handler. It first checks the legacy redirect map (`apps/api/redirects.go`) and emits a 308 if the path matches. Then, for an extensionless path with no trailing slash that resolves to a directory index, it emits a 301 to the trailing-slash form (the site is built with `trailingSlash: "always"`). Otherwise it resolves `/foo` against `static/foo`, then `static/foo/index.html`, then `static/foo.html`. If nothing matches it serves `static/404.html` with a 404 status.
 
@@ -45,10 +51,21 @@ The Go-side auth is opt-in: if `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` (or th
 
 ## Database
 
-- Pure-Go SQLite via `modernc.org/sqlite` (no CGO) so the distroless image stays static.
+- Pure-Go drivers only, so the distroless image stays static: `modernc.org/sqlite` for local files and `:memory:`, and `tursodatabase/libsql-client-go` for remote Turso. `internal/db.Open` selects the driver by `DATABASE_URL` scheme (`libsql://` / `http(s)` / `ws(s)` → Turso; anything else → SQLite). The Turso auth token rides in the URL as `?authToken=…`.
 - **Schema is owned by Go.** Migrations live in `apps/api/internal/db/migrations/` as goose `.sql` files, are embedded into the binary via `//go:embed`, and apply on every startup. Goose tracks state in its own table, so re-running is a no-op.
 - For dev: `just db_migrate`, `just db_status`, `just db_down`, `just db_create <name>` wrap a small CLI in `apps/api/cmd/migrate`.
-- Remote Turso (`libsql://`) is a planned follow-up; the current `Open()` rejects libsql/http schemes up front so misconfigurations fail fast.
+
+## Email → deals → Slack
+
+An opt-in pipeline turns forwarded "deals" newsletters into a Slack digest:
+
+1. `apps/email_receiver` is a Cloudflare Worker wired to Cloudflare Email Routing. On each message it POSTs the raw RFC822 bytes to the Go server's `POST /api/ingest` (bearer `INGEST_TOKEN`, `Content-Type: message/rfc822`). There is no archive mailbox: an oversize message is rejected with `setReject()`, and a persistent POST failure propagates so Cloudflare fails the delivery and the sender's MTA retries.
+2. `internal/ingest` reads the body (≤25 MB), parses the MIME (`internal/mailparse` + `internal/htmltext`), stores the email (`internal/store`, idempotent on message-id), extracts deals with the Gemini API (`internal/extract`), upserts them (dedup by sender registrable-domain + normalized title), and — best effort — posts a Block Kit digest to Slack (`internal/digest`) at most once per `DIGEST_INTERVAL`. `POST /api/admin/digest` forces one.
+3. The pipeline is enabled only when `DATABASE_URL` and `INGEST_TOKEN` are set; otherwise the server runs static-only. Extraction needs `GEMINI_API_KEY` (empty ⇒ `/api/ingest` returns 500). The Slack webhook is `SLACK_WEBHOOK_FOR_DEALS_CHANNEL`.
+
+Secrets (`DATABASE_URL` with its authToken, `INGEST_TOKEN`, `GEMINI_API_KEY`, `SLACK_WEBHOOK_FOR_DEALS_CHANNEL`) are Fly secrets; `INGEST_TOKEN` must match the value set on the Worker with `wrangler secret put`. Non-secret `GEMINI_MODEL` / `DIGEST_INTERVAL` / `REPOST_AFTER` live in `fly.toml`'s `[env]` block.
+
+> Note: Cloudflare does not document what a thrown `email()` handler does. The Worker relies on a thrown handler producing a retryable delivery failure (so a transient Go outage → sender re-delivers); confirm this on the first real deploy. The deterministic oversize case already uses the documented `setReject()`.
 
 ## Build and deploy
 

--- a/manual/src/getting-started.md
+++ b/manual/src/getting-started.md
@@ -39,11 +39,16 @@ VITE_WORKOS_API_HOSTNAME="your_workos_api_hostname"
 # server-only variables
 WORKOS_API_KEY="your_workos_api_key"
 DATABASE_URL="dev.db"
+
+# email-ingest pipeline (optional — see below)
+INGEST_TOKEN=""
+GEMINI_API_KEY=""
+SLACK_WEBHOOK_FOR_DEALS_CHANNEL=""
 ```
 
-`DATABASE_URL` is used by the migrate CLI in `apps/api/cmd/migrate` and by
-tests. Once the first DB-backed endpoint lands it will also be read at
-server startup.
+`DATABASE_URL` is used by the migrate CLI in `apps/api/cmd/migrate`, by tests, and — when the email-ingest pipeline is enabled — by the runtime server. In production it is a Turso URL (`libsql://<db>.turso.io?authToken=<token>`).
+
+The email-ingest pipeline (the `apps/email_receiver` Worker → `/api/ingest` → Turso → Slack) is opt-in: it runs only when `DATABASE_URL` and `INGEST_TOKEN` are both set, and extraction additionally needs `GEMINI_API_KEY`. See [Architecture](./architecture.md#email--deals--slack) for the full flow.
 
 ## Database Tasks
 

--- a/manual/src/index.md
+++ b/manual/src/index.md
@@ -14,6 +14,6 @@ Current ideas include authentication, daily puzzles, marking completed puzzles, 
 ## Start Here
 
 - Read "Getting Started" to set up your environment and run the app.
-- Skim "Architecture" for the high-level shape of the two apps and how they fit together.
+- Skim "Architecture" for the high-level shape of the apps and how they fit together.
 - Use "Project Structure" to find features and data quickly.
 - Check "Routing & Data" for Astro routing conventions.

--- a/manual/src/project-structure.md
+++ b/manual/src/project-structure.md
@@ -1,9 +1,10 @@
 # Project Structure
 
-This is a Bun workspace with two apps. Top-level shape:
+This is a Bun workspace with three apps. Top-level shape:
 
 - `apps/web/`: Astro frontend (SSG, React islands). Prerenders to `apps/web/dist/`.
 - `apps/api/`: Go + Echo backend. Owns the database schema and serves the prerendered site at runtime.
+- `apps/email_receiver/`: Cloudflare Worker (TypeScript) that receives forwarded "deals" email and POSTs it to the Go server's `/api/ingest`.
 - `manual/`: this mdBook documentation.
 - `mockups/`: HTML mockups, served via `just mockups`.
 
@@ -21,9 +22,20 @@ Inside `apps/api/`:
 - `main.go`: Echo bootstrap, static serving, route wiring.
 - `cmd/migrate/`: small CLI around goose for ad-hoc migration runs.
 - `internal/auth/`: WorkOS JWKS verifier + Echo middleware.
-- `internal/db/`: SQLite access (`modernc.org/sqlite`).
+- `internal/db/`: SQLite / Turso access (driver chosen by `DATABASE_URL` scheme).
 - `internal/db/migrations/`: goose `.sql` migrations, embedded into the binary and applied on startup.
+- `internal/ingest/`: the `/api/ingest` + `/api/admin/digest` handlers, bearer-token middleware, and pipeline config.
+- `internal/store/`: emails/deals/digests persistence and the once-per-interval digest claim.
+- `internal/mailparse/`, `internal/htmltext/`: raw MIME → normalized text.
+- `internal/extract/`: Gemini deal extraction.
+- `internal/digest/`: Slack Block Kit rendering + HTTP poster.
 - `static/`: populated at build time from `apps/web/dist/`. Gitignored.
+
+Inside `apps/email_receiver/` (Cloudflare Worker):
+
+- `src/index.ts`: the Cloudflare `email()` handler (runtime wiring).
+- `src/lib.ts`: `handleEmail` — POSTs the raw email to `/api/ingest` with retry (no archive forward).
+- `wrangler.jsonc`, `tsconfig.json`, `eslint.config.js`, `bunfig.toml`: per-app config.
 
 Generated files:
 


### PR DESCRIPTION
Implements #270.

Docs + env for the email pipeline.

- **README** and **manual** (`architecture`, `project-structure`, `getting-started`, `index`): three apps instead of two; the `apps/email_receiver` Worker; the `POST /api/ingest` + `POST /api/admin/digest` flow and the new `internal/{ingest,store,mailparse,htmltext,extract,digest}` packages; and Turso is now the production DB (driver selected by URL scheme) rather than a "follow-up". Added an "Email → deals → Slack" section to architecture.md with a deploy-time note about the Worker's thrown-handler bounce behavior.
- **env.local.example** / **.env-example**: add `INGEST_TOKEN`, `GEMINI_API_KEY`, `GEMINI_MODEL`, `SLACK_WEBHOOK_FOR_DEALS_CHANNEL`, `DIGEST_INTERVAL`, `REPOST_AFTER`; note the Turso prod URL form.
- **fly.toml**: an `[env]` block for non-secret pipeline config (secrets stay `fly secrets`).

## Testing
- `grep -ri "two apps"` and the stale Turso-"follow-up" references → none.
- `mdbook build manual` succeeds.
- New/edited prose is not hard-wrapped mid-paragraph (AGENTS.md).