### PR TITLE
Fix libsql/goose migrate crash-loop on Fly (pre-create version table; migrations via release_command)

### DIFF
--- a/apps/api/internal/db/db.go
+++ b/apps/api/internal/db/db.go
@@ -55,6 +55,15 @@ func Open(databaseURL string) (*sql.DB, error) {
 			_ = db.Close()
 			return nil, fmt.Errorf("db: enable foreign keys: %w", err)
 		}
+	} else {
+		// libsql/Turso over the HTTP (hranaV2) transport: each database/sql
+		// connection is a server-side stream Turso may close when idle. Cap the
+		// pool at one so this low-traffic pipeline reuses a single stream instead
+		// of churning several; Turso serializes writes server-side, so a single
+		// connection costs nothing here. Schema migration tolerates a closed stream
+		// on its own — see Migrate, which uses goose's pooled, retryable legacy API
+		// rather than the dedicated-connection Provider.
+		db.SetMaxOpenConns(1)
 	}
 
 	if err := db.Ping(); err != nil {
@@ -80,4 +89,14 @@ func driverFor(databaseURL string) string {
 	default:
 		return "sqlite"
 	}
+}
+
+// IsRemote reports whether databaseURL points at a remote libsql/Turso server
+// rather than a local SQLite file or :memory:. It uses the same scheme test as
+// driverFor. Callers use it to decide where migrations run: on startup for a
+// local database (dev ergonomics), or out of band via the migrate CLI /
+// `server -migrate` release step for a remote one, so a migration failure
+// aborts a deploy instead of crash-looping the serving process.
+func IsRemote(databaseURL string) bool {
+	return driverFor(databaseURL) == "libsql"
 }

--- a/apps/api/internal/db/db_test.go
+++ b/apps/api/internal/db/db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -63,5 +64,65 @@ func TestMigrateIsIdempotent(t *testing.T) {
 	}
 	if err := Migrate(ctx, d); err != nil {
 		t.Fatalf("second migrate: %v", err)
+	}
+}
+
+func TestIsRemote(t *testing.T) {
+	// Mirrors driverFor: remote libsql/Turso schemes vs local SQLite. Decides
+	// whether migrations run on startup (local) or via the release step (remote).
+	cases := map[string]bool{
+		"libsql://example.turso.io":        true,
+		"libsql://db.turso.io?authToken=x": true,
+		"http://localhost:8080/db":         true,
+		"https://example.com":              true,
+		"wss://example.com":                true,
+		"ws://example.com":                 true,
+		"dev.db":                           false,
+		":memory:":                         false,
+		"file:/tmp/x.db":                   false,
+		"sqlite:/tmp/x.db":                 false,
+		"/var/lib/app.db":                  false,
+	}
+	for url, want := range cases {
+		t.Run(url, func(t *testing.T) {
+			if got := IsRemote(url); got != want {
+				t.Fatalf("IsRemote(%q) = %v, want %v", url, got, want)
+			}
+		})
+	}
+}
+
+// TestMigrateAgainstLibsql exercises the migration against a live libsql/Turso
+// endpoint named by LIBSQL_TEST_URL. It is skipped when the var is unset so CI
+// stays hermetic (mirroring the env-gated Gemini live test). Point it at a local
+// server for a quick check:
+//
+//	turso dev --port 8080 --db-file /tmp/t.db &
+//	LIBSQL_TEST_URL=http://127.0.0.1:8080 go test ./internal/db -run TestMigrateAgainstLibsql
+//
+// or at a throwaway Turso database (libsql://…?authToken=…) to verify the
+// cloud-only failure this path guards against. Runs twice to prove idempotency.
+// NOTE: local sqld does not reproduce the original Turso crash — only a real
+// Turso endpoint does — so a green local run is necessary but not sufficient.
+func TestMigrateAgainstLibsql(t *testing.T) {
+	url := os.Getenv("LIBSQL_TEST_URL")
+	if url == "" {
+		t.Skip("set LIBSQL_TEST_URL (a `turso dev` http:// URL or a Turso libsql:// URL) to run")
+	}
+	if !IsRemote(url) {
+		t.Fatalf("LIBSQL_TEST_URL %q is not a remote libsql URL", url)
+	}
+	d, err := Open(url)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	ctx := context.Background()
+	if err := Migrate(ctx, d); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	if err := Migrate(ctx, d); err != nil {
+		t.Fatalf("second migrate (idempotent): %v", err)
 	}
 }

