### PR TITLE
Honor TURSO_AUTH_TOKEN so the Turso deploy authenticates

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -21,5 +21,9 @@ REPOST_AFTER=1080h
 
 JWT_SECRET=
 
-# Prod: DATABASE_URL is a Turso URL with the auth token in the query string.
+# Prod: DATABASE_URL is a Turso URL. Embed the auth token in the query string,
+# or set it separately as TURSO_AUTH_TOKEN (then DATABASE_URL can be tokenless):
 # DATABASE_URL=libsql://<db>.turso.io?authToken=<token>
+# — or —
+# DATABASE_URL=libsql://<db>.turso.io
+# TURSO_AUTH_TOKEN=<token>

--- a/apps/api/cmd/migrate/main.go
+++ b/apps/api/cmd/migrate/main.go
@@ -42,7 +42,7 @@ func main() {
 		return
 	}
 
-	dbURL := os.Getenv("DATABASE_URL")
+	dbURL := db.ResolveURL(os.Getenv("DATABASE_URL"), os.Getenv("TURSO_AUTH_TOKEN"))
 	if dbURL == "" {
 		log.Fatal("DATABASE_URL is empty")
 	}

--- a/apps/api/internal/db/db.go
+++ b/apps/api/internal/db/db.go
@@ -5,14 +5,16 @@
 // the pure-Go Turso client (github.com/tursodatabase/libsql-client-go); anything
 // else — a bare path, dev.db, :memory:, file:… — uses the pure-Go
 // modernc.org/sqlite driver. Both are CGO-free, so the distroless runtime image
-// stays static (CGO_ENABLED=0). The Turso auth token travels inside the URL as
-// ?authToken=…; there is no separate token env var.
+// stays static (CGO_ENABLED=0). The Turso auth token may travel inside the URL
+// as ?authToken=…, or be supplied separately as TURSO_AUTH_TOKEN and merged in by
+// ResolveURL (matching Turso's own TURSO_AUTH_TOKEN convention).
 package db
 
 import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	// Database drivers, registered for their side effects.
