### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,16 @@ updates:
       golang-x:
         patterns:
           - "golang.org/x/*"
+
+  # Keep the workflow actions current so their bundled Node runtime doesn't drift
+  # onto a deprecated version (the reason checkout/setup-go/upload-artifact all
+  # needed a manual node20 -> node24 bump). Workflows live in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # One PR for all action bumps rather than one per action.
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
           cache-dependency-path: apps/api/go.sum
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-html
           path: apps/web/coverage/


### PR DESCRIPTION
## Why

CI was warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-go@v5, actions/upload-artifact@v4.

GitHub is [removing the Node 20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) from Actions runners. The runner force-runs these three on Node 24 for now (the warning); once Node 20 is fully removed they **hard-fail**.

## What

Bump each to its current major — all declare `runs.using: node24` (verified via `gh api .../action.yml`):

| Action | Before | After | node24 first at |
| --- | --- | --- | --- |
| actions/checkout | v4 | **v7** | v5 |
| actions/setup-go | v5 | **v7** | v7 |
| actions/upload-artifact | v4 | **v7** | v6 |

`oven-sh/setup-bun@v2` already runs on node24 — left untouched (correctly absent from the warning).

Reviewed every major crossed; none affects this workflow:

- **checkout v7** blocks fork-PR checkout only for `pull_request_target` / `workflow_run` — this workflow is `pull_request` + `push`.
- **setup-go v7** — node24 lives only in v7. v6 carried a toolchain-handling change; we pin `go-version: "1.26"`, and the CI run confirms Go still resolves to 1.26 (the `go test`/`vet`/`govulncheck` steps exercise it).
- **upload-artifact v7** — direct-upload is opt-in (`archive: false`, default unchanged); the disruptive v3→v4 immutable-artifact change is already behind us.

## Also: stop the drift at the source

`.github/dependabot.yml` tracked `npm` + `gomod` but **not** `github-actions`, which is why these majors silently fell behind. Added a `github-actions` ecosystem, grouped into a single weekly PR (matching the existing `golang-x` grouping style).

## Verification

- Both YAML files parse.
- This PR's own `test` run is the check: the Node-20 deprecation annotation should be gone and all steps green.

Independent of the still-open #353 (forwarding allowlist) — this touches only `.github/`.

@coderabbitai review