--- a/apps/api/internal/db/migrate.go
+++ b/apps/api/internal/db/migrate.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"embed"
 	"fmt"
-	"io/fs"
 
 	"github.com/pressly/goose/v3"
 )
@@ -16,18 +15,24 @@ var migrationsFS embed.FS
 // Migrate brings db up to the latest schema using the embedded goose
 // migrations. Safe to call on every startup — goose tracks which versions
 // have run in its own table and skips already-applied migrations.
+//
+// It deliberately uses goose's legacy top-level API (SetBaseFS + UpContext)
+// rather than the newer Provider, because the two behave very differently
+// against Turso. The Provider holds ONE dedicated *sql.Conn for the whole run;
+// Turso closes that connection's server-side stream when it goes idle over the
+// HTTP (hranaV2) transport, and a dedicated conn gets no database/sql retry, so
+// the Provider's first probe or DDL then dies with "sql: connection is already
+// closed" — this is what crash-looped the deploy. The legacy API issues every
+// statement on the pooled *sql.DB, so database/sql transparently retries
+// driver.ErrBadConn on a fresh connection. The failure only reproduces against a
+// real Turso database — local SQLite and a local libsql server keep the stream
+// alive, so it never surfaces there (verified against a live Turso DB).
 func Migrate(ctx context.Context, db *sql.DB) error {
-	// goose expects the FS to be rooted at the migrations directory; the
-	// embed.FS rooted at the package keeps the "migrations/" prefix.
-	sub, err := fs.Sub(migrationsFS, "migrations")
-	if err != nil {
-		return fmt.Errorf("db: migrate scope: %w", err)
+	goose.SetBaseFS(migrationsFS)
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		return fmt.Errorf("db: migrate dialect: %w", err)
 	}
-	provider, err := goose.NewProvider(goose.DialectSQLite3, db, sub)
-	if err != nil {
-		return fmt.Errorf("db: migrate: %w", err)
-	}
-	if _, err := provider.Up(ctx); err != nil {
+	if err := goose.UpContext(ctx, db, "migrations"); err != nil {
 		return fmt.Errorf("db: migrate up: %w", err)
 	}
 	return nil

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -31,6 +31,15 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// `server -migrate` (the Fly release_command) applies database migrations
+	// and exits, so schema changes run once per deploy in a temporary machine
+	// before the new version serves traffic — a migration failure aborts the
+	// deploy instead of crash-looping the app.
+	if migrateRequested(os.Args[1:]) {
+		runMigrate(ctx)
+		return
+	}
+
 	// Wire WorkOS auth when the env is set. In barebones dev (no env) the
 	// static-serve + /healthz path still works — useful for smoke testing
 	// the binary without a real WorkOS tenant.
@@ -146,9 +155,15 @@ func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
 	if err != nil {
 		log.Fatalf("ingest: db open: %s", redactToken(err.Error(), tok))
 	}
-	if err := db.Migrate(ctx, database); err != nil {
-		_ = database.Close()
-		log.Fatalf("ingest: db migrate: %s", redactToken(err.Error(), tok))
+	// Migrate on boot only for a local SQLite database (dev ergonomics). A
+	// remote libsql/Turso database is migrated out of band by `server -migrate`
+	// (the Fly release_command), so a migration failure aborts the deploy rather
+	// than crash-looping the serving process.
+	if !db.IsRemote(cfg.DatabaseURL) {
+		if err := db.Migrate(ctx, database); err != nil {
+			_ = database.Close()
+			log.Fatalf("ingest: db migrate: %s", redactToken(err.Error(), tok))
+		}
 	}
 
 	var extractor extract.Extractor = extract.Disabled{}
@@ -165,6 +180,40 @@ func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
 
 	poster := digest.NewHTTPPoster(cfg.SlackWebhookURL)
 	return ingest.New(cfg, store.New(database), extractor, poster), database
+}
+
+// migrateRequested reports whether the process was asked to apply migrations and
+// exit (server -migrate), used by the Fly release_command. It scans args rather
+// than using the flag package so it stays correct however the container
+// ENTRYPOINT composes with the release command.
+func migrateRequested(args []string) bool {
+	for _, a := range args {
+		if a == "-migrate" || a == "--migrate" {
+			return true
+		}
+	}
+	return false
+}
+
+// runMigrate opens DATABASE_URL, applies the embedded migrations, and returns.
+// Invoked via `server -migrate` from the Fly release_command; it needs only
+// DATABASE_URL (not the rest of the ingest config). Any failure is fatal, which
+// makes the release step — and therefore the deploy — fail loudly.
+func runMigrate(ctx context.Context) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		log.Fatalf("migrate: DATABASE_URL is empty")
+	}
+	tok := authTokenOf(dbURL)
+	database, err := db.Open(dbURL)
+	if err != nil {
+		log.Fatalf("migrate: db open: %s", redactToken(err.Error(), tok))
+	}
+	defer func() { _ = database.Close() }()
+	if err := db.Migrate(ctx, database); err != nil {
+		log.Fatalf("migrate: %s", redactToken(err.Error(), tok))
+	}
+	log.Printf("migrate: schema up to date")
 }
 
 // handleMe returns the validated claims for the authenticated user. Light

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,14 @@
 app = "codeselfstudy"
 primary_region = "iad"
 
