### PR TITLE
Add @workos-inc/authkit-react + type WorkOS client env vars

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@workos-inc/authkit-react": "0.16.1",
     "astro": "7.1.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="astro/client" />
+
+// Client-exposed WorkOS config (see .env-example). Vite inlines VITE_-prefixed
+// variables into the browser bundle; declaring them here gives
+// `import.meta.env.VITE_*` autocomplete and type-checking. The Go server reads
+// the same pair as its WORKOS_CLIENT_ID / WORKOS_API_HOSTNAME fallbacks to
+// verify the JWTs these produce.
+interface ImportMetaEnv {
+  readonly VITE_WORKOS_CLIENT_ID: string;
+  readonly VITE_WORKOS_API_HOSTNAME: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "@tailwindcss/vite": "^4.3.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@workos-inc/authkit-react": "0.16.1",
         "astro": "7.1.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
@@ -659,6 +660,10 @@
     "@vscode/emmet-helper": ["@vscode/emmet-helper@2.11.0", "", { "dependencies": { "emmet": "^2.4.3", "jsonc-parser": "^2.3.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.15.1", "vscode-uri": "^3.0.8" } }, "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw=="],
 
     "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
+
+    "@workos-inc/authkit-js": ["@workos-inc/authkit-js@0.20.0", "", {}, "sha512-8+sw8eH1+XCt3NDoIB2bKKbHvq1N7CVFJeyq1uVrUWG83GCIbNNrFwWrocVNfeQJyhKsVVuDpRcp03iSVsK5Gg=="],
+
+    "@workos-inc/authkit-react": ["@workos-inc/authkit-react@0.16.1", "", { "dependencies": { "@workos-inc/authkit-js": "0.20.0" }, "peerDependencies": { "react": ">=17" } }, "sha512-u8IJsAAyZFFM02+3JhvvNTopSNQoJk/hjOoBlmOkh6j+AnVYrR8hjzJn8j3m9Vi5tRE0il7mpsEDT9fI2xRNjg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 


### PR DESCRIPTION
Foundation for client-side WorkOS auth (parent #294).

- `bun add @workos-inc/authkit-react` (v0.16.1) in `apps/web`.
- `apps/web/src/env.d.ts` — declares `VITE_WORKOS_CLIENT_ID` / `VITE_WORKOS_API_HOSTNAME` on `ImportMetaEnv` so `import.meta.env` is typed. The Go server reads the same pair as its `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` fallbacks.

The dependency has no consumer yet — #296 (the `AuthProvider`) is the first to import it.

## Verification
- `bun run build` (astro check + build) passes.

Implements #295. Targets `feature/workos-client-auth` (merges to `main` later, as a set).