### PR TITLE
Fix Navbar test to match the trimmed LINKS array

### DIFF
--- a/apps/web/src/components/Navbar.test.tsx
+++ b/apps/web/src/components/Navbar.test.tsx
@@ -24,10 +24,6 @@ describe("Navbar", () => {
     expect(
       screen.getByRole("link", { name: "Code Self Study" })
     ).toHaveAttribute("href", "/");
-    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute(
-      "href",
-      "/"
-    );
     expect(screen.getByRole("link", { name: "About" })).toHaveAttribute(
       "href",
       "/about/"

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -14,9 +14,9 @@ import AuthProvider from "@/integrations/workos/AuthProvider";
 import SignInButton from "@/components/auth/SignInButton";
 
 const LINKS = [
-  { href: "/", label: "Home" },
-  { href: "/about/", label: "About" },
+  // { href: "/", label: "Home" },
   { href: "/events/", label: "Events" },
+  { href: "/about/", label: "About" },
   // { href: "/contact/", label: "Contact" },
 ];
 
@@ -44,7 +44,6 @@ export default function Navbar() {
               </a>
             </div>
             <div className="flex items-center gap-1">
-              <ThemeToggle />
               <div className="hidden sm:flex sm:items-center sm:space-x-4">
                 {LINKS.map((link) => (
                   <a
@@ -58,6 +57,7 @@ export default function Navbar() {
                     {link.label}
                   </a>
                 ))}
+                <ThemeToggle />
                 <SignInButton />
               </div>
               <div className="sm:hidden">


### PR DESCRIPTION
## What

Repairs the failing `Navbar` test `renders the logo and desktop links with trailing-slash hrefs`.

## Why

Commit 5298c3a ("Rearrange navbar items. Remove duplicate link.") commented the `Home` entry out of the `LINKS` array in `apps/web/src/components/Navbar.tsx`, so the desktop nav now renders only **Events** (`/events/`) and **About** (`/about/`), plus the **Code Self Study** logo linking to `/`. `Navbar.test.tsx` still asserted an accessible link named `Home`, so the test failed.

## Change

- Drop the `Home` link assertion from the test.
- Keep verifying the logo href `/` and the trailing-slash hrefs on Events (`/events/`) and About (`/about/`).

## Notes for reviewers

- Test-only change; no production code touched. This is a pre-existing failure on the branch, unrelated to the WorkOS env-guard work.
- Verified with `bunx vitest run src/components/Navbar.test.tsx` in `apps/web` → **3 passed**.
- Base is `feature/workos-client-auth` (not `main`), so this PR also carries the parent navbar-rearrange commit 5298c3a that has not yet been pushed to the remote feature branch.