### PR TITLE
Update the manual for the WorkOS client auth island

### DIFF
--- a/manual/src/architecture.md
+++ b/manual/src/architecture.md
@@ -44,7 +44,7 @@ codeselfstudy/
 
 ## Auth
 
-- **Client:** deferred to the API phase. The Astro build currently ships no sign-in UI; the client-side WorkOS integration (and the bearer-token fetch wrapper) will return when the API surface is built out.
+- **Client:** the Astro navbar mounts a WorkOS AuthKit sign-in control (`@workos-inc/authkit-react`) as a browser-only island, so `Layout.astro` renders `Navbar` with `client:only="react"`. Signing in yields a WorkOS access token that `apiFetch` (`apps/web/src/lib/api.ts`) attaches as a Bearer credential to the gated API — the navbar reads `/api/me` to show the signed-in user.
 - **Server:** `apps/api/internal/auth/jwks.go` fetches the WorkOS JWKS on startup and refreshes periodically. `apps/api/internal/auth/middleware.go` validates signature, issuer, and expiry on every protected request. Validated claims are stashed in the Echo context for handlers to read.
 
 The Go-side auth is opt-in: if `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` (or their `VITE_`-prefixed fallbacks) are missing, `/api/me` is not mounted. Static serving and `/healthz` keep working — useful for barebones smoke tests.

--- a/manual/src/development.md
+++ b/manual/src/development.md
@@ -13,7 +13,7 @@ Boots two servers in parallel:
 - `apps/web/` (Astro dev server) on `http://localhost:7001`.
 - `apps/api/` (Go + Echo) on `http://localhost:8080`.
 
-The two servers run independently — there is no dev proxy. The navbar island calls `/api/me` at the page origin, so that request only resolves against the Go server, not the standalone Astro dev server on `:7001`. Build the site (`just build`) and run the Go server to exercise the production URL behavior (redirects, trailing-slash canonicalization) and the authenticated API end to end.
+The two servers run independently — there is no dev proxy. The navbar island calls `/api/me` as a same-origin request, so under `just dev` it targets the Astro dev server on `:7001`, which has no API, and 404s. The authenticated API works only when the Go binary serves the site and `/api/*` from one origin: run `just build`, then start the Go server. Use that Go-served build to exercise production URL behavior (redirects, trailing-slash canonicalization) and the authenticated API end to end.
 
 To run only one side:
 

--- a/manual/src/development.md
+++ b/manual/src/development.md
@@ -13,7 +13,7 @@ Boots two servers in parallel:
 - `apps/web/` (Astro dev server) on `http://localhost:7001`.
 - `apps/api/` (Go + Echo) on `http://localhost:8080`.
 
-The two servers run independently in this phase — there is no dev proxy, since the static site does not call the API yet. Build the site (`just build`) and run the Go server to exercise the production URL behavior (redirects, trailing-slash canonicalization) end to end.
+The two servers run independently — there is no dev proxy. The navbar island calls `/api/me` at the page origin, so that request only resolves against the Go server, not the standalone Astro dev server on `:7001`. Build the site (`just build`) and run the Go server to exercise the production URL behavior (redirects, trailing-slash canonicalization) and the authenticated API end to end.
 
 To run only one side:
 

--- a/manual/src/getting-started.md
+++ b/manual/src/getting-started.md
@@ -13,8 +13,8 @@
 bun install
 
 # Run the web (:7001) and Go API (:8080) dev servers together.
-# They run independently (no dev proxy); the navbar's /api/me call only
-# resolves against the Go server, not the standalone Astro server.
+# They run independently (no dev proxy): the navbar's same-origin /api/me
+# hits Astro on :7001 (which has no API); the authed API needs the Go build.
 just dev
 ```
 

--- a/manual/src/getting-started.md
+++ b/manual/src/getting-started.md
@@ -13,7 +13,8 @@
 bun install
 
 # Run the web (:7001) and Go API (:8080) dev servers together.
-# The two run independently; the static site doesn't call the API yet.
+# They run independently (no dev proxy); the navbar's /api/me call only
+# resolves against the Go server, not the standalone Astro server.
 just dev
 ```
 
@@ -31,8 +32,8 @@ bun run preview
 Copy `env.local.example` to `.env.local` at the repo root and fill in:
 
 ```bash
-# client-side variables (browser-exposed). The Astro app doesn't consume
-# these yet; the Go verifier reads them as fallback names.
+# client-side variables (browser-exposed). The Astro app consumes these for the
+# WorkOS AuthKit sign-in control; the Go verifier reads them as fallback names.
 VITE_WORKOS_CLIENT_ID="your_workos_client_id"
 VITE_WORKOS_API_HOSTNAME="your_workos_api_hostname"
 

--- a/manual/src/routing-and-data.md
+++ b/manual/src/routing-and-data.md
@@ -36,21 +36,21 @@ import PageWrapper from "@/components/PageWrapper.astro";
 
 ## Interactivity (islands)
 
-Pages are static HTML by default and ship no JavaScript. When a component needs to run in the browser it becomes an **island** — a React component rendered with a `client:*` directive. The navbar is the only island today; its mobile drawer needs client-side state, so `Layout.astro` renders it with `client:load`:
+Pages are static HTML by default and ship no JavaScript. When a component needs to run in the browser it becomes an **island** — a React component rendered with a `client:*` directive. The navbar is the only island today; it owns client-side state (the mobile drawer) and the WorkOS AuthKit sign-in control. Because AuthKit is browser-only and must not be prerendered, `Layout.astro` renders it with `client:only="react"`:
 
 ```astro
 ---
 import Navbar from "@/components/Navbar.tsx";
 ---
 
-<Navbar client:load />
+<Navbar client:only="react" />
 ```
 
 Keep islands small: everything outside them stays zero-JS.
 
 ## Data fetching
 
-The current site fetches no data — every page is prerendered at build time. When the Go API surface is built out, calls to `/api/*` will happen from islands (or future server code), not from the static pages. There are no route loaders.
+Every page is prerendered at build time. The one exception is the navbar island: once a user signs in it calls `/api/*` from the browser — `apiFetch` (`apps/web/src/lib/api.ts`) attaches the WorkOS bearer token and reads `/api/me`. Static pages fetch nothing, and there are no route loaders.
 
 ## Redirects and URL canonicalization
 


### PR DESCRIPTION
Docs ride-along for the auth work (parent #294) — the manual claimed the client had "no sign-in UI", the site "fetches no data", and the navbar was `client:load`, all now false.

- `architecture.md` — Auth **Client** bullet: navbar mounts the AuthKit control as a browser-only island; `apiFetch` sends the bearer token to `/api/me`.
- `routing-and-data.md` — islands section (navbar is now `client:only="react"` because AuthKit is browser-only) and data-fetching section (the navbar island reads `/api/me`).
- `development.md` / `getting-started.md` — the site now calls `/api/me`, which only resolves against the Go server (no dev proxy); the Astro app now consumes `VITE_WORKOS_*`.

Docs-only; `manual/book/` is gitignored build output and is untouched.

Implements #299.