### PR TITLE
Strip query params from deal URLs before posting to Slack

### DIFF
--- a/apps/api/internal/digest/blocks.go
+++ b/apps/api/internal/digest/blocks.go
@@ -151,22 +151,28 @@ func escapeMrkdwn(s string) string {
 
 // stripQueryParams drops the query string from a deal URL so the digest posts a
 // clean canonical link instead of the long tracking URL newsletters attach
-// (utm_*, mcID, linkID, …). Everything up to the first "?" is kept; a URL with
-// no query is returned unchanged. This is a Slack-display transform only — the
-// raw URL is left intact on the stored deal. A plain string split (rather than
-// net/url) is deliberate: the query we're discarding often holds unescaped junk
-// like "linkID={$linkID}" that url.Parse would reject.
+// (utm_*, mcID, linkID, …). Any fragment is preserved: per RFC 3986 the query
+// only exists when a "?" precedes the "#", so a "?" that sits inside the
+// fragment is left alone and a URL with no query is returned unchanged. This is
+// a Slack-display transform only — the raw URL is left intact on the stored
+// deal. A plain string split (rather than net/url) is deliberate: the query
+// we're discarding often holds unescaped junk like "linkID={$linkID}" that
+// url.Parse would reject.
 func stripQueryParams(u string) string {
-	if i := strings.IndexByte(u, '?'); i >= 0 {
-		return u[:i]
+	end := len(u)
+	if h := strings.IndexByte(u, '#'); h >= 0 {
+		end = h // only the part before the fragment can hold a query
+	}
+	if i := strings.IndexByte(u[:end], '?'); i >= 0 {
+		return u[:i] + u[end:] // drop the query, keep any fragment
 	}
 	return u
 }
 
 // escapeLinkURL percent-encodes the characters that would break Slack's
 // <url|text> link syntax. The entity-escaping used for display text is wrong for
-// a URL (it would corrupt query strings), so only these three delimiters are
-// encoded; everything else in the tracking URL is left intact.
+// a URL (it would corrupt the path/fragment), so only these three delimiters are
+// encoded; everything else in the link is left intact.
 var linkURLEscaper = strings.NewReplacer("<", "%3C", ">", "%3E", "|", "%7C")
 
 func escapeLinkURL(u string) string {

--- a/apps/api/internal/digest/blocks.go
+++ b/apps/api/internal/digest/blocks.go
@@ -115,7 +115,7 @@ func dealText(d store.Deal) string {
 
 	title := escapeMrkdwn(d.Title)
 	if d.URL != "" {
-		lines = append(lines, fmt.Sprintf("*<%s|%s>*", escapeLinkURL(d.URL), title))
+		lines = append(lines, fmt.Sprintf("*<%s|%s>*", escapeLinkURL(stripQueryParams(d.URL)), title))
 	} else {
 		lines = append(lines, "*"+title+"*")
 	}
@@ -147,6 +147,20 @@ func escapeMrkdwn(s string) string {
 	s = strings.ReplaceAll(s, "<", "&lt;")
 	s = strings.ReplaceAll(s, ">", "&gt;")
 	return s
+}
+
+// stripQueryParams drops the query string from a deal URL so the digest posts a
+// clean canonical link instead of the long tracking URL newsletters attach
+// (utm_*, mcID, linkID, …). Everything up to the first "?" is kept; a URL with
+// no query is returned unchanged. This is a Slack-display transform only — the
+// raw URL is left intact on the stored deal. A plain string split (rather than
+// net/url) is deliberate: the query we're discarding often holds unescaped junk
+// like "linkID={$linkID}" that url.Parse would reject.
+func stripQueryParams(u string) string {
+	if i := strings.IndexByte(u, '?'); i >= 0 {
+		return u[:i]
+	}
+	return u
 }
 
 // escapeLinkURL percent-encodes the characters that would break Slack's

--- a/apps/api/internal/digest/blocks_test.go
+++ b/apps/api/internal/digest/blocks_test.go
@@ -138,13 +138,44 @@ func TestDealTextOmitsEmptyFields(t *testing.T) {
 }
 
 func TestDealTextEscapesURLDelimiters(t *testing.T) {
-	// A tracking URL with |, <, > must not break Slack's <url|text> syntax.
-	got := dealText(store.Deal{Title: "T", URL: "https://x.example/d?a=1|2&b=<3>"})
-	if strings.Contains(got, "1|2") || strings.Contains(got, "<3>") {
+	// Any |, <, > that survives param-stripping (e.g. in the path) must not break
+	// Slack's <url|text> syntax.
+	got := dealText(store.Deal{Title: "T", URL: "https://x.example/d|e<f>"})
+	if strings.Contains(got, "|e") || strings.Contains(got, "<f>") {
 		t.Errorf("URL delimiters not escaped: %q", got)
 	}
-	want := "*<https://x.example/d?a=1%7C2&b=%3C3%3E|T>*"
+	want := "*<https://x.example/d%7Ce%3Cf%3E|T>*"
 	if got != want {
 		t.Errorf("dealText = %q, want %q", got, want)
+	}
+}
+
+func TestDealTextStripsQueryParams(t *testing.T) {
+	// The tracking query attached by newsletters must be gone from the Slack link.
+	got := dealText(store.Deal{Title: "T", URL: "https://x.example/deal?utm_source=news&id=9"})
+	want := "*<https://x.example/deal|T>*"
+	if got != want {
+		t.Errorf("dealText = %q, want %q", got, want)
+	}
+}
+
+func TestStripQueryParams(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{
+			"humble bundle newsletter",
+			"https://www.humblebundle.com/books/red-team-blue-team-hackers-complete-playbook-packt-books?mcID=102:6a5f9e600af1ea383606e189:ot:6a6064f6d273259125eb7a94:1&linkID={$linkID}&utm_source=Humble+Bundle+Newsletter&utm_content=cta_button&utm_medium=email&utm_campaign=teenagemutantninjaturtlesreturntonewyorkidw_bookbundle",
+			"https://www.humblebundle.com/books/red-team-blue-team-hackers-complete-playbook-packt-books",
+		},
+		{"no query unchanged", "https://x.example/deal", "https://x.example/deal"},
+		{"trailing question mark", "https://x.example/deal?", "https://x.example/deal"},
+		{"fragment kept when no query", "https://x.example/deal#section", "https://x.example/deal#section"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripQueryParams(tc.in); got != tc.want {
+				t.Errorf("stripQueryParams(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/apps/api/internal/digest/blocks_test.go
+++ b/apps/api/internal/digest/blocks_test.go
@@ -169,6 +169,9 @@ func TestStripQueryParams(t *testing.T) {
 		{"no query unchanged", "https://x.example/deal", "https://x.example/deal"},
 		{"trailing question mark", "https://x.example/deal?", "https://x.example/deal"},
 		{"fragment kept when no query", "https://x.example/deal#section", "https://x.example/deal#section"},
+		{"query dropped, fragment kept", "https://x.example/deal?utm=1#anchor", "https://x.example/deal#anchor"},
+		{"question mark inside fragment is not a query", "https://x.example/deal#section?foo", "https://x.example/deal#section?foo"},
+		{"hash route with params kept", "https://x.example/#/deals?id=9", "https://x.example/#/deals?id=9"},
 		{"empty", "", ""},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## What

Trim the query string from deal URLs when rendering the Slack digest link, so a newsletter link like:

```
https://www.humblebundle.com/books/red-team-blue-team-hackers-complete-playbook-packt-books?mcID=102:...&linkID={$linkID}&utm_source=Humble+Bundle+Newsletter&utm_medium=email&...
```

posts as:

```
https://www.humblebundle.com/books/red-team-blue-team-hackers-complete-playbook-packt-books
```

## Why

Extracted deals arrive with long tracking query strings (`utm_*`, `mcID`, `linkID`, …) that make the posted links noisy and leak campaign tracking into the channel.

## How

- New `stripQueryParams` helper in `digest` — keeps everything up to the first `?`; a URL with no query is returned unchanged.
- `dealText` calls it before `escapeLinkURL`, alongside the existing Slack URL transforms.
- Done at the **render boundary** only — the raw URL is left intact on the stored deal for provenance, and dedup is unaffected (keyed on sender + title, not URL).
- A plain string split is used rather than `net/url`: the discarded query often holds unescaped junk like `linkID={$linkID}` that `url.Parse` would reject.

## Notes for reviewer

- Fragments are preserved when there's no query (`#section` is navigation, not a tracking param).
- Golden block test is unchanged (its fixture URLs have no query).
- Updated `TestDealTextEscapesURLDelimiters` to place the `|`/`<`/`>` delimiters in the path, since a query no longer survives to Slack — the escaper is still exercised.
- New tests: `TestStripQueryParams` (table, incl. the Humble Bundle example + edge cases) and `TestDealTextStripsQueryParams` (end-to-end at `dealText`).

`go test ./...` and `go vet ./...` pass in `apps/api`.