### PR TITLE
Port the WorkOS AuthProvider to Astro

### DIFF
--- a/apps/web/src/integrations/workos/AuthProvider.test.tsx
+++ b/apps/web/src/integrations/workos/AuthProvider.test.tsx
@@ -1,17 +1,60 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 
-// AuthKit-react initializes a real WorkOS browser session on mount; stub the
-// provider so this stays a pure render test with no network.
+type CapturedProps = {
+  clientId?: string;
+  apiHostname?: string;
+  children?: ReactNode;
+};
+
+// Capture the props AuthProvider hands to AuthKitProvider without initializing a
+// real WorkOS browser session (AuthKit would otherwise reach the network on
+// mount). vi.hoisted lets the mock factory share this holder.
+const captured = vi.hoisted(() => ({ props: {} as CapturedProps }));
+
 vi.mock("@workos-inc/authkit-react", () => ({
-  AuthKitProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  AuthKitProvider: (props: CapturedProps) => {
+    captured.props = props;
+    return props.children;
+  },
 }));
 
-import AuthProvider from "@/integrations/workos/AuthProvider";
+import AuthProvider, { safeReturnTo } from "@/integrations/workos/AuthProvider";
+
+describe("safeReturnTo", () => {
+  const origin = "https://codeselfstudy.com";
+
+  test("keeps a same-origin path, preserving query and hash", () => {
+    expect(safeReturnTo("/events/", origin)).toBe("/events/");
+    expect(safeReturnTo("/events/?tab=past#top", origin)).toBe(
+      "/events/?tab=past#top"
+    );
+  });
+
+  test("rejects external and protocol-relative targets (open-redirect guard)", () => {
+    expect(safeReturnTo("https://evil.example/phish", origin)).toBeNull();
+    expect(safeReturnTo("//evil.example", origin)).toBeNull();
+  });
+
+  test("rejects empty or missing values", () => {
+    expect(safeReturnTo(undefined, origin)).toBeNull();
+    expect(safeReturnTo("", origin)).toBeNull();
+  });
+});
 
 describe("AuthProvider", () => {
-  test("renders its children inside the AuthKit provider", () => {
+  beforeEach(() => {
+    captured.props = {};
+    vi.stubEnv("VITE_WORKOS_CLIENT_ID", "client_test");
+    vi.stubEnv("VITE_WORKOS_API_HOSTNAME", "auth.example.com");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("renders children and wires WorkOS config from the environment", () => {
     render(
       <AuthProvider>
         <span>protected child</span>
@@ -19,5 +62,7 @@ describe("AuthProvider", () => {
     );
 
     expect(screen.getByText("protected child")).toBeInTheDocument();
+    expect(captured.props.clientId).toBe("client_test");
+    expect(captured.props.apiHostname).toBe("auth.example.com");
   });
 });

--- a/apps/web/src/integrations/workos/AuthProvider.test.tsx
+++ b/apps/web/src/integrations/workos/AuthProvider.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+// AuthKit-react initializes a real WorkOS browser session on mount; stub the
+// provider so this stays a pure render test with no network.
+vi.mock("@workos-inc/authkit-react", () => ({
+  AuthKitProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+import AuthProvider from "@/integrations/workos/AuthProvider";
+
+describe("AuthProvider", () => {
+  test("renders its children inside the AuthKit provider", () => {
+    render(
+      <AuthProvider>
+        <span>protected child</span>
+      </AuthProvider>
+    );
+
+    expect(screen.getByText("protected child")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/integrations/workos/AuthProvider.tsx
+++ b/apps/web/src/integrations/workos/AuthProvider.tsx
@@ -1,26 +1,48 @@
 import { AuthKitProvider } from "@workos-inc/authkit-react";
 import type { ReactNode } from "react";
 
+// safeReturnTo resolves a post-sign-in `returnTo` against the current origin and
+// returns a same-origin relative target, or null. `state` round-trips through
+// the WorkOS hosted flow and could be attacker-influenced, so an absolute or
+// protocol-relative external URL (an open-redirect attempt) is rejected, as is a
+// malformed value. Exported for direct testing.
+export function safeReturnTo(
+  returnTo: string | null | undefined,
+  origin: string
+): string | null {
+  if (!returnTo) return null;
+  try {
+    const url = new URL(returnTo, origin);
+    if (url.origin === origin) {
+      return url.pathname + url.search + url.hash;
+    }
+  } catch {
+    // Malformed returnTo — ignore.
+  }
+  return null;
+}
+
 // Client-side WorkOS AuthKit provider, ported from the doolin fork's
 // TanStack-Start version. AuthKit-react is a browser-only SPA integration (PKCE,
 // tokens held in the browser), so this has no server-rendered form and must be
 // mounted inside a `client:only="react"` island.
 //
 // After the hosted sign-in flow redirects back, `onRedirectCallback` returns the
-// user to the page they started from — the `returnTo` that the sign-in call
-// stashed on `state`. The fork navigated with TanStack Router's `useNavigate`;
-// on a static Astro site there is no client router, so a full-page
-// `window.location.assign` is the right equivalent.
+// user to the page they started from — the `returnTo` the sign-in call stashed
+// on `state`. The fork navigated with TanStack Router's `useNavigate`; on a
+// static Astro site there is no client router, so a full-page
+// `window.location.assign` is the equivalent (origin-guarded by safeReturnTo).
 export default function AuthProvider({ children }: { children: ReactNode }) {
   return (
     <AuthKitProvider
       clientId={import.meta.env.VITE_WORKOS_CLIENT_ID}
       apiHostname={import.meta.env.VITE_WORKOS_API_HOSTNAME}
       onRedirectCallback={({ state }) => {
-        const returnTo = (state as { returnTo?: string } | null)?.returnTo;
-        if (returnTo) {
-          window.location.assign(returnTo);
-        }
+        const target = safeReturnTo(
+          (state as { returnTo?: string } | null)?.returnTo,
+          window.location.origin
+        );
+        if (target) window.location.assign(target);
       }}
     >
       {children}

--- a/apps/web/src/integrations/workos/AuthProvider.tsx
+++ b/apps/web/src/integrations/workos/AuthProvider.tsx
@@ -1,0 +1,29 @@
+import { AuthKitProvider } from "@workos-inc/authkit-react";
+import type { ReactNode } from "react";
+
+// Client-side WorkOS AuthKit provider, ported from the doolin fork's
+// TanStack-Start version. AuthKit-react is a browser-only SPA integration (PKCE,
+// tokens held in the browser), so this has no server-rendered form and must be
+// mounted inside a `client:only="react"` island.
+//
+// After the hosted sign-in flow redirects back, `onRedirectCallback` returns the
+// user to the page they started from — the `returnTo` that the sign-in call
+// stashed on `state`. The fork navigated with TanStack Router's `useNavigate`;
+// on a static Astro site there is no client router, so a full-page
+// `window.location.assign` is the right equivalent.
+export default function AuthProvider({ children }: { children: ReactNode }) {
+  return (
+    <AuthKitProvider
+      clientId={import.meta.env.VITE_WORKOS_CLIENT_ID}
+      apiHostname={import.meta.env.VITE_WORKOS_API_HOSTNAME}
+      onRedirectCallback={({ state }) => {
+        const returnTo = (state as { returnTo?: string } | null)?.returnTo;
+        if (returnTo) {
+          window.location.assign(returnTo);
+        }
+      }}
+    >
+      {children}
+    </AuthKitProvider>
+  );
+}


### PR DESCRIPTION
Ports the project's own TanStack-era `src/integrations/workos/provider.tsx` to Astro (parent #294).

- `apps/web/src/integrations/workos/AuthProvider.tsx` — default-export `<AuthKitProvider>` wrapper.
- Config from `import.meta.env.VITE_WORKOS_CLIENT_ID` / `VITE_WORKOS_API_HOSTNAME` (no TanStack `env` module).
- `onRedirectCallback` returns the user to `state.returnTo` via `window.location.assign` — replaces the TanStack version's `@tanstack/react-router` `useNavigate` (no client router on a static site).
- It's a browser-only SPA integration, so it mounts inside a `client:only="react"` island (wired in #297).

## Verification
- `bunx vitest run` on the new test (mocks AuthKit, asserts children render) passes.
- `bun run build` (astro check + build) passes.

Implements #296.
