### PR TITLE
Redact Turso auth token from migrate CLI error logs

### DIFF
--- a/apps/api/cmd/migrate/main.go
+++ b/apps/api/cmd/migrate/main.go
@@ -46,16 +46,19 @@ func main() {
 	if dbURL == "" {
 		log.Fatal("DATABASE_URL is empty")
 	}
+	// dbURL may carry a Turso ?authToken=… (merged in by ResolveURL), so every
+	// fatal that logs a DB error runs it through db.RedactToken first — the same
+	// redaction the server's own db-open/migrate paths use (see main.go).
 	conn, err := db.Open(dbURL)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(db.RedactToken(err.Error(), dbURL))
 	}
 	defer conn.Close()
 
 	switch cmd {
 	case "up":
 		if err := db.Migrate(context.Background(), conn); err != nil {
-			log.Fatal(err)
+			log.Fatal(db.RedactToken(err.Error(), dbURL))
 		}
 	case "down":
 		// Drop one migration. Useful for dev only — never run against a
@@ -64,14 +67,14 @@ func main() {
 			log.Fatal(err)
 		}
 		if err := goose.Down(conn, migrationsDir()); err != nil {
-			log.Fatal(err)
+			log.Fatal(db.RedactToken(err.Error(), dbURL))
 		}
 	case "status":
 		if err := goose.SetDialect("sqlite3"); err != nil {
 			log.Fatal(err)
 		}
 		if err := goose.Status(conn, migrationsDir()); err != nil {
-			log.Fatal(err)
+			log.Fatal(db.RedactToken(err.Error(), dbURL))
 		}
 	default:
 		usage()

--- a/apps/api/internal/db/db.go
+++ b/apps/api/internal/db/db.go
@@ -126,3 +126,34 @@ func ResolveURL(rawURL, tursoAuthToken string) string {
 	u.RawQuery = q.Encode()
 	return u.String()
 }
+
+// authTokenOf extracts the authToken query value from a libsql DATABASE_URL, or
+// "" if absent. ResolveURL always injects the token as authToken=…, so matching
+// that single key covers every URL this package hands to Open — the token that
+// RedactToken needs to keep out of a logged error.
+func authTokenOf(dbURL string) string {
+	const key = "authToken="
+	i := strings.Index(dbURL, key)
+	if i < 0 {
+		return ""
+	}
+	v := dbURL[i+len(key):]
+	if amp := strings.IndexByte(v, '&'); amp >= 0 {
+		v = v[:amp]
+	}
+	return v
+}
+
+// RedactToken returns s with the Turso authToken carried in dbURL replaced by
+// "***". A libsql driver error can embed the full connection URL including
+// ?authToken=<token>; redacting the opaque token keeps the useful cause
+// (dial/connect/auth failure) in the log while keeping the secret out of it.
+// Pass the same (already ResolveURL-merged) dbURL that was handed to Open so the
+// injected token is caught. A no-op when dbURL carries no authToken.
+func RedactToken(s, dbURL string) string {
+	tok := authTokenOf(dbURL)
+	if tok == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, tok, "***")
+}

