### PR TITLE
feat(users): username validation, reserved names, generation (#348)

### DIFF
--- a/apps/api/internal/users/username.go
+++ b/apps/api/internal/users/username.go
@@ -1,0 +1,127 @@
+// Package users owns user accounts: the username rules and first-username
+// generation in this file, plus (in sibling files) the store-backed settings
+// API. This file is deliberately dependency-free — no database, no HTTP —
+// mirroring the framework-free internal packages (mailparse, htmltext) so the
+// rules can be exhaustively unit-tested in isolation.
+package users
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// Username length bounds. A username is also the user's display name; there is
+// no separate display-name field.
+const (
+	MinLen = 3
+	MaxLen = 30
+)
+
+// Validate rejects a username. Callers map these to a 400:
+//   - ErrUsernameInvalid: wrong length, illegal character, or a non-alphanumeric
+//     first/last character.
+//   - ErrUsernameReserved: a name the site keeps for routes or to block
+//     impersonation (see Reserved).
+var (
+	ErrUsernameInvalid  = errors.New("username: invalid format")
+	ErrUsernameReserved = errors.New("username: reserved")
+)
+
+// usernameRE encodes the whole format rule in one pass: 3–30 characters drawn
+// from ASCII letters, digits, hyphen and underscore, starting AND ending with an
+// alphanumeric. The {1,28} middle plus the two anchored ends yields the 3–30
+// length bound. The charset is ASCII-only on purpose: the uniqueness index is
+// COLLATE NOCASE, which folds ASCII only, so restricting input here keeps
+// "JaneDoe" and "janedoe" provably the same handle.
+var usernameRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{1,28}[A-Za-z0-9]$`)
+
+// Validate reports whether s is an acceptable username, returning a specific
+// sentinel error otherwise (see the error vars). It never partially accepts:
+// Generate is guaranteed to produce a value that passes this check.
+func Validate(s string) error {
+	if !usernameRE.MatchString(s) {
+		return ErrUsernameInvalid
+	}
+	if IsReserved(s) {
+		return ErrUsernameReserved
+	}
+	return nil
+}
+
+// reserved is the case-insensitive set of names nobody may take. Two categories:
+// paths the site already serves (or plausibly will), so a future /u/<username>/
+// route can never shadow or be shadowed by a real page; and identities that
+// would let one user impersonate staff or the brand. Stored lowercase; look up
+// via IsReserved, which folds case. Adding a name here is the cheap insurance
+// that makes public profile URLs safe later without a data migration.
+var reserved = map[string]struct{}{
+	// Route collisions (present or plausible).
+	"about": {}, "events": {}, "settings": {}, "auth": {}, "api": {},
+	"login": {}, "logout": {}, "me": {}, "s": {}, "learn": {}, "jobs": {},
+	"forum": {}, "puzzles": {}, "tools": {}, "codewars": {}, "contact": {},
+	"credits": {}, "discounts": {}, "404": {}, "u": {},
+	// Impersonation.
+	"admin": {}, "root": {}, "staff": {}, "moderator": {}, "support": {},
+	"system": {}, "codeselfstudy": {},
+}
+
+// IsReserved reports whether s is a reserved name, case-insensitively.
+func IsReserved(s string) bool {
+	_, ok := reserved[strings.ToLower(s)]
+	return ok
+}
+
+// Generate derives a first username for a brand-new account from the WorkOS
+// profile. It always returns a value that satisfies Validate — callers can seed
+// the row with it directly. It does NOT guarantee uniqueness; the store owns the
+// -2/-3 dedupe against the unique index, because uniqueness is a database
+// property, not a string property.
+//
+// Preference order: the slugified full name, then the email local-part, then the
+// literal "user". A reserved result (e.g. "admin") is disambiguated with a
+// trailing digit rather than discarded. Note the email fallback can surface part
+// of the address in a name that may become public later; the sign-up UX
+// mitigates this by showing the generated name in a focused, pre-selected box
+// before it is ever exposed.
+func Generate(firstName, lastName, email string) string {
+	for _, raw := range []string{firstName + lastName, localPart(email)} {
+		s := slug(raw)
+		if len(s) > MaxLen {
+			s = s[:MaxLen]
+		}
+		if len(s) < MinLen {
+			continue
+		}
+		if IsReserved(s) {
+			s = s + "1" // "admin" -> "admin1"; slug output is short, stays under MaxLen
+		}
+		if Validate(s) == nil {
+			return s
+		}
+	}
+	return "user"
+}
+
+// slug lowercases s and keeps only ASCII alphanumerics, dropping everything else
+// (spaces, dots, punctuation). "Jane Doe" -> "janedoe", "jane.doe" -> "janedoe".
+// The result is therefore always a valid username body (its every character is
+// alphanumeric, so any non-empty, length-bounded slice passes usernameRE).
+func slug(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// localPart returns the portion of email before the first '@', or the whole
+// string when there is no '@'.
+func localPart(email string) string {
+	if i := strings.IndexByte(email, '@'); i >= 0 {
+		return email[:i]
+	}
+	return email
+}

--- a/apps/api/internal/users/username_test.go
+++ b/apps/api/internal/users/username_test.go
@@ -1,0 +1,126 @@
+package users
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want error
+	}{
+		// Accepted.
+		{"min length", "abc", nil},
+		{"with underscore", "jane_doe", nil},
+		{"with hyphen", "a-b", nil},
+		{"digits", "user123", nil},
+		{"mixed case preserved", "JaneDoe", nil},
+		{"max length", strings.Repeat("a", MaxLen), nil},
+		{"digits at ends around symbols", "1_-_2", nil},
+
+		// Format failures.
+		{"empty", "", ErrUsernameInvalid},
+		{"too short", "ab", ErrUsernameInvalid},
+		{"too long", strings.Repeat("a", MaxLen+1), ErrUsernameInvalid},
+		{"illegal char", "ab!c", ErrUsernameInvalid},
+		{"space", "ab c", ErrUsernameInvalid},
+		{"leading hyphen", "-abc", ErrUsernameInvalid},
+		{"trailing hyphen", "abc-", ErrUsernameInvalid},
+		{"leading underscore", "_abc", ErrUsernameInvalid},
+		{"trailing underscore", "abc_", ErrUsernameInvalid},
+		{"unicode", "jösé", ErrUsernameInvalid},
+
+		// Reserved (format is fine).
+		{"reserved admin", "admin", ErrUsernameReserved},
+		{"reserved admin uppercase", "ADMIN", ErrUsernameReserved},
+		{"reserved settings mixed", "Settings", ErrUsernameReserved},
+		{"reserved api", "api", ErrUsernameReserved},
+		{"reserved brand", "codeselfstudy", ErrUsernameReserved},
+		{"reserved profile prefix", "u", ErrUsernameInvalid}, // also too short, format wins
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Validate(tc.in); !errors.Is(got, tc.want) {
+				t.Errorf("Validate(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Every reserved name (long enough to clear the format check) must be rejected
+// as reserved, in any case, so the set can't silently rot as routes are added.
+func TestReservedNamesRejected(t *testing.T) {
+	for name := range reserved {
+		if len(name) < MinLen {
+			continue // e.g. "s", "u", "me" fail the format check first; covered above
+		}
+		for _, variant := range []string{name, strings.ToUpper(name), capitalize(name)} {
+			if err := Validate(variant); !errors.Is(err, ErrUsernameReserved) {
+				t.Errorf("Validate(%q) = %v, want ErrUsernameReserved", variant, err)
+			}
+		}
+	}
+}
+
+// capitalize upper-cases the first byte only — a mixed-case variant for the
+// case-insensitivity check, without the deprecated strings.Title.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func TestGenerate(t *testing.T) {
+	cases := []struct {
+		name                       string
+		first, last, email, expect string
+	}{
+		{"full name", "Jane", "Doe", "jane.doe@example.com", "janedoe"},
+		{"name with spaces and punctuation", "Ada", "O'Lovelace", "a@b.com", "adaolovelace"},
+		{"uppercased name is folded", "JANE", "DOE", "x@y.com", "janedoe"},
+		{"falls back to email local part", "", "", "coder99@example.com", "coder99"},
+		{"email local part is slugified", "", "", "jane.doe@example.com", "janedoe"},
+		{"short name falls through to email", "Al", "", "bighandle@example.com", "bighandle"},
+		{"everything empty yields user", "", "", "", "user"},
+		{"unusable email yields user", "", "", "@nope.com", "user"},
+		{"reserved slug is disambiguated", "Admin", "", "x@y.com", "admin1"},
+		{"name too short and email too short yields user", "Jo", "", "al@x.com", "user"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Generate(tc.first, tc.last, tc.email)
+			if got != tc.expect {
+				t.Errorf("Generate(%q,%q,%q) = %q, want %q", tc.first, tc.last, tc.email, got, tc.expect)
+			}
+		})
+	}
+}
+
+// Whatever Generate returns must itself be a valid username — the sign-up flow
+// seeds the row with it directly, so an invalid generation would be a stored
+// broken account.
+func TestGenerateAlwaysValid(t *testing.T) {
+	cases := [][3]string{
+		{"Jane", "Doe", "jane@example.com"},
+		{"", "", ""},
+		{"", "", "@bad.com"},
+		{"Admin", "", "root@example.com"},
+		{"A", "b", "c@d.com"},
+		{strings.Repeat("Verylongname", 5), "", "x@y.com"},
+		{"你好", "世界", "ünïcodé@example.com"},
+		{"System", "", "support@example.com"},
+	}
+	for _, c := range cases {
+		got := Generate(c[0], c[1], c[2])
+		if err := Validate(got); err != nil {
+			t.Errorf("Generate(%q,%q,%q) = %q, which fails Validate: %v", c[0], c[1], c[2], got, err)
+		}
+		if len(got) > MaxLen {
+			t.Errorf("Generate(%q,%q,%q) = %q exceeds MaxLen %d", c[0], c[1], c[2], got, MaxLen)
+		}
+	}
+}


### PR DESCRIPTION
Closes #348. Part of #345 (usernames + settings).

## What

The dependency-free half of the accounts feature: username rules and first-username generation, no database or HTTP. New package `apps/api/internal/users`.

- `Validate(s)` — 3–30 chars, `[A-Za-z0-9_-]`, must start and end alphanumeric, not reserved. Returns `ErrUsernameInvalid` / `ErrUsernameReserved`.
- `Reserved` / `IsReserved` — case-insensitive set: route collisions (`about`, `events`, `settings`, `api`, `u`, …) plus impersonation (`admin`, `staff`, `codeselfstudy`, …). This is the cheap step that keeps a future `/u/<username>/` route safe.
- `Generate(firstName, lastName, email)` — slugified full name → email local-part → `"user"`, reserved results disambiguated with a trailing digit. Always returns a value that passes `Validate`.

Uniqueness and the `-2`/`-3` dedupe are intentionally **not** here — they belong to the store (#347), because uniqueness is a database property.

## Tests

Table-driven `username_test.go` at **100% coverage**: valid/too-short/too-long/illegal-char/leading-trailing-symbol/unicode; every reserved name rejected in three cases; generation from full name, email fallback, empty→`user`, short slug, reserved slug; and a property check that `Validate(Generate(...))` always holds.

## Notes

- No wiring — `internal/users` is not imported anywhere yet; #349 mounts it.
- `Generate` takes plain strings (not `session.Profile`) to keep the package dependency-free.