### PR TITLE
Add apiFetch bearer wrapper + /api/me round-trip

### DIFF
--- a/apps/web/src/components/auth/SignInButton.test.tsx
+++ b/apps/web/src/components/auth/SignInButton.test.tsx
@@ -16,12 +16,18 @@ const auth = vi.hoisted(() => ({
     isLoading: false,
     signIn: vi.fn(),
     signOut: vi.fn(),
+    getAccessToken: vi.fn(async () => "tok_test"),
   },
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => auth.value,
 }));
+
+// /api/me is exercised through a mocked apiFetch so the signed-in view can
+// assert the server-returned email without a real request.
+const apiFetchMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api", () => ({ apiFetch: apiFetchMock }));
 
 import SignInButton from "@/components/auth/SignInButton";
 
@@ -32,26 +38,37 @@ describe("SignInButton", () => {
       isLoading: false,
       signIn: vi.fn(),
       signOut: vi.fn(),
+      getAccessToken: vi.fn(async () => "tok_test"),
     };
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ email: "ada@example.com" }),
+    });
   });
 
-  test("signed out: shows a Sign In button", () => {
+  test("signed out: shows a Sign In button and does not call the API", () => {
     render(<SignInButton />);
 
     expect(screen.getByRole("button", { name: "Sign In" })).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Sign Out" })
     ).not.toBeInTheDocument();
+    expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
-  test("signed in: shows the name and a Sign Out button", () => {
+  test("signed in: shows the email from /api/me and a Sign Out button", async () => {
     auth.value.user = { firstName: "Ada", lastName: "Lovelace" };
     render(<SignInButton />);
 
-    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(await screen.findByText("ada@example.com")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Sign Out" })
     ).toBeInTheDocument();
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/me",
+      auth.value.getAccessToken
+    );
   });
 
   test("clicking Sign In launches the WorkOS flow with the current path as returnTo", async () => {

--- a/apps/web/src/components/auth/SignInButton.test.tsx
+++ b/apps/web/src/components/auth/SignInButton.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 type User = {
+  id?: string;
   firstName?: string | null;
   lastName?: string | null;
   profilePictureUrl?: string | null;
@@ -31,6 +32,10 @@ vi.mock("@/lib/api", () => ({ apiFetch: apiFetchMock }));
 
 import SignInButton from "@/components/auth/SignInButton";
 
+function meResolving(email: string) {
+  return { ok: true, json: async () => ({ email }) };
+}
+
 describe("SignInButton", () => {
   beforeEach(() => {
     auth.value = {
@@ -41,10 +46,7 @@ describe("SignInButton", () => {
       getAccessToken: vi.fn(async () => "tok_test"),
     };
     apiFetchMock.mockReset();
-    apiFetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ email: "ada@example.com" }),
-    });
+    apiFetchMock.mockResolvedValue(meResolving("ada@example.com"));
   });
 
   test("signed out: shows a Sign In button and does not call the API", () => {
@@ -58,7 +60,7 @@ describe("SignInButton", () => {
   });
 
   test("signed in: shows the email from /api/me and a Sign Out button", async () => {
-    auth.value.user = { firstName: "Ada", lastName: "Lovelace" };
+    auth.value.user = { id: "u_ada", firstName: "Ada", lastName: "Lovelace" };
     render(<SignInButton />);
 
     expect(await screen.findByText("ada@example.com")).toBeInTheDocument();
@@ -69,6 +71,24 @@ describe("SignInButton", () => {
       "/api/me",
       auth.value.getAccessToken
     );
+  });
+
+  test("does not show the previous account's email after switching users", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(meResolving("ada@example.com"))
+      .mockResolvedValueOnce(meResolving("grace@example.com"));
+
+    auth.value.user = { id: "u_ada", firstName: "Ada" };
+    const { rerender } = render(<SignInButton />);
+    expect(await screen.findByText("ada@example.com")).toBeInTheDocument();
+
+    auth.value.user = { id: "u_grace", firstName: "Grace" };
+    rerender(<SignInButton />);
+
+    // Bound to the identity: the instant we switch, the old email is gone even
+    // before grace's /api/me resolves.
+    expect(screen.queryByText("ada@example.com")).not.toBeInTheDocument();
+    expect(await screen.findByText("grace@example.com")).toBeInTheDocument();
   });
 
   test("clicking Sign In launches the WorkOS flow with the current path as returnTo", async () => {

--- a/apps/web/src/components/auth/SignInButton.tsx
+++ b/apps/web/src/components/auth/SignInButton.tsx
@@ -12,32 +12,42 @@ import { cn } from "@/lib/utils";
 // user (email from the server, name as a fallback) with a "Sign Out" button.
 export default function SignInButton() {
   const { user, isLoading, signIn, signOut, getAccessToken } = useAuth();
-  const [email, setEmail] = useState<string | null>(null);
+  const userId = user?.id ?? null;
+
+  // The fetched email is stored together with the id it belongs to, and rendered
+  // only when that id is still the active one. That way switching accounts never
+  // briefly shows the previous user's email while the new /api/me is in flight.
+  const [account, setAccount] = useState<{ id: string; email: string } | null>(
+    null
+  );
 
   // Prove the auth loop end to end: with a session, call the WorkOS-gated
-  // /api/me with the access token and show the email the *server* returns (not
+  // /api/me with the access token and record the email the *server* returns (not
   // the client-side user object), confirming the Go middleware accepted the
-  // token. Any failure just leaves email null and the name shows instead.
+  // token. Keyed on userId so it re-runs only when the identity changes.
   useEffect(() => {
-    if (!user) {
-      setEmail(null);
+    if (!userId) {
+      setAccount(null);
       return;
     }
     let cancelled = false;
     apiFetch("/api/me", getAccessToken)
       .then((res) => (res.ok ? res.json() : null))
       .then((data: { email?: string } | null) => {
-        if (!cancelled) setEmail(data?.email ?? null);
+        if (!cancelled && data?.email) {
+          setAccount({ id: userId, email: data.email });
+        }
       })
       .catch(() => {
-        if (!cancelled) setEmail(null);
+        // Leave the account unset; the name shows instead.
       });
     return () => {
       cancelled = true;
     };
-  }, [user, getAccessToken]);
+  }, [userId, getAccessToken]);
 
   if (user) {
+    const email = account?.id === userId ? account.email : null;
     const label =
       email ?? [user.firstName, user.lastName].filter(Boolean).join(" ");
     return (

--- a/apps/web/src/components/auth/SignInButton.tsx
+++ b/apps/web/src/components/auth/SignInButton.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 
+import { apiFetch } from "@/lib/api";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -7,12 +9,37 @@ import { cn } from "@/lib/utils";
 // restyled with the shared shadcn button. Signed out: a "Sign In" button that
 // launches the WorkOS hosted flow, passing the current path as `returnTo` so the
 // AuthProvider's redirect callback can bring the user back here. Signed in: the
-// user's name (avatar when present) with a "Sign Out" button.
+// user (email from the server, name as a fallback) with a "Sign Out" button.
 export default function SignInButton() {
-  const { user, isLoading, signIn, signOut } = useAuth();
+  const { user, isLoading, signIn, signOut, getAccessToken } = useAuth();
+  const [email, setEmail] = useState<string | null>(null);
+
+  // Prove the auth loop end to end: with a session, call the WorkOS-gated
+  // /api/me with the access token and show the email the *server* returns (not
+  // the client-side user object), confirming the Go middleware accepted the
+  // token. Any failure just leaves email null and the name shows instead.
+  useEffect(() => {
+    if (!user) {
+      setEmail(null);
+      return;
+    }
+    let cancelled = false;
+    apiFetch("/api/me", getAccessToken)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { email?: string } | null) => {
+        if (!cancelled) setEmail(data?.email ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setEmail(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user, getAccessToken]);
 
   if (user) {
-    const name = [user.firstName, user.lastName].filter(Boolean).join(" ");
+    const label =
+      email ?? [user.firstName, user.lastName].filter(Boolean).join(" ");
     return (
       <div className="flex items-center gap-2">
         {user.profilePictureUrl && (
@@ -22,9 +49,9 @@ export default function SignInButton() {
             className="h-7 w-7 rounded-full"
           />
         )}
-        {name && (
+        {label && (
           <span className="hidden text-sm font-medium text-[#4a4a4a] sm:inline">
-            {name}
+            {label}
           </span>
         )}
         <button

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { apiFetch } from "@/lib/api";
+
+describe("apiFetch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  test("attaches the access token as a Bearer header", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const getToken = vi.fn().mockResolvedValue("tok_123");
+
+    await apiFetch("/api/me", getToken);
+
+    expect(getToken).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/me");
+    expect(new Headers(init.headers).get("Authorization")).toBe(
+      "Bearer tok_123"
+    );
+  });
+
+  test("omits the Authorization header when there is no token", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("", { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await apiFetch("/api/me", async () => null);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(new Headers(init.headers).get("Authorization")).toBeNull();
+    expect(res.status).toBe(401);
+  });
+
+  test("preserves caller-supplied init (method, headers)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiFetch("/api/rsvp", async () => "tok", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("POST");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("Authorization")).toBe("Bearer tok");
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,21 @@
+// apiFetch calls the Go JSON API with the caller's WorkOS access token attached
+// as a Bearer credential. The server's /api/* routes are gated by the WorkOS
+// JWKS middleware, so authenticated requests must carry the token AuthKit issues.
+//
+// getToken is AuthKit's getAccessToken (from useAuth). When it yields no token
+// the request still goes out, just unauthenticated — the server answers 401 —
+// so callers can surface that state without a crash rather than throwing here.
+export type GetToken = () => Promise<string | undefined | null>;
+
+export async function apiFetch(
+  path: string,
+  getToken: GetToken,
+  init: RequestInit = {}
+): Promise<Response> {
+  const token = await getToken();
+  const headers = new Headers(init.headers);
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  return fetch(path, { ...init, headers });
+}


### PR DESCRIPTION
Closes the client-side auth loop against the already-built Go `/api/me` (parent #294).

- `lib/api.ts` — `apiFetch(path, getToken, init?)` attaches `Authorization: Bearer <token>` from AuthKit's `getAccessToken`. No token → request goes out unauthenticated (server 401s), never throws — so a signed-out call surfaces the 401 without crashing.
- `SignInButton` — when signed in, calls `/api/me` with the token and renders the **server-returned** email (name as fallback), proving the Go WorkOS JWKS middleware accepts the client-minted token end to end.

This is the reusable fetch foundation the meetup feature will build on.

## Verification
- Full web suite green (33 tests): `apiFetch` attaches/omits the bearer header and preserves caller init; SignInButton signed-in shows the `/api/me` email, signed-out makes no API call.
- `eslint` clean; `bun run build` passes.

Implements #298.