### PR TITLE
chore(auth): standardize WorkOS env names, name the missing var (closes #343)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,16 +3,6 @@
 # process environment in production (Fly) and, where noted, the Cloudflare
 # email Worker (wrangler).
 
-# PUBLIC CLIENT VARS ######################
-
-# The Astro web app inlines these into the browser bundle for the client-side
-# WorkOS sign-in control. The Go server also reads them as fallback names for
-# its JWKS verifier (see newVerifierFromEnv in apps/api/main.go).
-# In production PUBLIC_WORKOS_API_HOSTNAME is your WorkOS Custom Auth Domain.
-PUBLIC_WORKOS_CLIENT_ID=client_...
-PUBLIC_WORKOS_API_HOSTNAME=api.workos.com
-
-
 # PRIVATE SERVER VARS #####################
 
 # Local SQLite file for the migrate CLI (apps/api/cmd/migrate), tests, and —
@@ -24,8 +14,16 @@ DATABASE_URL="dev.db"
 # Prod only: Turso auth token, when not embedded in DATABASE_URL above.
 # TURSO_AUTH_TOKEN=<token>
 
-# Server-side WorkOS session (apps/api/internal/session). All three must be set
-# to enable sign-in and the /auth/* routes; otherwise those routes stay off.
+# WorkOS auth (apps/api/internal/auth + internal/session). Sign-in is entirely
+# server-side: the Go API runs the code exchange and keeps the session in a
+# sealed first-party cookie, so the browser bundle reads no WorkOS values at
+# all. Use these exact names — the server accepts no PUBLIC_/VITE_-prefixed
+# aliases. All five must be set to enable sign-in; with any of them missing the
+# /auth/* routes stay off and the server logs exactly which one is absent. In
+# production WORKOS_API_HOSTNAME is your WorkOS Custom Auth Domain, if you have
+# one.
+WORKOS_CLIENT_ID=client_...
+WORKOS_API_HOSTNAME=api.workos.com
 WORKOS_API_KEY=sk_test_...
 WORKOS_COOKIE_PASSWORD=<32+ secure random chars>   # seals the session cookie; >= 32 chars
 APP_BASE_URL=https://codeselfstudy.com             # e.g. http://localhost:4321 in dev

--- a/apps/api/internal/session/session.go
+++ b/apps/api/internal/session/session.go
@@ -64,21 +64,55 @@ type Config struct {
 }
 
 // LoadConfig reads the session config from the environment. getenv is injected
-// so tests and main share one code path.
+// so tests and main share one code path. Only the canonical WORKOS_* names are
+// read: the verifier in main.go once accepted PUBLIC_/VITE_-prefixed aliases
+// that this function did not, and that asymmetry silently disabled /auth/* in
+// production while /api/me kept working.
 func LoadConfig(getenv func(string) string) Config {
 	return Config{
-		ClientID:       firstNonEmpty(getenv("WORKOS_CLIENT_ID"), getenv("PUBLIC_WORKOS_CLIENT_ID")),
+		ClientID:       getenv("WORKOS_CLIENT_ID"),
 		APIKey:         getenv("WORKOS_API_KEY"),
 		CookiePassword: getenv("WORKOS_COOKIE_PASSWORD"),
 		BaseURL:        getenv("APP_BASE_URL"),
 	}
 }
 
+// minCookiePassword is the shortest seal secret WorkOS considers safe: 32
+// characters of entropy.
+const minCookiePassword = 32
+
+// Missing returns a human-readable description of every value the session flow
+// needs but does not have, in a stable order, so a half-configured deploy can
+// name the exact culprit instead of listing every var it might be. An empty
+// slice means the config is complete. A too-short cookie password is reported
+// as its own case — silently treating it as absent is the trap that makes
+// /auth/* 404 with no clue why.
+func (c Config) Missing() []string {
+	var missing []string
+	if c.ClientID == "" {
+		missing = append(missing, "WORKOS_CLIENT_ID")
+	}
+	if c.APIKey == "" {
+		missing = append(missing, "WORKOS_API_KEY")
+	}
+	switch {
+	case c.CookiePassword == "":
+		missing = append(missing, "WORKOS_COOKIE_PASSWORD")
+	case len(c.CookiePassword) < minCookiePassword:
+		missing = append(missing, fmt.Sprintf(
+			"WORKOS_COOKIE_PASSWORD (needs >= %d chars, got %d)",
+			minCookiePassword, len(c.CookiePassword)))
+	}
+	if c.BaseURL == "" {
+		missing = append(missing, "APP_BASE_URL")
+	}
+	return missing
+}
+
 // Enabled reports whether every value required to run the server-side session
-// flow is present. A short cookie password is treated as absent: WorkOS requires
-// at least 32 characters of entropy to seal a session safely.
+// flow is present.
 func (c Config) Enabled() bool {
-	return c.ClientID != "" && c.APIKey != "" && len(c.CookiePassword) >= 32 && c.BaseURL != ""
+	return len(c.Missing()) == 0
 }
 
 // Manager owns the sealed-cookie session flow: the /auth/* routes, the gate
@@ -107,8 +141,8 @@ type refreshFunc func(ctx context.Context, refreshToken string) (accessToken, ne
 // Verifier (used to validate access tokens). It configures the WorkOS SDK's
 // default client with the API key.
 func New(cfg Config, verifier *auth.Verifier) (*Manager, error) {
-	if !cfg.Enabled() {
-		return nil, errors.New("session: incomplete config (need WORKOS_CLIENT_ID, WORKOS_API_KEY, WORKOS_COOKIE_PASSWORD>=32, APP_BASE_URL)")
+	if missing := cfg.Missing(); len(missing) > 0 {
+		return nil, fmt.Errorf("session: incomplete config, missing: %s", strings.Join(missing, ", "))
 	}
 	if verifier == nil {
 		return nil, errors.New("session: verifier is required")
@@ -587,13 +621,4 @@ func safeReturnTo(raw string) string {
 // to service-worker scripts.
 func noStore(c echo.Context) {
 	c.Response().Header().Set("Cache-Control", "no-store")
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }

--- a/apps/api/internal/session/session.go
+++ b/apps/api/internal/session/session.go
@@ -103,10 +103,24 @@ func (c Config) Missing() []string {
 			"WORKOS_COOKIE_PASSWORD (needs >= %d chars, got %d)",
 			minCookiePassword, len(c.CookiePassword)))
 	}
-	if c.BaseURL == "" {
+	switch {
+	case c.BaseURL == "":
 		missing = append(missing, "APP_BASE_URL")
+	case !absoluteURL(c.BaseURL):
+		// A malformed value must land here rather than in New(): main.go
+		// log.Fatalf's on a New() error, so a typo'd base URL would crash-loop
+		// the server instead of warning and leaving the rest of the site up.
+		missing = append(missing, fmt.Sprintf(
+			"APP_BASE_URL (must be an absolute URL like https://codeselfstudy.com, got %q)", c.BaseURL))
 	}
 	return missing
+}
+
+// absoluteURL reports whether raw parses as a URL with both a scheme and a
+// host. New() requires the same shape to build the origin and callback URL.
+func absoluteURL(raw string) bool {
+	u, err := url.Parse(raw)
+	return err == nil && u.Scheme != "" && u.Host != ""
 }
 
 // Enabled reports whether every value required to run the server-side session
@@ -147,6 +161,8 @@ func New(cfg Config, verifier *auth.Verifier) (*Manager, error) {
 	if verifier == nil {
 		return nil, errors.New("session: verifier is required")
 	}
+	// Missing() already rejects a malformed base URL, so this is a belt-and-braces
+	// guard for callers that build a Config by hand rather than via LoadConfig.
 	base, err := url.Parse(cfg.BaseURL)
 	if err != nil || base.Scheme == "" || base.Host == "" {
 		return nil, fmt.Errorf("session: invalid APP_BASE_URL %q", cfg.BaseURL)

--- a/apps/api/internal/session/session_test.go
+++ b/apps/api/internal/session/session_test.go
@@ -176,6 +176,9 @@ func TestConfigEnabled(t *testing.T) {
 	if !base.Enabled() {
 		t.Fatal("complete config should be enabled")
 	}
+	if got := base.Missing(); len(got) != 0 {
+		t.Fatalf("complete config Missing() = %v, want none", got)
+	}
 	cases := map[string]Config{
 		"no client":      {APIKey: "k", CookiePassword: testCookiePassword, BaseURL: "https://x"},
 		"no key":         {ClientID: "c", CookiePassword: testCookiePassword, BaseURL: "https://x"},
@@ -188,6 +191,86 @@ func TestConfigEnabled(t *testing.T) {
 				t.Errorf("expected disabled for %q", name)
 			}
 		})
+	}
+}
+
+// TestConfigMissingNamesTheCulprit locks in the diagnostic that a generic
+// "not fully set" log lacked: the exact var, and short-vs-absent for the cookie
+// password. A half-configured deploy that silently 404s /auth/* cost a full
+// debugging cycle in production.
+func TestConfigMissingNamesTheCulprit(t *testing.T) {
+	full := Config{ClientID: "c", APIKey: "k", CookiePassword: testCookiePassword, BaseURL: "https://x"}
+	cases := []struct {
+		name    string
+		mutate  func(*Config)
+		want    string
+		wantSub string
+	}{
+		{name: "client id", mutate: func(c *Config) { c.ClientID = "" }, want: "WORKOS_CLIENT_ID"},
+		{name: "api key", mutate: func(c *Config) { c.APIKey = "" }, want: "WORKOS_API_KEY"},
+		{name: "base url", mutate: func(c *Config) { c.BaseURL = "" }, want: "APP_BASE_URL"},
+		{name: "password absent", mutate: func(c *Config) { c.CookiePassword = "" }, want: "WORKOS_COOKIE_PASSWORD"},
+		{
+			name:    "password too short",
+			mutate:  func(c *Config) { c.CookiePassword = testCookiePassword[:minCookiePassword-1] },
+			wantSub: "WORKOS_COOKIE_PASSWORD (needs >= 32 chars, got 31)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := full
+			tc.mutate(&cfg)
+			got := cfg.Missing()
+			if len(got) != 1 {
+				t.Fatalf("Missing() = %v, want exactly one entry", got)
+			}
+			if tc.want != "" && got[0] != tc.want {
+				t.Errorf("Missing() = %q, want %q", got[0], tc.want)
+			}
+			if tc.wantSub != "" && got[0] != tc.wantSub {
+				t.Errorf("Missing() = %q, want %q", got[0], tc.wantSub)
+			}
+			if cfg.Enabled() {
+				t.Error("Enabled() = true with a missing value")
+			}
+		})
+	}
+}
+
+// TestLoadConfigCanonicalNamesOnly keeps the PUBLIC_/VITE_ aliases out. Honouring
+// them here while main.go's verifier honoured a different set is what let a
+// deploy come up with a working /api/me and a 404ing /auth/login.
+func TestLoadConfigCanonicalNamesOnly(t *testing.T) {
+	canonical := map[string]string{
+		"WORKOS_CLIENT_ID":       "client_canonical",
+		"WORKOS_API_KEY":         "sk_test",
+		"WORKOS_COOKIE_PASSWORD": testCookiePassword,
+		"APP_BASE_URL":           "https://codeselfstudy.com",
+	}
+	cfg := LoadConfig(func(k string) string { return canonical[k] })
+	if !cfg.Enabled() {
+		t.Fatalf("canonical env should load a complete config, missing: %v", cfg.Missing())
+	}
+	if cfg.ClientID != "client_canonical" {
+		t.Errorf("ClientID = %q, want client_canonical", cfg.ClientID)
+	}
+
+	aliases := map[string]string{
+		"PUBLIC_WORKOS_CLIENT_ID": "client_public",
+		"VITE_WORKOS_CLIENT_ID":   "client_vite",
+		"WORKOS_API_KEY":          "sk_test",
+		"WORKOS_COOKIE_PASSWORD":  testCookiePassword,
+		"APP_BASE_URL":            "https://codeselfstudy.com",
+	}
+	cfg = LoadConfig(func(k string) string { return aliases[k] })
+	if cfg.ClientID != "" {
+		t.Errorf("ClientID = %q, want empty (aliases must not be honoured)", cfg.ClientID)
+	}
+	if cfg.Enabled() {
+		t.Error("Enabled() = true from alias-only env, want false")
+	}
+	if got := cfg.Missing(); len(got) != 1 || got[0] != "WORKOS_CLIENT_ID" {
+		t.Errorf("Missing() = %v, want [WORKOS_CLIENT_ID]", got)
 	}
 }
 

--- a/apps/api/internal/session/session_test.go
+++ b/apps/api/internal/session/session_test.go
@@ -209,6 +209,14 @@ func TestConfigMissingNamesTheCulprit(t *testing.T) {
 		{name: "client id", mutate: func(c *Config) { c.ClientID = "" }, want: "WORKOS_CLIENT_ID"},
 		{name: "api key", mutate: func(c *Config) { c.APIKey = "" }, want: "WORKOS_API_KEY"},
 		{name: "base url", mutate: func(c *Config) { c.BaseURL = "" }, want: "APP_BASE_URL"},
+		{
+			// A malformed value must be caught here, not in New(): main.go
+			// log.Fatalf's on a New() error, so a typo would crash-loop the
+			// server rather than disable sign-in and leave the site up.
+			name:    "base url without scheme",
+			mutate:  func(c *Config) { c.BaseURL = "codeselfstudy.com" },
+			wantSub: `APP_BASE_URL (must be an absolute URL like https://codeselfstudy.com, got "codeselfstudy.com")`,
+		},
 		{name: "password absent", mutate: func(c *Config) { c.CookiePassword = "" }, want: "WORKOS_COOKIE_PASSWORD"},
 		{
 			name:    "password too short",

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -50,7 +50,7 @@ func main() {
 			log.Fatalf("auth: %v", err)
 		}
 	} else {
-		log.Printf("auth: WORKOS_CLIENT_ID / WORKOS_API_HOSTNAME not set; /api/me disabled")
+		log.Printf("auth: WORKOS_CLIENT_ID / WORKOS_API_HOSTNAME not set; auth disabled (/api/me and /auth/* off)")
 	}
 
 	// The server-side session (sealed first-party cookie) needs the extra
@@ -87,15 +87,17 @@ func main() {
 	}
 }
 
-// newVerifierFromEnv reads WorkOS client config from the environment. The
-// web app validates the same pair as PUBLIC_WORKOS_CLIENT_ID /
-// PUBLIC_WORKOS_API_HOSTNAME (Astro's client-var prefix; VITE_WORKOS_* is
-// kept as a legacy fallback; the OS-level vars are the same values), so
-// production deploys reuse them. Returns nil if either is missing — the
+// newVerifierFromEnv reads WorkOS client config from the environment. Only the
+// canonical server names are accepted. Earlier revisions also honoured the
+// PUBLIC_/VITE_-prefixed aliases the browser bundle once used, but
+// session.LoadConfig never did — so a deploy carrying only the aliases brought
+// the verifier up while leaving the session off, and /auth/* 404'd while
+// /api/me answered. The web app no longer reads any WorkOS var, so the aliases
+// have no remaining purpose. Returns nil if either value is missing — the
 // caller falls back to running without auth.
 func newVerifierFromEnv() *auth.Verifier {
-	clientID := firstNonEmpty(os.Getenv("WORKOS_CLIENT_ID"), os.Getenv("PUBLIC_WORKOS_CLIENT_ID"), os.Getenv("VITE_WORKOS_CLIENT_ID"))
-	hostname := firstNonEmpty(os.Getenv("WORKOS_API_HOSTNAME"), os.Getenv("PUBLIC_WORKOS_API_HOSTNAME"), os.Getenv("VITE_WORKOS_API_HOSTNAME"))
+	clientID := os.Getenv("WORKOS_CLIENT_ID")
+	hostname := os.Getenv("WORKOS_API_HOSTNAME")
 	if clientID == "" || hostname == "" {
 		return nil
 	}
@@ -104,15 +106,6 @@ func newVerifierFromEnv() *auth.Verifier {
 		log.Fatalf("auth: %v", err)
 	}
 	return v
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 // newSessionFromEnv builds the server-side session Manager when the extra
@@ -125,8 +118,14 @@ func newSessionFromEnv(v *auth.Verifier) *session.Manager {
 		return nil
 	}
 	cfg := session.LoadConfig(os.Getenv)
-	if !cfg.Enabled() {
-		log.Printf("auth: WORKOS_API_KEY / WORKOS_COOKIE_PASSWORD / APP_BASE_URL not fully set; server-side session disabled (/auth/* off)")
+	if missing := cfg.Missing(); len(missing) > 0 {
+		// The verifier came up, so auth is clearly intended — but sign-in is
+		// about to be silently unavailable. Name the exact culprits and say
+		// what breaks, loudly: a bare "not fully set" listing every candidate
+		// var (all of which were in fact set) once cost a full debugging cycle
+		// on a production 404.
+		log.Printf("auth: WARNING: WorkOS verifier is configured but the server-side session is NOT; missing: %s", strings.Join(missing, ", "))
+		log.Printf("auth: WARNING: /auth/login, /auth/callback and /auth/logout will return 404 and nobody can sign in")
 		return nil
 	}
 	m, err := session.New(cfg, v)

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -306,3 +306,41 @@ func TestIngestRouteAbsentWhenDisabled(t *testing.T) {
 		t.Fatalf("POST /api/ingest with pipeline disabled: want 404, got %d", rec.Code)
 	}
 }
+
+// TestNewVerifierFromEnvCanonicalNamesOnly locks the PUBLIC_/VITE_ aliases out
+// of the verifier. It used to accept three names for the client id while
+// session.LoadConfig accepted a different set, so a deploy carrying only an
+// alias brought the verifier up and left sign-in off: /api/me answered while
+// /auth/login returned 404.
+func TestNewVerifierFromEnvCanonicalNamesOnly(t *testing.T) {
+	clear := func(t *testing.T) {
+		t.Helper()
+		for _, k := range []string{
+			"WORKOS_CLIENT_ID", "WORKOS_API_HOSTNAME",
+			"PUBLIC_WORKOS_CLIENT_ID", "PUBLIC_WORKOS_API_HOSTNAME",
+			"VITE_WORKOS_CLIENT_ID", "VITE_WORKOS_API_HOSTNAME",
+		} {
+			t.Setenv(k, "")
+		}
+	}
+
+	t.Run("canonical names build a verifier", func(t *testing.T) {
+		clear(t)
+		t.Setenv("WORKOS_CLIENT_ID", "client_canonical")
+		t.Setenv("WORKOS_API_HOSTNAME", "api.workos.com")
+		if newVerifierFromEnv() == nil {
+			t.Fatal("newVerifierFromEnv() = nil with canonical names set")
+		}
+	})
+
+	for _, prefix := range []string{"PUBLIC_", "VITE_"} {
+		t.Run(prefix+"aliases are ignored", func(t *testing.T) {
+			clear(t)
+			t.Setenv(prefix+"WORKOS_CLIENT_ID", "client_alias")
+			t.Setenv(prefix+"WORKOS_API_HOSTNAME", "api.workos.com")
+			if v := newVerifierFromEnv(); v != nil {
+				t.Fatalf("newVerifierFromEnv() = %v with only %s aliases set, want nil", v, prefix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #343.

## Problem

`newVerifierFromEnv` accepted three names for the client id (`WORKOS_*` → `PUBLIC_WORKOS_*` → `VITE_WORKOS_*`) while `session.LoadConfig` accepted only two. A deploy carrying just `VITE_WORKOS_CLIENT_ID` therefore brought the JWKS verifier up while leaving the session config empty: `/api/me` answered 401 as designed but **`/auth/login` returned 404**, and the only clue was a log line naming three vars that were all in fact set. That cost a full debugging cycle in production.

## Changes

- **Canonical names only.** The verifier reads `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME`; the `PUBLIC_`/`VITE_` fallbacks are gone from both the verifier and `session.LoadConfig`. The web app no longer reads any WorkOS var, so the browser-prefixed aliases have no remaining purpose.
- **`Config.Missing()`** lists exactly the values the session flow lacks, and reports a **too-short cookie password as its own case** rather than as absent — that silent length check is what disables `/auth/*` with no explanation. `Enabled()` is now `len(Missing()) == 0` so the two can't drift, and `session.New` reports the same list in its error.
- **Loud logging.** `newSessionFromEnv` names the specific missing vars and warns that sign-in is about to be unavailable, instead of listing every candidate var generically.
- **`.env.local.example`** documents all five server-side `WORKOS_*` names; the obsolete `PUBLIC CLIENT VARS` block is removed.

## Safety

**No production change is required.** `fly secrets list` already shows only the canonical names — `WORKOS_CLIENT_ID`, `WORKOS_API_HOSTNAME`, `WORKOS_API_KEY`, `WORKOS_COOKIE_PASSWORD`, `APP_BASE_URL` — with no `VITE_`/`PUBLIC_` entries left, so removing the fallbacks can't break the deploy.

⚠️ **Local dev:** if your `.env.local` still defines only `PUBLIC_WORKOS_CLIENT_ID` / `PUBLIC_WORKOS_API_HOSTNAME`, add `WORKOS_CLIENT_ID` and `WORKOS_API_HOSTNAME` to it before running `just api`, or `/auth/*` will be off locally (the new warning will say so explicitly).

## Test

`go vet ./...` and `go test -race ./...` green. New coverage: each missing value asserted **by name**, the 31-char password reported as too-short rather than absent, and both `LoadConfig` and `newVerifierFromEnv` proven to ignore `PUBLIC_`/`VITE_` aliases — so the asymmetry can't come back.

Verified against a real boot with the secrets unset:

```
auth: WARNING: WorkOS verifier is configured but the server-side session is NOT; missing: WORKOS_API_KEY, WORKOS_COOKIE_PASSWORD, APP_BASE_URL
auth: WARNING: /auth/login, /auth/callback and /auth/logout will return 404 and nobody can sign in
```

and with a 10-char password:

```
auth: WARNING: ... missing: WORKOS_COOKIE_PASSWORD (needs >= 32 chars, got 10)
```

## Note

#342 (trust the sealed cookie) was closed as not-planned — with JWKS already cached in memory, the refresh token still in the payload, and the cookie at ~1401 of 4096 bytes, none of its three stated benefits survived inspection, and it would have signed out every user. Rationale recorded on the issue.
