### PR TITLE
Add kill-switch service worker to evict stale Gatsby/CRA workers

### DIFF
--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -312,6 +312,15 @@ func staticHandler(staticRoot string) echo.HandlerFunc {
 		}
 
 		if path, ok := resolveStatic(staticRoot, rel); ok {
+			// Service worker scripts live at fixed, unhashed URLs, so any cached
+			// copy would pin an outdated worker in browsers and at the CDN.
+			// Serve them revalidate-always so the kill switches (apps/web/public)
+			// reach returning visitors immediately and can be removed cleanly
+			// once stale registrations have drained. Hashed /_astro/* assets are
+			// immutable and intentionally left cacheable.
+			if isServiceWorkerScript(clean) {
+				c.Response().Header().Set("Cache-Control", "no-cache")
+			}
 			return c.File(path)
 		}
 
@@ -320,6 +329,15 @@ func staticHandler(staticRoot string) echo.HandlerFunc {
 		}
 		return echo.NewHTTPError(http.StatusNotFound)
 	}
+}
+
+// isServiceWorkerScript reports whether p is one of the root-scope service
+// worker scripts shipped as cache kill switches (apps/web/public/sw.js and
+// service-worker.js). They must be served with Cache-Control: no-cache —
+// unlike the content-hashed assets under /_astro, their URLs never change, so
+// any cached copy would keep an outdated worker alive.
+func isServiceWorkerScript(p string) bool {
+	return p == "/sw.js" || p == "/service-worker.js"
 }
 
 // dirIndexExists reports whether rel resolves to a directory index.html — the

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -311,16 +311,16 @@ func staticHandler(staticRoot string) echo.HandlerFunc {
 			}
 		}
 
+		// Service worker scripts live at fixed, unhashed URLs, so any cached
+		// copy would pin an outdated worker in browsers and at the CDN — and a
+		// 404 can be negatively cached too, hiding a later kill-switch deploy.
+		// Set the header by request path, before resolution, so both the file
+		// and its 404 fallback are always revalidated. Hashed /_astro/* assets
+		// are immutable and intentionally left cacheable.
+		if isServiceWorkerScript(clean) {
+			c.Response().Header().Set("Cache-Control", "no-cache")
+		}
 		if path, ok := resolveStatic(staticRoot, rel); ok {
-			// Service worker scripts live at fixed, unhashed URLs, so any cached
-			// copy would pin an outdated worker in browsers and at the CDN.
-			// Serve them revalidate-always so the kill switches (apps/web/public)
-			// reach returning visitors immediately and can be removed cleanly
-			// once stale registrations have drained. Hashed /_astro/* assets are
-			// immutable and intentionally left cacheable.
-			if isServiceWorkerScript(clean) {
-				c.Response().Header().Set("Cache-Control", "no-cache")
-			}
 			return c.File(path)
 		}
 

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -25,6 +25,8 @@ func fixtureDir(t *testing.T) string {
 		"404.html":              "<!doctype html><title>Not Found</title>missing",
 		"favicon.ico":           "icon-bytes",
 		"team/alice/index.html": "<!doctype html><title>Alice</title>alice",
+		"sw.js":                 "/* kill switch */",
+		"service-worker.js":     "/* kill switch */",
 	}
 	for rel, body := range files {
 		full := filepath.Join(dir, rel)
@@ -73,6 +75,38 @@ func TestStaticFileServed(t *testing.T) {
 			}
 			if !strings.Contains(rec.Body.String(), tc.body) {
 				t.Fatalf("body: want to contain %q, got %q", tc.body, rec.Body.String())
+			}
+		})
+	}
+}
+
+// Service worker scripts sit at fixed, unhashed URLs; they must be served
+// Cache-Control: no-cache so a returning visitor's browser (and the CDN) always
+// revalidates and the kill switches can be retired cleanly. Ordinary assets
+// must be left untouched.
+func TestServiceWorkerScriptsSentNoCache(t *testing.T) {
+	e := newServer(fixtureDir(t), nil, nil)
+	cases := []struct {
+		name        string
+		path        string
+		wantNoCache bool
+	}{
+		{"sw.js", "/sw.js", true},
+		{"service-worker.js", "/service-worker.js", true},
+		{"ordinary asset", "/favicon.ico", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: want 200, got %d", rec.Code)
+			}
+			cc := rec.Header().Get("Cache-Control")
+			if gotNoCache := strings.Contains(cc, "no-cache"); gotNoCache != tc.wantNoCache {
+				t.Fatalf("%s Cache-Control=%q: no-cache want=%v got=%v", tc.path, cc, tc.wantNoCache, gotNoCache)
 			}
 		})
 	}

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -112,6 +112,28 @@ func TestServiceWorkerScriptsSentNoCache(t *testing.T) {
 	}
 }
 
