### PR TITLE
Render digest timestamps in California time

### DIFF
--- a/apps/api/internal/digest/blocks.go
+++ b/apps/api/internal/digest/blocks.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 	"time"
 
+	// tzdata embeds the IANA time-zone database into the binary. The production
+	// runtime is a CGO_ENABLED=0 distroless image with no system zoneinfo, so
+	// without this LoadLocation("America/Los_Angeles") would fail there (it
+	// succeeds on a dev machine with system zoneinfo). Importing it in this
+	// package keeps the digest — and its tests — self-contained.
+	_ "time/tzdata"
+
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
 )
 
@@ -15,6 +22,20 @@ import (
 // queued for the next one. Slack also limits a message to 50 blocks, and each
 // deal uses two (section + divider), so 25 keeps us well under that.
 const MaxDealsPerDigest = 25
+
+// pacific is the location for the digest footer timestamp. The deals are curated
+// for a California audience, so the footer reads Pacific time (PST/PDT) instead
+// of UTC. It is resolved once; if the tz database can't be read it falls back to
+// UTC, so a lookup failure degrades the label rather than breaking the digest.
+var pacific = loadPacific()
+
+func loadPacific() *time.Location {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}
 
 // Slack Block Kit payload types (only the subset we emit).
 type payload struct {
@@ -73,7 +94,7 @@ func BuildBlocks(deals []store.Deal, now time.Time) ([]byte, error) {
 	}
 	blocks = append(blocks, contextBlock{
 		Type:     "context",
-		Elements: []textObject{{Type: "mrkdwn", Text: "deal-digest · " + now.UTC().Format("2006-01-02 15:04 MST")}},
+		Elements: []textObject{{Type: "mrkdwn", Text: "deal-digest · " + now.In(pacific).Format("2006-01-02 15:04 MST")}},
 	})
 
 	return json.MarshalIndent(payload{Blocks: blocks}, "", "  ")

--- a/apps/api/internal/digest/blocks_test.go
+++ b/apps/api/internal/digest/blocks_test.go
@@ -53,6 +53,35 @@ func TestBuildBlocksGolden(t *testing.T) {
 	}
 }
 
+func TestBuildBlocksFooterPacific(t *testing.T) {
+	// The footer renders Pacific time, not UTC, and picks up the right DST label:
+	// a summer instant is PDT, a winter instant is PST. tzdata is embedded (see
+	// blocks.go) so this resolves the same on a dev machine and in the distroless
+	// runtime.
+	cases := []struct {
+		name string
+		now  time.Time
+		want string
+	}{
+		{"summer PDT", time.Date(2026, 7, 20, 14, 2, 0, 0, time.UTC), "deal-digest · 2026-07-20 07:02 PDT"},
+		{"winter PST", time.Date(2026, 1, 15, 8, 30, 0, 0, time.UTC), "deal-digest · 2026-01-15 00:30 PST"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BuildBlocks([]store.Deal{{Title: "X"}}, tc.now)
+			if err != nil {
+				t.Fatalf("BuildBlocks: %v", err)
+			}
+			if !strings.Contains(string(got), tc.want) {
+				t.Errorf("footer missing %q in\n%s", tc.want, got)
+			}
+			if strings.Contains(string(got), " UTC") {
+				t.Errorf("footer still renders UTC:\n%s", got)
+			}
+		})
+	}
+}
+
 func TestBuildBlocksOverflow(t *testing.T) {
 	deals := make([]store.Deal, 30)
 	for i := range deals {

--- a/apps/api/internal/digest/testdata/golden_blocks.json
+++ b/apps/api/internal/digest/testdata/golden_blocks.json
@@ -42,7 +42,7 @@
       "elements": [
         {
           "type": "mrkdwn",
-          "text": "deal-digest · 2026-07-20 14:02 UTC"
+          "text": "deal-digest · 2026-07-20 07:02 PDT"
         }
       ]
     }


### PR DESCRIPTION
The Slack deal-digest footer rendered UTC (e.g. `deal-digest · 2026-07-22 06:20 UTC`). This switches it to Pacific time so it matches the audience — the `MST` layout token prints `PST`/`PDT` automatically per DST.

## Changes
- `internal/digest/blocks.go`: resolve `America/Los_Angeles` once (falls back to UTC on error, so a lookup failure degrades the label rather than breaking the digest) and format `now.In(pacific)`.
- Blank `_ "time/tzdata"` import in the `digest` package: the production runtime is a `CGO_ENABLED=0` distroless image with **no system zoneinfo**, so the IANA tz database is embedded into the binary. Keeping the import in this package makes the digest — and its tests — self-contained.
- Tests: golden fixture regenerated (`… 07:02 PDT`); new `TestBuildBlocksFooterPacific` asserts both DST states (summer PDT, winter PST) and that the footer is no longer UTC.

## Verification
- `go test ./... && go vet ./...` green.
- `CGO_ENABLED=0 go build .` succeeds (the distroless build flag).

Closes #289