### PR TITLE
test(session): fix flaky tamper assertions by mutating the first base64 char

### DIFF
--- a/apps/api/internal/session/session_test.go
+++ b/apps/api/internal/session/session_test.go
@@ -158,15 +158,23 @@ func cookieFrom(rec *httptest.ResponseRecorder) string {
 	return ""
 }
 
-func flipLast(s string) string {
+// flipFirst mutates the FIRST character of a base64 string, not the last.
+// Everything here is RawURLEncoding (unpadded), so when the encoded length is
+// 2 or 3 mod 4 the final character's low bits map to no output byte and Go's
+// non-strict decoder silently drops them: flipping a trailing 'A' to 'B' (values
+// 0 and 1, differing only in bit 0) decodes to the IDENTICAL bytes, the tamper
+// is a no-op, and the "rejects tampered input" assertions fail at random. The
+// first character is always fully significant, so this always changes the
+// decoded bytes.
+func flipFirst(s string) string {
 	if s == "" {
 		return "A"
 	}
 	repl := byte('A')
-	if s[len(s)-1] == 'A' {
+	if s[0] == 'A' {
 		repl = 'B'
 	}
-	return s[:len(s)-1] + string(repl)
+	return string(repl) + s[1:]
 }
 
 // --- tests -----------------------------------------------------------------
@@ -233,7 +241,7 @@ func TestUnsealRejectsTamperAndWrongKey(t *testing.T) {
 	m := newTestManager(t, f)
 	sealed := mustSeal(t, m, sessionData{AccessToken: "at"})
 
-	if _, err := m.unseal(flipLast(sealed)); err == nil {
+	if _, err := m.unseal(flipFirst(sealed)); err == nil {
 		t.Error("expected unseal to reject tampered ciphertext")
 	}
 
@@ -251,7 +259,7 @@ func TestStateSignVerify(t *testing.T) {
 	if !ok || got != "/events/" || nonce != "nonce123" {
 		t.Fatalf("verifyState round-trip: got %q nonce %q ok=%v", got, nonce, ok)
 	}
-	if _, _, ok := m.verifyState(flipLast(state)); ok {
+	if _, _, ok := m.verifyState(flipFirst(state)); ok {
 		t.Error("tampered state should not verify")
 	}
 	if _, _, ok := m.verifyState("not-base64!!"); ok {
@@ -342,7 +350,7 @@ func TestMiddlewareRejectsMissingAndTampered(t *testing.T) {
 		}
 	})
 	t.Run("tampered", func(t *testing.T) {
-		if rec := serveMe(m, cookie(flipLast(good))); rec.Code != http.StatusUnauthorized {
+		if rec := serveMe(m, cookie(flipFirst(good))); rec.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401 got %d", rec.Code)
 		}
 	})


### PR DESCRIPTION
## Problem

`TestMiddlewareRejectsMissingAndTampered/tampered` in `apps/api/internal/session/session_test.go` failed intermittently with `want 401 got 200` — roughly 4 in 50 runs. Not caused by any change to `internal/session`; the bug is in the test helper and has been latent since the helper was written.

## Root cause

`flipLast` tampered with a base64 string by replacing the **last** character with `'A'`, or `'B'` when it was already `'A'`.

Everything in this package is `base64.RawURLEncoding` (unpadded). When the encoded length is 2 or 3 mod 4, the final character's low bits map to no output byte, and Go's non-strict decoder silently discards them. `'A'` and `'B'` are base64 values 0 and 1 — they differ *only* in bit 0, exactly the bit that gets dropped.

So whenever the sealed cookie happened to end in `'A'` at one of those lengths, the "tampered" value decoded to the **identical** ciphertext, AES-GCM authenticated it, and the middleware correctly returned 200. The sealed length varies run to run because the fixture JWT's length is not constant — hence the intermittency.

Demonstrated directly (all-zero input, so the canonical encoding ends in `'A'`):

```
bytes= 1 len= 2 len%4=2  flipLast-identical=true   flipFirst-identical=false
bytes= 2 len= 3 len%4=3  flipLast-identical=true   flipFirst-identical=false
bytes= 3 len= 4 len%4=0  flipLast-identical=false  flipFirst-identical=false
```

## Fix

Mutate the **first** character instead. Every leading character carries 6 fully significant bits, so the decoded bytes always change — and for a sealed cookie the changed byte lands in the GCM nonce.

`flipLast` → `flipFirst`. The two other call sites had the same latent bug and are fixed by the same change:

- `TestUnsealRejectsTamperAndWrongKey` (tampered ciphertext)
- `TestStateSignVerify` (tampered signed state)

## Verification

- `go test -count=200 -run 'TestMiddlewareRejectsMissingAndTampered|TestUnsealRejectsTamperAndWrongKey|TestStateSignVerify' ./internal/session/...` — 200/200 pass (was ~8% failure before)
- `go test ./...` — full API suite green
- `go vet ./...` — clean

## Not done here

`unseal` accepts non-canonical base64: a cookie with garbage trailing bits still decodes and authenticates, so distinct cookie strings can map to the same session. Decoding with `base64.RawURLEncoding.Strict()` would reject that outright, but it is a production behavior change and deserves its own decision, so it is deliberately left out of this test-only fix.

**No production code is touched by this PR.**