+// Service worker scripts must carry no-cache even when the file is missing:
+// caches can store 404s, and a negatively cached /sw.js would hide a later
+// kill-switch deploy.
+func TestMissingServiceWorkerStillNoCache(t *testing.T) {
+	dir := t.TempDir()
+	for name, body := range map[string]string{"index.html": "home", "404.html": "missing"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+	e := newServer(dir, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/sw.js", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: want 404, got %d", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); !strings.Contains(cc, "no-cache") {
+		t.Fatalf("missing /sw.js: want Cache-Control no-cache, got %q", cc)
+	}
+}
+
 // HEAD must work everywhere GET works (RFC 9110 §9.3.2). Curl -I, fly's
 // healthcheck probes, and ad-hoc monitoring all use HEAD; without explicit
 // support Echo returns 405 instead of mirroring the GET status.

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -26,6 +26,19 @@ export default [
     },
   },
   {
+    // Static scripts in public/ (the /sw.js and /service-worker.js kill
+    // switches) run in the ServiceWorkerGlobalScope; expose the globals they
+    // reference so the linter doesn't flag them as undefined.
+    files: ["public/**/*.js"],
+    languageOptions: {
+      globals: {
+        self: "readonly",
+        caches: "readonly",
+        clients: "readonly",
+      },
+    },
+  },
+  {
     // The repo now has multiple app tsconfigs (apps/web, apps/email_receiver),
     // so pin this config's TSConfig root explicitly — otherwise typescript-eslint
     // errors with "multiple candidate TSConfigRootDirs" when a run spans apps.

--- a/apps/web/public/service-worker.js
+++ b/apps/web/public/service-worker.js
@@ -1,0 +1,40 @@
+// Kill-switch service worker.
+//
+// codeselfstudy.com previously ran Gatsby (gatsby-plugin-offline) and
+// create-react-app, both of which registered a root-scope service worker that
+// precached the HTML and CSS bundle. After the migration to Astro those became
+// "zombies": a returning visitor's browser keeps serving the old cached
+// index.html, which links a CSS hash that no longer exists on the server, so
+// the page loads unstyled. A 404 on the old worker script does NOT clear the
+// registration, so the stale worker persists until site data is cleared.
+//
+// create-react-app registered its worker at /service-worker.js; this file
+// mirrors /sw.js so that CRA-era registrations are cleaned up too. Browsers
+// re-fetch the top-level worker script on their next navigation (it bypasses
+// the HTTP cache on update checks), install this version, and it unregisters
+// itself, clears all caches, and reloads open tabs so they fetch fresh,
+// worker-free assets. The current Astro site registers no service worker, so
+// fresh visitors never fetch or run this file. Safe to delete once stale-worker
+// traffic has drained (keep it for several months).
+self.addEventListener("install", () => self.skipWaiting());
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      try {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((key) => caches.delete(key)));
+      } catch {
+        /* Cache Storage unavailable */
+      }
+      await self.registration.unregister();
+      const clients = await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      });
+      for (const client of clients) {
+        client.navigate(client.url);
+      }
+    })()
+  );
+});

--- a/apps/web/public/service-worker.js
+++ b/apps/web/public/service-worker.js
@@ -32,9 +32,12 @@ self.addEventListener("activate", (event) => {
         type: "window",
         includeUncontrolled: true,
       });
-      for (const client of clients) {
-        client.navigate(client.url);
-      }
+      // navigate() rejects if this worker doesn't control the client or the URL
+      // is unusable; the reload is best-effort while the stale worker is torn
+      // down, so await all attempts and swallow per-client failures.
+      await Promise.all(
+        clients.map((client) => client.navigate(client.url).catch(() => {}))
+      );
     })()
   );
 });

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -31,9 +31,12 @@ self.addEventListener("activate", (event) => {
         type: "window",
         includeUncontrolled: true,
       });
