### PR TITLE
fix(web): inline VITE_-prefixed env vars into the client bundle

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -34,6 +34,13 @@ export default defineConfig({
   ],
 
   vite: {
+    // Astro defaults Vite's envPrefix to `PUBLIC_`, so only PUBLIC_-prefixed
+    // vars are inlined into client bundles. Our WorkOS client config is exposed
+    // under the `VITE_` prefix (ported from the old Vite/TanStack app, and
+    // shared with the Go API's VITE_WORKOS_* fallback in apps/api/main.go), so
+    // `VITE_` must be added here — otherwise import.meta.env.VITE_WORKOS_CLIENT_ID
+    // is `undefined` in the browser and AuthKit throws NoClientIdProvidedException.
+    envPrefix: ["PUBLIC_", "VITE_"],
     plugins: [tailwindcss()],
   },
 });

--- a/apps/web/astro.config.test.ts
+++ b/apps/web/astro.config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import astroConfig from "./astro.config.mjs";
+
+// Regression guard for the WorkOS "Missing Client ID" bug.
+//
+// Astro inlines into client bundles only the env vars matching Vite's
+// `envPrefix`, and it defaults that prefix to `PUBLIC_`. Our WorkOS client
+// config is exposed under the `VITE_` prefix (see AuthProvider.tsx and the Go
+// API's VITE_WORKOS_* fallback in apps/api/main.go), so the config widens
+// `envPrefix` to include `VITE_`. If a future edit drops it,
+// `import.meta.env.VITE_WORKOS_CLIENT_ID` silently becomes `undefined` in the
+// browser and AuthKit throws NoClientIdProvidedException in production — a
+// failure the build-time env guard cannot catch, because it reads `process.env`
+// (which is populated) rather than the inlined client bundle (which is not).
+describe("astro.config vite.envPrefix", () => {
+  it("inlines both PUBLIC_ and VITE_ prefixed vars into client bundles", () => {
+    const envPrefix = astroConfig.vite?.envPrefix;
+    expect(envPrefix).toContain("PUBLIC_");
+    expect(envPrefix).toContain("VITE_");
+  });
+});


### PR DESCRIPTION
## Problem

The Navbar throws `NoClientIdProvidedException: Missing Client ID` on **both** production and `just dev`. `.env.local` has `VITE_WORKOS_CLIENT_ID`, and the `require-workos-env` build guard passes — yet the shipped bundle still fails.

## Root cause

Astro defaults Vite's `envPrefix` to `PUBLIC_`, so **only `PUBLIC_`-prefixed vars are inlined into client bundles**. Our WorkOS client config uses the `VITE_` prefix (ported from the old Vite/TanStack app), so `import.meta.env.VITE_WORKOS_CLIENT_ID` in `AuthProvider.tsx` compiled to `undefined` in the browser → AuthKit called `createClient(undefined)` → threw.

Verified against the live bundle (`_astro/Navbar.rXp6fulC.js`): the only `client_…` literal is the SDK's hardcoded **sample** inside the exception text — our real id was never inlined.

The build guard gave false confidence: it reads `process.env.VITE_WORKOS_*` (populated by `--env-file=.env.local`), not the inlined client bundle. So the build "succeeded" while shipping `undefined`.

## Fix

Widen `vite.envPrefix` to `["PUBLIC_", "VITE_"]`. The existing `VITE_WORKOS_*` vars — a convention shared with the Go API's fallback (`apps/api/main.go:90-91`) — are now inlined into the client. No `.env.local`, CI, Go, or Fly-secret changes. Only `VITE_`-prefixed vars in the repo are the two public WorkOS ones, so nothing sensitive is newly exposed.

## Verification

- Built with a dummy id → confirmed the Navbar bundle now inlines `clientId:` with the real value (previously `undefined`); bundle hash changed.
- Console clean, no `NoClientIdProvidedException`.
- 42/42 web tests pass; added a regression test asserting both prefixes stay configured (the env guard can't catch this class of bug).

## Deploy note

Needs a `just deploy` from the checkout with `.env.local`. Assets are content-hashed, so purge the Cloudflare cache (or the cached `index.html`) after deploy; the kill-switch service workers handle any zombie SW.