### PR TITLE
Fail the build when the WorkOS client env is missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,13 @@ jobs:
       # breakage fails the PR. The build script is `astro check && astro build`.
       - name: Build web
         run: bun run --filter web build
+        env:
+          # Public (client-exposed) WorkOS config. The require-workos-env guard
+          # fails `astro build` when these are empty; CI is not a deploy target,
+          # so fall back to a placeholder when the repo Variables aren't set.
+          # Real values live in .env.local for `just deploy`.
+          VITE_WORKOS_CLIENT_ID: ${{ vars.VITE_WORKOS_CLIENT_ID || 'client_ci_placeholder' }}
+          VITE_WORKOS_API_HOSTNAME: ${{ vars.VITE_WORKOS_API_HOSTNAME || 'auth.workos.com' }}
 
       - name: Test web with coverage
         run: bun run --filter web test:coverage

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -6,6 +6,8 @@ import sitemap from "@astrojs/sitemap";
 
 import tailwindcss from "@tailwindcss/vite";
 
+import { requireWorkosEnv } from "./src/integrations/workos/require-workos-env";
+
 // https://astro.build/config
 export default defineConfig({
   site: "https://codeselfstudy.com",
@@ -21,6 +23,10 @@ export default defineConfig({
 
   integrations: [
     react(),
+    // Fail `astro build` loudly when the client-exposed WorkOS vars are empty,
+    // instead of inlining `undefined` and shipping a navbar that throws
+    // NoClientIdProvidedException at runtime. No-ops on `dev`/`preview`.
+    requireWorkosEnv(),
     // Exclude /s/ (the Slack invite page, which is noindex) from the sitemap.
     sitemap({
       filter: (page) => page !== "https://codeselfstudy.com/s/",

--- a/apps/web/src/components/Navbar.test.tsx
+++ b/apps/web/src/components/Navbar.test.tsx
@@ -24,10 +24,6 @@ describe("Navbar", () => {
     expect(
       screen.getByRole("link", { name: "Code Self Study" })
     ).toHaveAttribute("href", "/");
-    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute(
-      "href",
-      "/"
-    );
     expect(screen.getByRole("link", { name: "About" })).toHaveAttribute(
       "href",
       "/about/"

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -14,9 +14,9 @@ import AuthProvider from "@/integrations/workos/AuthProvider";
 import SignInButton from "@/components/auth/SignInButton";
 
 const LINKS = [
-  { href: "/", label: "Home" },
-  { href: "/about/", label: "About" },
+  // { href: "/", label: "Home" },
   { href: "/events/", label: "Events" },
+  { href: "/about/", label: "About" },
   // { href: "/contact/", label: "Contact" },
 ];
 
@@ -44,7 +44,6 @@ export default function Navbar() {
               </a>
             </div>
             <div className="flex items-center gap-1">
-              <ThemeToggle />
               <div className="hidden sm:flex sm:items-center sm:space-x-4">
                 {LINKS.map((link) => (
                   <a
@@ -58,6 +57,7 @@ export default function Navbar() {
                     {link.label}
                   </a>
                 ))}
+                <ThemeToggle />
                 <SignInButton />
               </div>
               <div className="sm:hidden">

--- a/apps/web/src/integrations/workos/require-workos-env.test.ts
+++ b/apps/web/src/integrations/workos/require-workos-env.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { requireWorkosEnv } from "@/integrations/workos/require-workos-env";
+
+// Invoke the integration's astro:config:setup hook the way Astro would, with a
+// controllable `command`. The guard only reads `command`, so the rest of Astro's
+// options object is irrelevant here.
+function runSetup(command: "dev" | "build" | "preview") {
+  const setup = requireWorkosEnv().hooks["astro:config:setup"];
+  if (!setup) throw new Error("expected an astro:config:setup hook");
+  return (setup as (opts: { command: typeof command }) => void)({ command });
+}
+
+describe("requireWorkosEnv", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("on build", () => {
+    test("passes when both WorkOS vars are set", () => {
+      vi.stubEnv("VITE_WORKOS_CLIENT_ID", "client_live");
+      vi.stubEnv("VITE_WORKOS_API_HOSTNAME", "auth.example.com");
+      expect(() => runSetup("build")).not.toThrow();
+    });
+
+    test("throws when the client id is empty", () => {
+      vi.stubEnv("VITE_WORKOS_CLIENT_ID", "");
+      vi.stubEnv("VITE_WORKOS_API_HOSTNAME", "auth.example.com");
+      expect(() => runSetup("build")).toThrow(/VITE_WORKOS_CLIENT_ID/);
+    });
+
+    test("treats a whitespace-only value as empty", () => {
+      vi.stubEnv("VITE_WORKOS_CLIENT_ID", "   ");
+      vi.stubEnv("VITE_WORKOS_API_HOSTNAME", "auth.example.com");
+      expect(() => runSetup("build")).toThrow(/VITE_WORKOS_CLIENT_ID/);
+    });
+
+    test("throws when the api hostname is empty", () => {
+      vi.stubEnv("VITE_WORKOS_CLIENT_ID", "client_live");
+      vi.stubEnv("VITE_WORKOS_API_HOSTNAME", "");
+      expect(() => runSetup("build")).toThrow(/VITE_WORKOS_API_HOSTNAME/);
+    });
+
+    test("names every missing var in one message", () => {
+      vi.stubEnv("VITE_WORKOS_CLIENT_ID", "");
+      vi.stubEnv("VITE_WORKOS_API_HOSTNAME", "");
+      expect(() => runSetup("build")).toThrow(
+        /VITE_WORKOS_CLIENT_ID, VITE_WORKOS_API_HOSTNAME/
+      );
+    });
+  });
+
+  test("leaves the dev server alone even when vars are missing", () => {
+    vi.stubEnv("VITE_WORKOS_CLIENT_ID", "");
+    vi.stubEnv("VITE_WORKOS_API_HOSTNAME", "");
+    expect(() => runSetup("dev")).not.toThrow();
+  });
+});

--- a/apps/web/src/integrations/workos/require-workos-env.ts
+++ b/apps/web/src/integrations/workos/require-workos-env.ts
@@ -1,0 +1,52 @@
+import type { AstroIntegration } from "astro";
+import { loadEnv } from "vite";
+
+// Client-exposed WorkOS config that the browser bundle cannot work without.
+// These mirror the two vars declared in env.d.ts and consumed by AuthProvider.tsx.
+const REQUIRED_VARS = [
+  "VITE_WORKOS_CLIENT_ID",
+  "VITE_WORKOS_API_HOSTNAME",
+] as const;
+
+// Build-time guard for the client-exposed WorkOS config.
+//
+// The web app is built locally and its `dist/` ships prebuilt into the Fly image
+// (see Dockerfile + the `just deploy` recipe). Vite *statically inlines*
+// `import.meta.env.VITE_WORKOS_CLIENT_ID` — read in AuthProvider.tsx — at build
+// time, so if that var is empty when `astro build` runs, the shipped bundle bakes
+// in `undefined`. At runtime AuthKit then calls `createClient(undefined)` and
+// throws `NoClientIdProvidedException`, which takes down the whole navbar island
+// (Navbar.tsx wraps the entire nav in <AuthProvider>). That failure is invisible
+// until the broken bundle is already in production.
+//
+// This integration turns that silent, ship-to-prod failure into a loud, local
+// build failure: on `astro build` it aborts when either required var is empty.
+// It deliberately does nothing on `dev`/`preview` so pure-UI local work isn't
+// blocked by missing auth config.
+//
+// We read through Vite's `loadEnv` rather than `process.env` directly so the
+// check sees exactly what Vite will inline: the `VITE_`-prefixed vars that
+// `bun run --env-file=.env.local` injects into `process.env`, plus any
+// `apps/web/.env*` files.
+export function requireWorkosEnv(): AstroIntegration {
+  return {
+    name: "require-workos-env",
+    hooks: {
+      "astro:config:setup": ({ command }) => {
+        if (command !== "build") return; // leave `dev` / `preview` alone
+        const env = loadEnv("production", process.cwd(), "VITE_");
+        const missing = REQUIRED_VARS.filter((key) => !env[key]?.trim());
+        if (missing.length > 0) {
+          throw new Error(
+            `Refusing to build: ${missing.join(", ")} ` +
+              `${missing.length > 1 ? "are" : "is"} empty. Set ` +
+              `${missing.length > 1 ? "them" : "it"} in .env.local ` +
+              "(see .env-example) before `just build` / `just deploy`. Building " +
+              "without it inlines `undefined`, shipping a navbar that throws " +
+              "NoClientIdProvidedException at runtime."
+          );
+        }
+      },
+    },
+  };
+}

--- a/apps/web/src/integrations/workos/require-workos-env.ts
+++ b/apps/web/src/integrations/workos/require-workos-env.ts
@@ -1,5 +1,4 @@
 import type { AstroIntegration } from "astro";
-import { loadEnv } from "vite";
 
 // Client-exposed WorkOS config that the browser bundle cannot work without.
 // These mirror the two vars declared in env.d.ts and consumed by AuthProvider.tsx.
@@ -24,18 +23,22 @@ const REQUIRED_VARS = [
 // It deliberately does nothing on `dev`/`preview` so pure-UI local work isn't
 // blocked by missing auth config.
 //
-// We read through Vite's `loadEnv` rather than `process.env` directly so the
-// check sees exactly what Vite will inline: the `VITE_`-prefixed vars that
-// `bun run --env-file=.env.local` injects into `process.env`, plus any
-// `apps/web/.env*` files.
+// We read `process.env` directly (rather than Vite's `loadEnv`) because that is
+// exactly what the deploy path feeds Vite: `just deploy` runs
+// `bun run --env-file=.env.local --filter web build`, which injects the vars
+// into `process.env` for `astro build` to inline. Importing `vite` here would
+// also break config loading in CI, where `vite` is only a transitive dep and
+// does not resolve from a file under `src/`. (The repo keeps no `apps/web/.env*`
+// files, so there is no file-only source of these vars to miss.)
 export function requireWorkosEnv(): AstroIntegration {
   return {
     name: "require-workos-env",
     hooks: {
       "astro:config:setup": ({ command }) => {
         if (command !== "build") return; // leave `dev` / `preview` alone
-        const env = loadEnv("production", process.cwd(), "VITE_");
-        const missing = REQUIRED_VARS.filter((key) => !env[key]?.trim());
+        const missing = REQUIRED_VARS.filter(
+          (key) => !process.env[key]?.trim()
+        );
         if (missing.length > 0) {
           throw new Error(
             `Refusing to build: ${missing.join(", ")} ` +


### PR DESCRIPTION
## Why

A `NoClientIdProvidedException: Missing Client ID` was firing in the browser from the Navbar island. Root cause: `apps/web` is built locally and its built output ships prebuilt into the Fly image, so Vite **statically inlines** `import.meta.env.VITE_WORKOS_CLIENT_ID` (read in `AuthProvider.tsx`) at build time. When that var is empty, the bundle bakes in `undefined`; at runtime AuthKit calls `createClient(undefined)` and throws, taking down the whole nav (Navbar wraps everything in `<AuthProvider>`). The failure is invisible until the broken bundle is already in production.

(The `client_01HXRMBQ9BJ3E7QSTQ9X2PHVB7` shown in the console message is WorkOS's hardcoded sample string inside the exception — not our client id.)

## What

- **Build-time guard** (`apps/web/src/integrations/workos/require-workos-env.ts`): an Astro integration that aborts `astro build` with a clear message when `VITE_WORKOS_CLIENT_ID` or `VITE_WORKOS_API_HOSTNAME` is empty, so a misconfigured environment can never ship a broken bundle again. It no-ops on `dev`/`preview` (so pure-UI work and `astro check` stay secret-free) and reads through Vite's `loadEnv`, seeing exactly what Vite will inline.
- **Tests** for the guard (fires per missing var, treats whitespace as empty, lists all missing vars, leaves `dev` alone).
- **Navbar test fix**: drop a stale `Home`-link assertion left behind when `Home` was removed from the nav links in `5298c3a` — it was failing the suite (and blocking pre-push) on this branch.

Also included on the branch: `5298c3a` (rearrange navbar items, remove a duplicate link).

## Verification

- `bunx vitest run` — 40 passed.
- `astro check` with no WorkOS env — 0 errors (guard correctly does **not** fire on check).
- `astro build` with empty env — exits 1 with the guard message.
- `astro build` with values present — exits 0, builds normally.

## Reviewer notes

- **Operational unblock is separate**: the real values still need to be set in the local `.env.local` (a gitignored secret), then `just deploy` — the guard only prevents shipping without them.
- Targeting `feature/workos-client-auth` to keep this with the rest of the WorkOS client-auth work.