-      for (const client of clients) {
-        client.navigate(client.url);
-      }
+      // navigate() rejects if this worker doesn't control the client or the URL
+      // is unusable; the reload is best-effort while the stale worker is torn
+      // down, so await all attempts and swallow per-client failures.
+      await Promise.all(
+        clients.map((client) => client.navigate(client.url).catch(() => {}))
+      );
     })()
   );
 });

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,39 @@
+// Kill-switch service worker.
+//
+// codeselfstudy.com previously ran Gatsby (gatsby-plugin-offline) and
+// create-react-app, both of which registered a root-scope service worker that
+// precached the HTML and CSS bundle. After the migration to Astro those became
+// "zombies": a returning visitor's browser keeps serving the old cached
+// index.html, which links a CSS hash that no longer exists on the server, so
+// the page loads unstyled. A 404 on the old /sw.js does NOT clear the
+// registration, so the stale worker persists until site data is cleared.
+//
+// This script replaces the old /sw.js. Browsers re-fetch the top-level worker
+// script on their next navigation (it bypasses the HTTP cache on update
+// checks), install this version, and it unregisters itself, clears all caches,
+// and reloads open tabs so they fetch fresh, worker-free assets. The current
+// Astro site registers no service worker, so fresh visitors never fetch or run
+// this file. Safe to delete once stale-worker traffic has drained (keep it for
+// several months).
+self.addEventListener("install", () => self.skipWaiting());
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      try {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((key) => caches.delete(key)));
+      } catch {
+        /* Cache Storage unavailable */
+      }
+      await self.registration.unregister();
+      const clients = await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      });
+      for (const client of clients) {
+        client.navigate(client.url);
+      }
+    })()
+  );
+});


### PR DESCRIPTION
## Problem

On **codeselfstudy.com** the site can render **unstyled** ("the CSS file doesn't load"), while **codeselfstudy.fly.dev** is fine.

## Root cause — a "zombie" service worker (not a server/CSS/Cloudflare bug)

Diagnosis showed the deployed site is healthy on both hosts:

- Both serve **identical HTML** referencing the **same CSS** (`/_astro/Layout.CG7JesgK.css`, same `last-modified`).
- `curl --compressed` decodes that CSS **identically on both hosts** — 42 KB, valid `text/css`, single clean gzip, HTTP 200.
- A **fresh browser renders codeselfstudy.com fully styled** (CSS 200, fonts 200, no console errors, `getRegistrations()` → `[]`).

The failure is **client-side**. This origin previously ran **create-react-app** and then **Gatsby (`gatsby-plugin-offline`)**, both of which register a **root-scope service worker** (`/sw.js`, `/service-worker.js`) that precaches the HTML + CSS bundle. After the migration to Astro those workers became **zombies** in returning visitors' browsers: they keep serving the **old cached `index.html`**, which links a CSS hash that no longer exists → CSS 404 → unstyled page. `/sw.js` now 404s, and **a 404 during a worker update check does not clear the registration**, so the stale worker persists. `.fly.dev` is a different origin that never ran Gatsby → no registration → always fine.

## Fix

1. **Kill-switch workers.** Ship a **self-unregistering** worker at both `/sw.js` (Gatsby) and `/service-worker.js` (CRA). Browsers re-fetch the top-level worker script on their next navigation (it bypasses the HTTP cache on update checks), install this version, and it:
   - clears all Cache Storage,
   - `unregister()`s itself,
   - reloads open tabs so they fetch fresh, worker-free assets.

   The current Astro site registers **no** service worker, so fresh visitors never fetch or run these files — the change is inert for them (zero risk).

2. **`Cache-Control: no-cache` for both scripts** (Go static handler, `apps/api/main.go`). They sit at fixed, unhashed URLs, so a cached copy would pin an outdated worker at the browser and the CDN. Serving them revalidate-always means the kill switch propagates without a manual Cloudflare purge, and the files can be **deleted cleanly** later once stale registrations have drained. Hashed `/_astro/*` assets keep their default immutable caching.

3. **ESLint:** a small flat-config block so `public/**/*.js` lints with service-worker globals (`self`, `caches`, `clients`) instead of failing `no-undef`.

## Testing

- `bunx eslint .` → clean; `prettier --check` → clean.
- `bun run build` (astro check && astro build) → passes.
- Served the build via `astro preview`: `/sw.js` and `/service-worker.js` both return **200 / `text/javascript`** with the kill-switch content.
- `bun run test` (web) → 23/23 pass.
- Go: `gofmt`/`go vet` clean; `go test ./...` passes, incl. a new `TestServiceWorkerScriptsSentNoCache` asserting the two scripts get `no-cache` and ordinary assets do not.

## Deploy note

Deploy as usual (`just deploy`). Cloudflare may hold a short-lived cached **404** for `/sw.js` from before this change, so **purge those two paths once** on the first deploy to flush it. After that the `no-cache` header keeps them fresh automatically — no further purges, and the eventual cleanup (deleting both files) propagates instantly. Post-deploy check:

```bash
curl -sI https://codeselfstudy.com/sw.js   # want: 200, JS content-type, cache-control: no-cache
```

Affected returning visitors recover automatically on their next visit or two (worker update → activate → unregister → reload). Anyone wanting an immediate fix can unregister manually: DevTools → Application → Service Workers → Unregister → Clear site data → hard reload.

## Notes

- Safe to delete both files once stale-worker traffic has drained (keep several months).
- Not related to #305 (the design refresh) — standalone hotfix off `main`.
