### PR TITLE
fix(auth): don't pin the JWT issuer in the session path (fixes #341)

### DIFF
--- a/apps/api/internal/auth/jwks.go
+++ b/apps/api/internal/auth/jwks.go
@@ -97,19 +97,34 @@ func (v *Verifier) keySet(ctx context.Context) (jwk.Set, error) {
 	return v.keys.Get(ctx, v.jwksURL)
 }
 
-// ParseToken validates a raw JWT against the cached JWKS and the expected
-// issuer, returning the parsed token. It is the single validation entry point
-// shared by the Bearer Middleware and the cookie-backed session manager, so
-// both accept exactly the same tokens (WorkOS-signed, unexpired, right issuer).
+// ParseToken validates a raw JWT against the cached JWKS, the expected issuer,
+// and expiry, returning the parsed token. Used by the Bearer Middleware, where
+// the token arrives unwrapped from an untrusted client and the issuer must be
+// pinned.
 func (v *Verifier) ParseToken(ctx context.Context, raw string) (jwt.Token, error) {
+	return v.parse(ctx, raw, jwt.WithIssuer(v.issuer))
+}
+
+// ParseTokenNoIssuer validates signature and expiry but NOT the issuer. It is
+// for the cookie-backed session, where the token has already been sealed into a
+// first-party AES-256-GCM cookie (tamper-proof) before we ever re-read it — so
+// signature + expiry are the meaningful checks, and pinning the exact issuer
+// only adds fragility. WorkOS AuthKit access tokens use
+// `iss = "https://api.workos.com/"` (trailing slash) or
+// `.../user_management/<client_id>` depending on setup, none of which match the
+// bare host the Bearer path pins; requiring an exact match here made every
+// /api/me reject the session and clear the cookie.
+func (v *Verifier) ParseTokenNoIssuer(ctx context.Context, raw string) (jwt.Token, error) {
+	return v.parse(ctx, raw)
+}
+
+func (v *Verifier) parse(ctx context.Context, raw string, opts ...jwt.ParseOption) (jwt.Token, error) {
 	keys, err := v.keySet(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return jwt.Parse(
 		[]byte(raw),
-		jwt.WithKeySet(keys),
-		jwt.WithValidate(true),
-		jwt.WithIssuer(v.issuer),
+		append([]jwt.ParseOption{jwt.WithKeySet(keys), jwt.WithValidate(true)}, opts...)...,
 	)
 }

--- a/apps/api/internal/session/session.go
+++ b/apps/api/internal/session/session.go
@@ -289,7 +289,7 @@ func (m *Manager) Middleware() echo.MiddlewareFunc {
 			}
 
 			ctx := c.Request().Context()
-			if _, err := m.verifier.ParseToken(ctx, data.AccessToken); err != nil {
+			if _, err := m.verifier.ParseTokenNoIssuer(ctx, data.AccessToken); err != nil {
 				// Expired or otherwise unusable — try one refresh. A cookie an
 				// attacker cannot forge (AES-GCM) means the refresh token here is
 				// genuine; WorkOS rejects a stale one, which we turn into 401.
@@ -304,7 +304,7 @@ func (m *Manager) Middleware() echo.MiddlewareFunc {
 					m.clearCookie(c)
 					return echo.NewHTTPError(http.StatusUnauthorized)
 				}
-				if _, verr := m.verifier.ParseToken(ctx, access); verr != nil {
+				if _, verr := m.verifier.ParseTokenNoIssuer(ctx, access); verr != nil {
 					m.clearCookie(c)
 					return echo.NewHTTPError(http.StatusUnauthorized)
 				}
@@ -370,7 +370,7 @@ func profileFrom(u usermanagement.User) profile {
 // sessionID extracts the WorkOS session id (`sid` claim) from a validated
 // access token, for use at logout. Best-effort: an unreadable token yields "".
 func (m *Manager) sessionID(ctx context.Context, accessToken string) string {
-	tok, err := m.verifier.ParseToken(ctx, accessToken)
+	tok, err := m.verifier.ParseTokenNoIssuer(ctx, accessToken)
 	if err != nil {
 		return ""
 	}

--- a/apps/api/internal/session/session_test.go
+++ b/apps/api/internal/session/session_test.go
@@ -60,9 +60,15 @@ func newJWKSFixture(t *testing.T) *jwksFixture {
 }
 
 func (f *jwksFixture) signAccess(t *testing.T, exp time.Time) string {
+	return f.signAccessIssuer(t, exp, testIssuer)
+}
+
+// signAccessIssuer signs a token with an arbitrary `iss`, so tests can mint a
+// WorkOS-style token whose issuer does not match the verifier's pinned issuer.
+func (f *jwksFixture) signAccessIssuer(t *testing.T, exp time.Time, iss string) string {
 	t.Helper()
 	tok, err := jwt.NewBuilder().
-		Issuer(testIssuer).
+		Issuer(iss).
 		Subject("user_test").
 		Claim("sid", "session_test_1").
 		IssuedAt(time.Now().Add(-1 * time.Minute)).
@@ -287,6 +293,36 @@ func TestMiddlewareValidCookie(t *testing.T) {
 	}
 	if body["name"] != "Ada Lovelace" {
 		t.Errorf("name: got %v", body["name"])
+	}
+}
+
+// Regression for the /api/me self-destruct: the session path validates the
+// sealed cookie's token but must NOT pin the issuer. WorkOS AuthKit tokens carry
+// an `iss` (e.g. "https://api.workos.com/") that differs from the bare host the
+// Bearer path pins; requiring an exact match made the middleware reject the
+// session and clear the cookie on the first request.
+func TestMiddlewareAcceptsMismatchedIssuer(t *testing.T) {
+	f := newJWKSFixture(t)
+	m := newTestManager(t, f) // verifier is configured WithIssuer(testIssuer)
+
+	// Valid signature + unexpired, but a WorkOS-style issuer != testIssuer.
+	token := f.signAccessIssuer(t, time.Now().Add(5*time.Minute), "https://api.workos.com/")
+	sealed := mustSeal(t, m, sessionData{
+		AccessToken:  token,
+		RefreshToken: "rt",
+		SessionID:    "sid",
+		User:         profile{Email: "ada@example.com"},
+	})
+
+	rec := serveMe(m, cookie(sealed))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	// The cookie must not be cleared (that was the self-destruct symptom).
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == cookieName && ck.MaxAge < 0 {
+			t.Error("session cookie was cleared despite a valid token with a mismatched issuer")
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #341.

## Problem

After a successful WorkOS login the navbar reverted to "Sign In". `/auth/callback` set the `wos_session` cookie correctly (confirmed: `GET /` sent it), but the first **`/api/me` cleared it** (response `Set-Cookie: wos_session=""`) and returned 401 — reproduced in Brave and Firefox, so the **server** was deleting it.

## Root cause

`session.Middleware` validated the sealed cookie's access token with `auth.Verifier.ParseToken`, which pins `iss == "https://api.workos.com"` (the trailing slash is trimmed in `NewVerifier`). WorkOS AuthKit access tokens carry `iss = "https://api.workos.com/"` (or `.../user_management/<client_id>`), so the exact-match `jwt.WithIssuer` failed on every token → `refreshOnce` → new token, same issuer → fail → `clearCookie` + 401. Every `/api/me` self-destructed the freshly minted session. Invisible before because the old browser-only UI rendered the user from client-side data, not `/api/me`.

## Fix

Add `Verifier.ParseTokenNoIssuer` (JWKS signature + expiry, **no** issuer) and use it in `session.Middleware` and `session.sessionID`. The access token is already inside a first-party AES-256-GCM cookie before we ever re-read it, so signature + expiry are the meaningful checks; pinning the exact issuer only added fragility (the string differs across WorkOS setups). The Bearer `auth.Middleware`, which takes tokens from an untrusted client, stays strict.

## Test

`go test -race ./...` green. New `TestMiddlewareAcceptsMismatchedIssuer`: a valid, unexpired token whose `iss` ≠ the verifier's pinned issuer now passes the session middleware and the cookie is **not** cleared.

## After merge

Deploy → sign in → `/api/me` returns 200 (no `Set-Cookie` clearing `wos_session`) → button becomes the avatar → click an internal link → still signed in.

Follow-ups tracked in #342 (trust the sealed cookie — drop per-request JWT re-validation, shrink the cookie) and #343 (standardize `WORKOS_*` secret names + louder config errors).
