### PR TITLE
Raise apps/web coverage to 100% and add a 90% floor

### DIFF
--- a/apps/web/src/components/ThemeToggle.test.tsx
+++ b/apps/web/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ThemeToggle from "@/components/ThemeToggle";
+
+// `test/setup.ts` only installs its `matchMedia` stub when jsdom has none, and
+// jsdom ships one — so the component gets jsdom's real MediaQueryList, which
+// never fires a "change" event. Swap in a controllable one whose listeners we
+// can invoke by hand to drive the OS-preference path.
+function stubMatchMedia() {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => ({
+      matches: false,
+      media: "(prefers-color-scheme: dark)",
+      addEventListener: (
+        _type: string,
+        listener: (event: MediaQueryListEvent) => void
+      ) => listeners.add(listener),
+      removeEventListener: (
+        _type: string,
+        listener: (event: MediaQueryListEvent) => void
+      ) => listeners.delete(listener),
+    }))
+  );
+
+  // The listener calls setState outside React's event system, so wrap it in act.
+  return (matches: boolean) =>
+    act(async () => {
+      for (const listener of listeners) {
+        listener({ matches } as MediaQueryListEvent);
+      }
+    });
+}
+
+function getToggle() {
+  return screen.getByRole("button", { name: "Toggle dark mode" });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  // The component mutates the real <html> element and localStorage, so both
+  // leak into the next test unless they are reset here.
+  document.documentElement.className = "";
+  localStorage.clear();
+});
+
+describe("ThemeToggle", () => {
+  test("clicking from light turns dark mode on and stores the choice", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    expect(getToggle()).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(getToggle());
+
+    expect(document.documentElement).toHaveClass("dark");
+    expect(localStorage.getItem("theme")).toBe("dark");
+    expect(getToggle()).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("mounting with dark already set reflects it, and clicking turns it off", async () => {
+    // The inline script in Layout.astro sets this class before the island
+    // hydrates, so the initial state has to be read off the DOM, not assumed.
+    document.documentElement.classList.add("dark");
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    expect(getToggle()).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(getToggle());
+
+    expect(document.documentElement).not.toHaveClass("dark");
+    expect(localStorage.getItem("theme")).toBe("light");
+    expect(getToggle()).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("follows the OS setting while the user has not chosen explicitly", async () => {
+    const fireChange = stubMatchMedia();
+    render(<ThemeToggle />);
+
+    await fireChange(true);
+
+    expect(document.documentElement).toHaveClass("dark");
+    expect(getToggle()).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("ignores the OS setting once a theme is stored", async () => {
+    localStorage.setItem("theme", "light");
+    const fireChange = stubMatchMedia();
+    render(<ThemeToggle />);
+
+    await fireChange(true);
+
+    expect(document.documentElement).not.toHaveClass("dark");
+    expect(getToggle()).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("treats an unreadable localStorage as no stored choice", async () => {
+    // Safari in private mode and cookie-blocking extensions can make these
+    // throw; the component swallows that rather than breaking the navbar.
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    const fireChange = stubMatchMedia();
+    render(<ThemeToggle />);
+
+    await fireChange(true);
+
+    expect(document.documentElement).toHaveClass("dark");
+  });
+
+  test("still toggles when the choice cannot be persisted", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.click(getToggle());
+
+    expect(document.documentElement).toHaveClass("dark");
+    expect(getToggle()).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("works in a browser without matchMedia", async () => {
+    vi.stubGlobal("matchMedia", undefined);
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.click(getToggle());
+
+    expect(document.documentElement).toHaveClass("dark");
+  });
+});

--- a/apps/web/src/components/auth/SignInButton.test.tsx
+++ b/apps/web/src/components/auth/SignInButton.test.tsx
@@ -125,4 +125,109 @@ describe("SignInButton", () => {
       "/auth/logout?returnTo=%2Fevents%2F"
     );
   });
+
+  test("a failed /api/me request falls back to signed out", async () => {
+    // The API being down must not take the whole navbar with it.
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    render(<SignInButton />);
+
+    expect(
+      await screen.findByRole("button", { name: "Sign In" })
+    ).toBeEnabled();
+  });
+
+  test("renders the avatar when /api/me returns one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        meOk({
+          email: "ada@example.com",
+          avatar: "https://example.com/ada.png",
+        })
+      )
+    );
+    const { container } = render(<SignInButton />);
+
+    await screen.findByRole("button", { name: "Sign Out" });
+    // The avatar is decorative (alt=""), so it is not in the a11y tree.
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://example.com/ada.png"
+    );
+  });
+
+  test("falls back to the name when /api/me returns no email", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(meOk({ name: "Ada Lovelace" }))
+    );
+    render(<SignInButton />);
+
+    expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument();
+  });
+
+  test("signed in with an empty profile still renders Sign Out only", async () => {
+    // A 200 with no email, name or avatar is still a valid session; render the
+    // sign-out control without an empty label or a broken image beside it.
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(meOk({})));
+    const { container } = render(<SignInButton />);
+
+    expect(
+      await screen.findByRole("button", { name: "Sign Out" })
+    ).toBeInTheDocument();
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("span")).toBeNull();
+  });
+
+  test("ignores a /api/me response that arrives after unmount", async () => {
+    let settle: (value: unknown) => void = () => {};
+    const pending = new Promise((resolve) => {
+      settle = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pending));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { unmount } = render(<SignInButton />);
+    unmount();
+
+    // The `cancelled` flag set by the effect cleanup is what keeps this late
+    // resolution from touching state on a component that is already gone.
+    settle(meOk({ email: "ada@example.com" }));
+    await pending;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: "Sign Out" })
+    ).not.toBeInTheDocument();
+  });
+
+  test("ignores a /api/me failure that arrives after unmount", async () => {
+    let fail: (reason: unknown) => void = () => {};
+    const pending = new Promise((_resolve, reject) => {
+      fail = reject;
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pending));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { unmount } = render(<SignInButton />);
+    unmount();
+
+    // Same guard as above, on the error path: the component's own .catch keeps
+    // the rejection from surfacing, and `cancelled` keeps it from setting state.
+    fail(new Error("offline"));
+    await pending.catch(() => {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: "Sign In" })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/ui/sheet.test.tsx
+++ b/apps/web/src/components/ui/sheet.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+
+// The navbar drawer only uses Sheet/Trigger/Content/Title, so the header,
+// footer, description and standalone close parts are exercised here instead.
+// The jsdom stubs Base UI's Dialog needs live in `test/setup.ts`.
+function SheetHarness({
+  side,
+  showCloseButton,
+}: {
+  side?: "top" | "right" | "bottom" | "left";
+  showCloseButton?: boolean;
+}) {
+  return (
+    <Sheet>
+      <SheetTrigger>Open panel</SheetTrigger>
+      <SheetContent side={side} showCloseButton={showCloseButton}>
+        <SheetHeader>
+          <SheetTitle>Panel title</SheetTitle>
+          <SheetDescription>Panel description</SheetDescription>
+        </SheetHeader>
+        <SheetFooter>
+          {/* Not named "Close": SheetContent's built-in close button already
+              uses that accessible name, and two would make the query ambiguous. */}
+          <SheetClose>Done</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+describe("Sheet", () => {
+  test("renders the header, title, description and footer once opened", async () => {
+    const user = userEvent.setup();
+    render(<SheetHarness />);
+
+    expect(screen.queryByText("Panel title")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open panel" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(screen.getByText("Panel title")).toBeInTheDocument();
+    expect(screen.getByText("Panel description")).toBeInTheDocument();
+    expect(dialog.querySelector("[data-slot='sheet-header']")).not.toBeNull();
+    expect(dialog.querySelector("[data-slot='sheet-footer']")).not.toBeNull();
+  });
+
+  test("closes when a SheetClose control is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SheetHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Open panel" }));
+    await screen.findByRole("dialog");
+
+    await user.click(screen.getByRole("button", { name: "Done" }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("Panel title")).not.toBeInTheDocument()
+    );
+  });
+
+  test("defaults to the right side and honours an explicit side", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<SheetHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Open panel" }));
+    expect(await screen.findByRole("dialog")).toHaveAttribute(
+      "data-side",
+      "right"
+    );
+
+    unmount();
+    render(<SheetHarness side="left" />);
+
+    await user.click(screen.getByRole("button", { name: "Open panel" }));
+    expect(await screen.findByRole("dialog")).toHaveAttribute(
+      "data-side",
+      "left"
+    );
+  });
+
+  test("omits the built-in close button when showCloseButton is false", async () => {
+    const user = userEvent.setup();
+    render(<SheetHarness showCloseButton={false} />);
+
+    await user.click(screen.getByRole("button", { name: "Open panel" }));
+    await screen.findByRole("dialog");
+
+    expect(
+      screen.queryByRole("button", { name: "Close" })
+    ).not.toBeInTheDocument();
+    // The caller's own close control is unaffected.
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -2,9 +2,13 @@
 import { getViteConfig } from "astro/config";
 
 // Use Astro's Vite config for tests so path aliases (`@/*`) and integration
-// plugins (React) resolve identically to the app build. Coverage discipline is
-// ported from the old app: 100% on `src/lib/**` (pure, testable logic), and no
-// global floor so component/page files don't force meaningless test coverage.
+// plugins (React) resolve identically to the app build. Coverage discipline:
+// 100% on `src/lib/**` (pure, testable logic), and a 90% floor everywhere else
+// so a new untested component can't quietly drag the suite back down. CI runs
+// `bun run --filter web test:coverage`, so these thresholds are the gate.
+// Note: files matched by the `src/lib/**` glob are checked against that entry
+// and excluded from the global numbers. Only `.ts`/`.tsx` is measured — `.astro`
+// pages, components and layouts are outside `include`.
 export default getViteConfig({
   test: {
     globals: true,
@@ -17,6 +21,10 @@ export default getViteConfig({
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.d.ts"],
       thresholds: {
+        lines: 90,
+        statements: 90,
+        functions: 90,
+        branches: 90,
         "src/lib/**": {
           lines: 100,
           branches: 100,

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -9,6 +9,8 @@ exact = true
 # Note: Bun does not run lifecycle scripts by default. Allowlist trusted
 # packages via `"trustedDependencies"` in package.json.
 
-[test]
-coverage = true
-coverageThreshold = 0.9
+# No `[test]` block here on purpose: nothing runs `bun test` at the repo root,
+# and Vitest ignores bunfig, so a root coverage threshold would look like a
+# repo-wide gate while enforcing nothing. The real gates are the thresholds in
+# apps/web/vitest.config.ts and the `[test]` block in
+# apps/email_receiver/bunfig.toml (that app does run `bun test`).


### PR DESCRIPTION
Closes #338.

## What changed

`apps/web` went from **76.5% → 100%** lines (and 100% statements, branches and functions), with a 90% floor added so it can't silently regress.

| | Before | After |
|---|---|---|
| Lines | 52/68 (76.5%) | 68/68 (100%) |
| Statements | 53/72 (73.6%) | 72/72 (100%) |
| Branches | 33/44 (75%) | 44/44 (100%) |
| Functions | 27/34 (79.4%) | 34/34 (100%) |

Tests: 30 → 47.

### Tests

- **`ThemeToggle.test.tsx`** (new, was 10/21 lines and 1/6 branches — the biggest gap): both toggle directions, the pre-hydration `.dark` read that `Layout.astro`'s inline script sets, the `prefers-color-scheme` listener with and without a stored choice, both `localStorage` try/catch paths, and a browser with no `matchMedia`.
  `test/setup.ts` only stubs `matchMedia` when jsdom has none — and jsdom ships one that never fires `change` — so these tests install a controllable `MediaQueryList` whose listeners they invoke by hand.
- **`ui/sheet.test.tsx`** (new, was 6/10 functions): `SheetClose`, `SheetHeader`, `SheetFooter` and `SheetDescription`, none of which the navbar drawer uses, plus the `side` variants and `showCloseButton={false}`.
- **`SignInButton.test.tsx`** (extended, was 18/24 branches): the `/api/me` failure fallback, the avatar and name-fallback labels, an empty `200` profile, and late responses — both resolve and reject — arriving after unmount to exercise the `cancelled` guard.

### Config

- **`apps/web/vitest.config.ts`**: added a global `thresholds` floor of 90% on lines/statements/functions/branches. The existing `src/lib/** = 100%` rule is unchanged. CI already runs `bun run --filter web test:coverage`, so this is enforced on every PR — verified by temporarily setting the floor to 101% and confirming a non-zero exit with `ERROR: Coverage for lines (100%) does not meet global threshold`. The file's leading comment said there was deliberately no global floor, which is no longer true, so it was rewritten.
- **`bunfig.toml`** (root): removed the `[test] coverage / coverageThreshold = 0.9` block. It enforced nothing — no target runs `bun test` at the repo root, and Vitest ignores `bunfig` — while reading like a repo-wide 90% gate. Replaced with a comment naming the two real gates. `apps/email_receiver/bunfig.toml` is untouched and its 90% gate is still live (worker is at 100%).

## Note: the issue's file table was stale

#338 was written before the auth rewrite landed. On current `main`:

- `src/integrations/workos/AuthProvider.tsx` **no longer exists** (removed by #340's pivot to a server-side session), so that task is obsolete.
- `SignInButton.tsx` was rewritten around the cookie-gated `/api/me` and already had 6 tests at 95.5% lines, not 95.2%.
- The "⛔ don't touch the auth files until the auth work lands" caveat no longer applies — #340 and #344 are both ancestors of this branch — so `SignInButton` is covered here rather than deferred.
- The real starting total was 76.5% lines, not the 79.5% quoted.

## Verification

All of the JS side of CI, locally:

- `bun run --filter web test:coverage` → 47 tests pass, 100% on all four metrics, exit 0
- `bunx eslint .` and `bunx stylelint "**/*.{css,scss}"` in `apps/web` → clean
- `bun run --filter email_receiver test` → 11 pass, still 100%

## Out of scope

`.astro` pages, components and layouts — outside the coverage `include`, which is `.ts`/`.tsx` only.