@@ -99,4 +101,28 @@ func driverFor(databaseURL string) string {
 // aborts a deploy instead of crash-looping the serving process.
 func IsRemote(databaseURL string) bool {
 	return driverFor(databaseURL) == "libsql"
+}
+
+// ResolveURL returns rawURL with tursoAuthToken applied as an ?authToken= query
+// parameter, but only when rawURL is a remote libsql URL (see IsRemote) that
+// carries no token of its own and tursoAuthToken is non-empty. It returns rawURL
+// unchanged otherwise: a local SQLite path, an empty URL, or a URL that already
+// has an authToken/auth_token/jwt parameter (the embedded token wins). This lets
+// the Turso auth token be supplied either inside DATABASE_URL or as a separate
+// TURSO_AUTH_TOKEN, matching Turso's own convention.
+func ResolveURL(rawURL, tursoAuthToken string) string {
+	if tursoAuthToken == "" || !IsRemote(rawURL) {
+		return rawURL
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL // leave it for Open to surface the parse error
+	}
+	q := u.Query()
+	if q.Get("authToken") != "" || q.Get("auth_token") != "" || q.Get("jwt") != "" {
+		return rawURL // an explicit token in the URL takes precedence
+	}
+	q.Set("authToken", tursoAuthToken)
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/apps/api/internal/db/db_test.go
+++ b/apps/api/internal/db/db_test.go
@@ -126,3 +126,28 @@ func TestMigrateAgainstLibsql(t *testing.T) {
 		t.Fatalf("second migrate (idempotent): %v", err)
 	}
 }
+
+func TestResolveURL(t *testing.T) {
+	const tok = "tok123"
+	cases := []struct {
+		name, rawURL, token, want string
+	}{
+		{"bare libsql gets token", "libsql://db.turso.io", tok, "libsql://db.turso.io?authToken=tok123"},
+		{"https gets token", "https://db.turso.io", tok, "https://db.turso.io?authToken=tok123"},
+		{"embedded authToken wins", "libsql://db.turso.io?authToken=abc", tok, "libsql://db.turso.io?authToken=abc"},
+		{"embedded auth_token wins", "libsql://db.turso.io?auth_token=abc", tok, "libsql://db.turso.io?auth_token=abc"},
+		{"local sqlite path unchanged", "dev.db", tok, "dev.db"},
+		{"memory unchanged", ":memory:", tok, ":memory:"},
+		{"empty url unchanged", "", tok, ""},
+		{"empty token unchanged", "libsql://db.turso.io", "", "libsql://db.turso.io"},
+		{"embedded jwt wins", "libsql://db.turso.io?jwt=abc", tok, "libsql://db.turso.io?jwt=abc"},
+		{"preserves other query params", "libsql://db.turso.io?foo=bar", tok, "libsql://db.turso.io?authToken=tok123&foo=bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveURL(tc.rawURL, tc.token); got != tc.want {
+				t.Fatalf("ResolveURL(%q, %q) = %q, want %q", tc.rawURL, tc.token, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -150,8 +150,9 @@ func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
 		return nil, nil
 	}
 
-	tok := authTokenOf(cfg.DatabaseURL)
-	database, err := db.Open(cfg.DatabaseURL)
+	dbURL := db.ResolveURL(cfg.DatabaseURL, os.Getenv("TURSO_AUTH_TOKEN"))
+	tok := authTokenOf(dbURL)
+	database, err := db.Open(dbURL)
 	if err != nil {
 		log.Fatalf("ingest: db open: %s", redactToken(err.Error(), tok))
 	}
@@ -159,7 +160,7 @@ func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
 	// remote libsql/Turso database is migrated out of band by `server -migrate`
 	// (the Fly release_command), so a migration failure aborts the deploy rather
 	// than crash-looping the serving process.
-	if !db.IsRemote(cfg.DatabaseURL) {
+	if !db.IsRemote(dbURL) {
 		if err := db.Migrate(ctx, database); err != nil {
 			_ = database.Close()
 			log.Fatalf("ingest: db migrate: %s", redactToken(err.Error(), tok))
@@ -200,7 +201,7 @@ func migrateRequested(args []string) bool {
 // DATABASE_URL (not the rest of the ingest config). Any failure is fatal, which
 // makes the release step — and therefore the deploy — fail loudly.
 func runMigrate(ctx context.Context) {
-	dbURL := os.Getenv("DATABASE_URL")
+	dbURL := db.ResolveURL(os.Getenv("DATABASE_URL"), os.Getenv("TURSO_AUTH_TOKEN"))
 	if dbURL == "" {
 		log.Fatalf("migrate: DATABASE_URL is empty")
 	}

--- a/env.local.example
+++ b/env.local.example
@@ -14,8 +14,12 @@ VITE_WORKOS_API_HOSTNAME=api.workos.com
 
 # Local SQLite file for the migrate CLI (apps/api/cmd/migrate), tests, and —
 # when the email-ingest pipeline is enabled (see below) — the runtime server.
-# In production this is a Turso URL: libsql://<db>.turso.io?authToken=<token>.
+# In production this is a Turso URL. Embed the auth token in the query string
+# (libsql://<db>.turso.io?authToken=<token>) or set it separately as
+# TURSO_AUTH_TOKEN, in which case a bare libsql://<db>.turso.io works too.
 DATABASE_URL="dev.db"
+# Prod only: Turso auth token, when not embedded in DATABASE_URL above.
+# TURSO_AUTH_TOKEN=<token>
 WORKOS_API_KEY=get_this_from_workos
 
 

--- a/manual/src/getting-started.md
+++ b/manual/src/getting-started.md
@@ -46,7 +46,7 @@ GEMINI_API_KEY=""
 SLACK_WEBHOOK_FOR_DEALS_CHANNEL=""
 ```
 
-`DATABASE_URL` is used by the migrate CLI in `apps/api/cmd/migrate`, by tests, and — when the email-ingest pipeline is enabled — by the runtime server. In production it is a Turso URL (`libsql://<db>.turso.io?authToken=<token>`).
+`DATABASE_URL` is used by the migrate CLI in `apps/api/cmd/migrate`, by tests, and — when the email-ingest pipeline is enabled — by the runtime server. In production it is a Turso URL (`libsql://<db>.turso.io?authToken=<token>`). The auth token may instead be supplied separately as `TURSO_AUTH_TOKEN` (Turso's own convention), in which case `DATABASE_URL` can be a bare `libsql://<db>.turso.io`.
 
 The email-ingest pipeline (the `apps/email_receiver` Worker → `/api/ingest` → Turso → Slack) is opt-in: it runs only when `DATABASE_URL` and `INGEST_TOKEN` are both set, and extraction additionally needs `GEMINI_API_KEY`. See [Architecture](./architecture.md#email--deals--slack) for the full flow.
 


### PR DESCRIPTION
Implements #283. Follow-up to #282.

## The problem

After #282 fixed the migrate crash-loop, the Fly `release_command` (`/server -migrate`) ran and reached SQL execution, but Turso rejected it:

```
error code 401: Unauthorized: `unauthorized access attempt on database: empty JWT token`
```

The app has a separate `TURSO_AUTH_TOKEN` secret (Turso's own convention), but this code reads the token **only** from the `DATABASE_URL` query string (`?authToken=`). With a bare `libsql://…` `DATABASE_URL`, the driver sent an empty token → 401.

## The fix

`db.ResolveURL(rawURL, tursoAuthToken)`: when `DATABASE_URL` is a remote libsql URL with no embedded token, apply `TURSO_AUTH_TOKEN` as `?authToken=`. Applied at the three env boundaries that open the database — `runMigrate`, `newIngestFromEnv` (`main.go`), and `cmd/migrate`. An embedded token still wins, so existing `DATABASE_URL=libsql://…?authToken=…` setups are unchanged. `internal/ingest/config.go` stays a pure env reader.

## Verified against real Turso ✅

On a throwaway Turso database configured exactly like prod (bare `DATABASE_URL` + separate `TURSO_AUTH_TOKEN`):

- `server -migrate` migrates a cold-start database (`00001` + `00002`); all tables land.
- The **distroless container** running `/server -migrate` — the exact Fly `release_command` path — migrates it too.
- The embedded-token form (`?authToken=`) still authenticates (backward compatible).

Plus `TestResolveURL`, `go test ./...`, `go vet ./...`, and `CGO_ENABLED=0 GOOS=linux go build .` all green.

## For the maintainer

After this lands and deploys, `TURSO_AUTH_TOKEN` alone is enough — no need to also embed the token in `DATABASE_URL`.

Targets `feature/email-deals-ingest`.
