### PR TITLE
Fix archived meetup issue count: 18 → 19

### DIFF
--- a/docs/meetup/archived-issues.md
+++ b/docs/meetup/archived-issues.md
@@ -3,7 +3,7 @@
 **Archived:** 2026-07-22
 **Status:** all closed / superseded
 
-These are the 18 GitHub issues that were labeled `meetup` (#118–#136), captured verbatim before being closed. They described a first-party Meetup.com replacement (events + RSVPs + AI recaps) planned against the site's **previous** architecture:
+These are the 19 GitHub issues that were labeled `meetup` (#118–#136), captured verbatim before being closed. They described a first-party Meetup.com replacement (events + RSVPs + AI recaps) planned against the site's **previous** architecture:
 
 > TanStack Start + oRPC + Drizzle/Turso (libsql) + WorkOS AuthKit + shadcn/ui + Gemini Flash
 


### PR DESCRIPTION
Follow-up to #316 (already merged), addressing a review comment.

The intro line of `docs/meetup/archived-issues.md` said "18 GitHub issues (#118–#136)", but that range is inclusive — 136 − 118 + 1 = **19** issues (18 sub-issues + the parent epic #136). The file itself contains all 19 issue sections; only the summary number was off by one.

One-line doc fix; range and surrounding text unchanged.