### PR TITLE
ci(dependabot): add 4-day npm cooldown to match bunfig minimumReleaseAge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Mirror bunfig.toml `minimumReleaseAge = 345600` (4 days): Bun refuses to
+    # install versions newer than that, so don't open PRs for them until they
+    # age past the threshold and become installable.
+    cooldown:
+      default-days: 4
 
   - package-ecosystem: "gomod"
     directory: "/apps/api" # The Go module lives here, not at the repo root


### PR DESCRIPTION
Adds a Dependabot `cooldown` to the npm ecosystem so it stops opening PRs for versions Bun cannot yet install.

## Problem

`bunfig.toml` sets `minimumReleaseAge = 345600` (4 days) across the workspace, so Bun refuses to install any package version published less than 4 days ago. Dependabot had no matching setting and opened npm version-update PRs the moment a release landed — those PRs then failed `bun install --frozen-lockfile` in CI (`.github/workflows/test.yml:28`) until the version aged past the threshold.

## Change

```yaml
    cooldown:
      default-days: 4
```

Added to the **npm** entry only. `cooldown.default-days` is Dependabot's direct analog of Bun's `minimumReleaseAge` (GA feature), so Dependabot now waits until a version is 4 days old — exactly when Bun will accept it — before opening the PR.

- Only `default-days` is set. No `semver-major/minor/patch-days`: Bun's 4-day floor is uniform across bump types, and any per-semver value below 4 would reintroduce the failure (e.g. patch PRs opening at 3 days).
- `gomod` is intentionally left unchanged — Go has no install-age constraint.

## Reviewer notes

- GitHub validates `dependabot.yml` on push, not in CI. After merge, confirm a green config at repo → Insights → Dependency graph → Dependabot.
- Existing open PRs for too-new versions will not auto-close; cooldown only gates future runs.