+[deploy]
+  # Apply database migrations once per deploy, in a temporary machine, before the
+  # new version serves traffic. `server -migrate` opens DATABASE_URL, runs the
+  # embedded goose migrations, and exits; if it fails the deploy is aborted and
+  # the previous version keeps serving instead of crash-looping. Migrations are
+  # idempotent, so this is a no-op when the schema is already current.
+  release_command = "/server -migrate"
+
 [http_service]
   internal_port = 8080
   force_https = true


### PR DESCRIPTION
Implements #281.

## The bug

The email-ingest pipeline migrates its schema with goose on startup. Against real Turso the app crash-loops at boot:

```
db migrate: ... create version table: sql: connection is already closed; sql: connection is already closed
```

`log.Fatalf` fires before `e.Start(":8080")`, so fly-proxy reports "instance refused connection." Root cause: prod `DATABASE_URL=libsql://…turso.io` is served over the HTTP (hranaV2) transport, where each connection is a server-side stream Turso closes when idle. goose's **Provider** API runs the whole migration on ONE dedicated `*sql.Conn`; a dedicated conn gets no `database/sql` retry, so when Turso drops its stream the first probe/DDL dies with `ErrConnDone`.

## The fix

**Part 1 — switch to goose's legacy API.** `db.Migrate` now uses `goose.SetBaseFS` + `goose.UpContext`, which issue every statement on the pooled `*sql.DB`, where `database/sql` transparently retries `driver.ErrBadConn` on a fresh connection. That is the whole fix for the crash. The libsql branch of `Open` also caps the pool at one connection.

**Part 2 — decouple migrations from the web boot.** New `db.IsRemote`; the server migrates on boot only for a local SQLite database and skips it for libsql. A new `server -migrate` flag runs migrations and exits, wired as a Fly `[deploy] release_command`. A migration failure now aborts the deploy and keeps the previous version serving, instead of crash-looping.

## Verified against real Turso ✅

Reproduced and fixed against a **live throwaway Turso database** (local `sqld` cannot reproduce it — it keeps the stream alive, so the earlier local-only checks gave false confidence):

- **Reproduced**: the pre-fix code fails on real Turso with the exact production error.
- **Fixed**: the new code migrates a cold-start database — both `00001` and `00002` apply — and is idempotent, via both `cmd/migrate up` and the `server -migrate` release path. All expected tables (`emails`, `deals`, `digests`, `goose_db_version`) land.
- The review's concern that the `00002` DDL might still fail is **resolved**: it applies cleanly under the legacy API, so the migration files need no changes.

Also: `go test -race ./...`, `go vet ./...`, and `CGO_ENABLED=0 GOOS=linux go build .` all green; the Docker image builds and `/server -migrate` works in the distroless image (migrate-mode, not server) with normal boot still serving `/healthz` 204; source-verified code review.

## Scope

Targets `feature/email-deals-ingest`. The feature→astro-experiment→main merges and the production deploy remain the maintainer's call.