--- a/apps/api/internal/db/db_test.go
+++ b/apps/api/internal/db/db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -149,5 +150,40 @@ func TestResolveURL(t *testing.T) {
 				t.Fatalf("ResolveURL(%q, %q) = %q, want %q", tc.rawURL, tc.token, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRedactToken(t *testing.T) {
+	const url = "libsql://db.turso.io?authToken=SUPERSECRET123"
+
+	// authTokenOf pulls the injected token back out of a resolved URL, and is
+	// empty for a URL that carries none.
+	if tok := authTokenOf(url); tok != "SUPERSECRET123" {
+		t.Fatalf("authTokenOf = %q, want SUPERSECRET123", tok)
+	}
+	if tok := authTokenOf("libsql://db.turso.io?authToken=SUPERSECRET123&mode=ro"); tok != "SUPERSECRET123" {
+		t.Fatalf("authTokenOf with trailing param = %q, want SUPERSECRET123", tok)
+	}
+	if authTokenOf("file:./dev.db") != "" {
+		t.Error("authTokenOf should be empty for a local file URL")
+	}
+
+	// A driver error embedding the URL must come out with the token redacted but
+	// the useful cause intact.
+	errStr := `db: ping: dial ` + url + `: connection refused`
+	got := RedactToken(errStr, url)
+	if strings.Contains(got, "SUPERSECRET123") {
+		t.Errorf("RedactToken left the token: %q", got)
+	}
+	if !strings.Contains(got, "connection refused") {
+		t.Errorf("RedactToken dropped the cause: %q", got)
+	}
+
+	// No token in the URL → nothing to redact (local sqlite path, empty URL).
+	if RedactToken("plain error", "file:./dev.db") != "plain error" {
+		t.Error("RedactToken with a tokenless URL should be a no-op")
+	}
+	if RedactToken("plain error", "") != "plain error" {
+		t.Error("RedactToken with an empty URL should be a no-op")
 	}
 }

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -108,32 +108,6 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-// authTokenOf extracts the authToken query value from a libsql DATABASE_URL, or
-// "" if absent. Used to redact the token from database errors before logging.
-func authTokenOf(dbURL string) string {
-	const key = "authToken="
-	i := strings.Index(dbURL, key)
-	if i < 0 {
-		return ""
-	}
-	v := dbURL[i+len(key):]
-	if amp := strings.IndexByte(v, '&'); amp >= 0 {
-		v = v[:amp]
-	}
-	return v
-}
-
-// redactToken replaces every occurrence of token in s with "***". A libsql
-// driver error can embed the full connection URL including ?authToken=<token>;
-// redacting the opaque token keeps the useful cause (dial/connect/auth failure)
-// in the log while keeping the secret out of it. A no-op when token is "".
-func redactToken(s, token string) string {
-	if token == "" {
-		return s
-	}
-	return strings.ReplaceAll(s, token, "***")
-}
-
 // newIngestFromEnv builds the email-ingest handlers from the environment. It
 // returns (nil, nil) when the pipeline is not configured (no DATABASE_URL /
 // INGEST_TOKEN), so the server still runs static-only — mirroring the WorkOS
@@ -151,10 +125,9 @@ func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
 	}
 
 	dbURL := db.ResolveURL(cfg.DatabaseURL, os.Getenv("TURSO_AUTH_TOKEN"))
-	tok := authTokenOf(dbURL)
 	database, err := db.Open(dbURL)
 	if err != nil {
-		log.Fatalf("ingest: db open: %s", redactToken(err.Error(), tok))
+		log.Fatalf("ingest: db open: %s", db.RedactToken(err.Error(), dbURL))
 	}
 	// Migrate on boot only for a local SQLite database (dev ergonomics). A
 	// remote libsql/Turso database is migrated out of band by `server -migrate`
@@ -163,7 +136,7 @@ func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
 	if !db.IsRemote(dbURL) {
 		if err := db.Migrate(ctx, database); err != nil {
 			_ = database.Close()
-			log.Fatalf("ingest: db migrate: %s", redactToken(err.Error(), tok))
+			log.Fatalf("ingest: db migrate: %s", db.RedactToken(err.Error(), dbURL))
 		}
 	}
 
@@ -205,14 +178,13 @@ func runMigrate(ctx context.Context) {
 	if dbURL == "" {
 		log.Fatalf("migrate: DATABASE_URL is empty")
 	}
-	tok := authTokenOf(dbURL)
 	database, err := db.Open(dbURL)
 	if err != nil {
-		log.Fatalf("migrate: db open: %s", redactToken(err.Error(), tok))
+		log.Fatalf("migrate: db open: %s", db.RedactToken(err.Error(), dbURL))
 	}
 	defer func() { _ = database.Close() }()
 	if err := db.Migrate(ctx, database); err != nil {
-		log.Fatalf("migrate: %s", redactToken(err.Error(), tok))
+		log.Fatalf("migrate: %s", db.RedactToken(err.Error(), dbURL))
 	}
 	log.Printf("migrate: schema up to date")
 }

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -239,30 +239,6 @@ func TestIngestRouteWiredWhenEnabled(t *testing.T) {
 	}
 }
 
-func TestRedactToken(t *testing.T) {
-	url := "libsql://db.turso.io?authToken=SUPERSECRET123"
-	tok := authTokenOf(url)
-	if tok != "SUPERSECRET123" {
-		t.Fatalf("authTokenOf = %q, want SUPERSECRET123", tok)
-	}
-	// A driver error embedding the URL must come out with the token redacted but
-	// the useful cause intact.
-	errStr := `db: ping: dial libsql://db.turso.io?authToken=SUPERSECRET123: connection refused`
-	got := redactToken(errStr, tok)
-	if strings.Contains(got, "SUPERSECRET123") {
-		t.Errorf("redactToken left the token: %q", got)
-	}
-	if !strings.Contains(got, "connection refused") {
-		t.Errorf("redactToken dropped the cause: %q", got)
-	}
-	if authTokenOf("file:./dev.db") != "" {
-		t.Error("authTokenOf should be empty for a local file URL")
-	}
-	if redactToken("plain error", "") != "plain error" {
-		t.Error("redactToken with empty token should be a no-op")
-	}
-}
-
 func TestIngestRouteAbsentWhenDisabled(t *testing.T) {
 	// With no ingest handler, POST /api/ingest falls through to the /api/* JSON
 	// 404 reservation (the pipeline is disabled).


### PR DESCRIPTION
## What

`cmd/migrate` injects `TURSO_AUTH_TOKEN` into the DATABASE_URL via `db.ResolveURL` (as `?authToken=…`), but logged `db.Open` / `db.Migrate` / `down` / `status` failures with a bare `log.Fatal(err)`. A libsql driver error can embed that URL, so the token could reach the logs. The server (`main.go`) already redacts this (the pattern from #267); `cmd/migrate` was the odd one out.

Verified-safe today — the `libsql-client-go` driver carries the token in the `Authorization: Bearer` header, not the request URL string — so this is defense-in-depth / consistency, not a live leak. Low priority.

## Changes

- **`internal/db`**: new exported `RedactToken(s, dbURL string) string` (+ private `authTokenOf`) — a single source of truth. Extracts the injected `authToken=` value and replaces it with `***`; a no-op when the URL carries no token.
- **`cmd/migrate`**: all four DB-operation fatals (Open, Migrate, Down, Status) run their error through `db.RedactToken`. The `SetDialect` fatals stay bare (no URL/token in a dialect error).
- **`main.go`**: deleted the local `authTokenOf` / `redactToken`; `newIngestFromEnv` and `runMigrate` now delegate to `db.RedactToken`. Behavior is identical — the redaction (a security fix) is preserved.
- **Tests**: `TestRedactToken` moved into the `db` package (in-package, so it also covers the private `authTokenOf`, including the `&`-trailing-param case); removed from `main_test.go`.

## Verification

`cd apps/api && go build ./... && go vet ./... && go test ./...` — all green.
