### PR TITLE
Correct the manual's migration model in the docs

### DIFF
--- a/manual/src/architecture.md
+++ b/manual/src/architecture.md
@@ -52,7 +52,7 @@ The Go-side auth is opt-in: if `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` (or th
 ## Database
 
 - Pure-Go drivers only, so the distroless image stays static: `modernc.org/sqlite` for local files and `:memory:`, and `tursodatabase/libsql-client-go` for remote Turso. `internal/db.Open` selects the driver by `DATABASE_URL` scheme (`libsql://` / `http(s)` / `ws(s)` → Turso; anything else → SQLite). The Turso auth token rides in the URL as `?authToken=…`.
-- **Schema is owned by Go.** Migrations live in `apps/api/internal/db/migrations/` as goose `.sql` files, are embedded into the binary via `//go:embed`, and apply on every startup. Goose tracks state in its own table, so re-running is a no-op.
+- **Schema is owned by Go.** Migrations live in `apps/api/internal/db/migrations/` as goose `.sql` files and are embedded into the binary via `//go:embed`. A local SQLite database is migrated on boot; a remote Turso database is migrated out of band by `server -migrate`, which Fly runs as the `[deploy] release_command` once per deploy before the new version serves traffic (see [Deployment](./deployment.md#migrations)). Goose tracks state in its own table, so re-running is a no-op.
 - For dev: `just db_migrate`, `just db_status`, `just db_down`, `just db_create <name>` wrap a small CLI in `apps/api/cmd/migrate`.
 
 ## Email → deals → Slack

--- a/manual/src/deployment.md
+++ b/manual/src/deployment.md
@@ -6,7 +6,7 @@ The deployed app is a single Go binary that serves the prerendered web app, the 
 
 - `apps/web/dist/` — prerendered HTML/CSS/JS produced by `bun run build`. Built locally so Fly's remote builder doesn't re-run `bun install` (~10 min on a cold cache).
 - `apps/api/static/` — copy of `apps/web/dist/` mirrored by `just build` so the Go binary serves it.
-- `server` (the Go binary) — Echo + middleware + auth + DB; embeds goose migrations and applies them on startup.
+- `server` (the Go binary) — Echo + middleware + auth + DB; embeds the goose migrations and applies them via the deploy's release command (see [Migrations](#migrations)).
 
 ## Docker image
 
@@ -32,7 +32,9 @@ just deploy
 
 ## Migrations
 
-Goose migrations live in `apps/api/internal/db/migrations/` and are embedded into the binary via `//go:embed`. The server applies pending migrations on startup, so a deploy that introduces a new migration applies it automatically the first time the new binary boots. There is no separate migration step in the deploy pipeline.
+Goose migrations live in `apps/api/internal/db/migrations/` and are embedded into the binary via `//go:embed`. In production they are applied by a dedicated deploy step, not on server startup: `fly.toml` sets `[deploy] release_command = "/server -migrate"`, so Fly runs `server -migrate` once per deploy in a temporary machine before the new version serves traffic. If it fails, the release command fails — which aborts the deploy and leaves the previous version serving, rather than crash-looping the new one. Migrations are idempotent (goose tracks state in its own table), so the step is a no-op when the schema is already current.
+
+The one exception is a local SQLite database, which the server migrates on boot as a dev convenience; a remote Turso database is always migrated out of band by the release command.
 
 For ad-hoc runs against a local DB:
 

--- a/manual/src/getting-started.md
+++ b/manual/src/getting-started.md
@@ -52,9 +52,7 @@ The email-ingest pipeline (the `apps/email_receiver` Worker â†’ `/api/ingest` â†
 
 ## Database Tasks
 
-The Go side owns the schema. Migrations live under
-`apps/api/internal/db/migrations/` and are applied on server startup, so most
-of the time you don't need to run anything.
+The Go side owns the schema. Migrations live under `apps/api/internal/db/migrations/`. A local database is migrated automatically on server startup, so most of the time you don't need to run anything; in production a remote Turso database is migrated by the deploy's release command instead (see [Deployment](./deployment.md#migrations)).
 
 ```bash
 just db_status               # show which migrations have been applied

--- a/manual/src/project-structure.md
+++ b/manual/src/project-structure.md
@@ -23,7 +23,7 @@ Inside `apps/api/`:
 - `cmd/migrate/`: small CLI around goose for ad-hoc migration runs.
 - `internal/auth/`: WorkOS JWKS verifier + Echo middleware.
 - `internal/db/`: SQLite / Turso access (driver chosen by `DATABASE_URL` scheme).
-- `internal/db/migrations/`: goose `.sql` migrations, embedded into the binary and applied on startup.
+- `internal/db/migrations/`: goose `.sql` migrations, embedded into the binary and applied by the deploy's release command (on boot for a local SQLite DB).
 - `internal/ingest/`: the `/api/ingest` + `/api/admin/digest` handlers, bearer-token middleware, and pipeline config.
 - `internal/store/`: emails/deals/digests persistence and the once-per-interval digest claim.
 - `internal/mailparse/`, `internal/htmltext/`: raw MIME → normalized text.


### PR DESCRIPTION
The email-ingest work moved production migrations to a Fly release command (`server -migrate`, run as `[deploy] release_command`), but the manual still described the old behavior — "the server applies pending migrations on startup … there is no separate migration step in the deploy pipeline."

That's now inaccurate. Per `apps/api/main.go` (lines ~132–141 and `runMigrate`) and `fly.toml`:
- a **remote / Turso** database is migrated **out of band** by `server -migrate`, which Fly runs as the release command once per deploy, before the new version serves traffic (a failure aborts the deploy instead of crash-looping);
- only a **local SQLite** database is migrated **on boot**, as a dev convenience.

## Changed
- `deployment.md` — the `server` bullet + the **Migrations** section.
- `architecture.md` — the **Database** "schema is owned by Go" bullet.
- `project-structure.md` — the `internal/db/migrations/` line.
- `getting-started.md` — the **Database Tasks** intro.

Docs-only; `manual/book/` is gitignored build output and is untouched.