### PR TITLE
style(api): gofmt apps/api/internal/auth

### DIFF
--- a/apps/api/internal/auth/auth_test.go
+++ b/apps/api/internal/auth/auth_test.go
@@ -191,7 +191,7 @@ func TestMiddlewareRejects(t *testing.T) {
 			header: "Basic abc",
 		},
 		{
-			name:   "expired token",
+			name: "expired token",
 			header: "Bearer " + f.signToken(t, func(tok jwt.Token) {
 				_ = tok.Set(jwt.IssuedAtKey, time.Now().Add(-1*time.Hour))
 				_ = tok.Set(jwt.ExpirationKey, time.Now().Add(-30*time.Minute))

--- a/apps/api/internal/auth/jwks.go
+++ b/apps/api/internal/auth/jwks.go
@@ -20,10 +20,10 @@ import (
 // validation. Construct one per process via NewVerifier; the cache refreshes
 // itself on a goroutine in the background.
 type Verifier struct {
-	jwksURL  string
-	issuer   string
-	keys     *jwk.Cache
-	refresh  time.Duration
+	jwksURL string
+	issuer  string
+	keys    *jwk.Cache
+	refresh time.Duration
 }
 
 // NewVerifier builds a Verifier that pulls keys from the WorkOS JWKS endpoint


### PR DESCRIPTION
## What

`gofmt -l apps/api/internal/auth/` listed two files:

- `apps/api/internal/auth/jwks.go` — struct-field alignment in the `Verifier` type
- `apps/api/internal/auth/auth_test.go` — one composite-literal field in a table test

Ran `gofmt -w` on both. Whitespace only; no behavior change.

## Why

Repo hygiene. The drift dates to the files' original creation in 11a8293, not to any recent change. CI runs `go test -race` and `go vet` but no gofmt check, so this was never failing anything — it just meant an editor with format-on-save would produce spurious diffs in those files.

## Verification

- `gofmt -l apps/api/` — empty
- `cd apps/api && go vet ./...` — clean
- `cd apps/api && go test -race ./...` — all packages pass