### PR TITLE
feat(store): users schema + store methods (#347)

### DIFF
--- a/apps/api/internal/db/migrations/00003_users.sql
+++ b/apps/api/internal/db/migrations/00003_users.sql
@@ -28,9 +28,12 @@ CREATE TABLE account_deletion_requests (
   handled_at   TEXT
 );
 
--- Partial index over just the open requests: the admin's "who wants out" query
--- stays tiny no matter how many historical requests accumulate.
-CREATE INDEX deletion_requests_pending ON account_deletion_requests(status) WHERE status = 'pending';
+-- One open request per user, enforced in the schema so CreateDeletionRequest is
+-- idempotent even under a double-click race (the store's check-then-insert is not
+-- atomic). Also serves the admin's "who wants out" query — SQLite can scan this
+-- partial index for `WHERE status = 'pending'` — and stays tiny no matter how many
+-- historical requests accumulate.
+CREATE UNIQUE INDEX deletion_requests_pending ON account_deletion_requests(user_id) WHERE status = 'pending';
 
 -- +goose Down
 DROP INDEX deletion_requests_pending;

--- a/apps/api/internal/db/migrations/00003_users.sql
+++ b/apps/api/internal/db/migrations/00003_users.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+CREATE TABLE users (
+  id                  INTEGER PRIMARY KEY,
+  workos_id           TEXT NOT NULL UNIQUE,
+  email               TEXT NOT NULL,
+  username            TEXT NOT NULL,
+  timezone            TEXT NOT NULL DEFAULT '',
+  avatar_url          TEXT NOT NULL DEFAULT '',
+  created_at          TEXT NOT NULL,
+  updated_at          TEXT NOT NULL,
+  username_changed_at TEXT
+);
+
+-- Case-insensitive uniqueness: "JaneDoe" and "janedoe" are the same handle, but
+-- the casing the user typed is preserved for display. NOCASE folds ASCII only,
+-- which is exactly the allowed username charset. Queries that look a username up
+-- (rather than relying on the insert/update conflict) MUST write
+-- `WHERE username = ? COLLATE NOCASE`, or SQLite won't use this index.
+CREATE UNIQUE INDEX users_username_unique ON users(username COLLATE NOCASE);
+CREATE INDEX users_email ON users(email);
+
+CREATE TABLE account_deletion_requests (
+  id           INTEGER PRIMARY KEY,
+  user_id      INTEGER NOT NULL REFERENCES users(id),
+  requested_at TEXT NOT NULL,
+  reason       TEXT NOT NULL DEFAULT '',
+  status       TEXT NOT NULL DEFAULT 'pending',
+  handled_at   TEXT
+);
+
+-- Partial index over just the open requests: the admin's "who wants out" query
+-- stays tiny no matter how many historical requests accumulate.
+CREATE INDEX deletion_requests_pending ON account_deletion_requests(status) WHERE status = 'pending';
+
+-- +goose Down
+DROP INDEX deletion_requests_pending;
+DROP TABLE account_deletion_requests;
+DROP INDEX users_email;
+DROP INDEX users_username_unique;
+DROP TABLE users;

--- a/apps/api/internal/store/users.go
+++ b/apps/api/internal/store/users.go
@@ -1,0 +1,318 @@
+package store
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ErrUsernameTaken is returned by SetUsername (and surfaced from the upsert dedupe
+// internally) when a username collides with an existing one. The comparison is
+// case-insensitive: it is the users_username_unique index (COLLATE NOCASE) that
+// rejects the write, so "JaneDoe" and "janedoe" collide. Callers map this to 409.
+var ErrUsernameTaken = errors.New("store: username already taken")
+
+// maxUsernameSuffix bounds the deterministic "-2", "-3", … dedupe attempts before
+// falling back to a random suffix. Ten is far more than any real name collides in
+// practice; the random fallback only exists so a pathological run can still insert.
+const maxUsernameSuffix = 10
+
+// usernameMaxLen mirrors users.MaxLen. It is duplicated (rather than imported) to
+// keep the store free of a dependency on internal/users; the store only needs it
+// to keep a suffixed candidate within the same width the app validates.
+const usernameMaxLen = 30
+
+// User is a local account row. WorkOS remains the identity provider; this row
+// adds the site-owned fields (a unique username, timezone) plus a mirror of the
+// email/avatar for display without a WorkOS round-trip. UsernameChangedAt is nil
+// until the user first renames, and drives the change-rate limit.
+type User struct {
+	ID                int64
+	WorkOSID          string
+	Email             string
+	Username          string
+	Timezone          string
+	AvatarURL         string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	UsernameChangedAt *time.Time
+}
+
+// DeletionRequest is a user's request that an admin delete their account. Users
+// never self-delete (data-integrity risk); this row is the durable record the
+// admin actions manually.
+type DeletionRequest struct {
+	ID          int64
+	UserID      int64
+	RequestedAt time.Time
+	Reason      string
+	Status      string
+	HandledAt   *time.Time
+}
+
+// UpsertUserByWorkOSID creates or refreshes the local row for a WorkOS user.
+//
+// On first sight it inserts a row seeded with candidate (u.Username, normally
+// from users.Generate), deduping against the unique index so the stored username
+// is unique even when two people generate the same one. On later logins it
+// refreshes the WorkOS-owned fields (email, avatar) and leaves the user's chosen
+// username and timezone untouched, returning isNew=false.
+//
+// u must carry WorkOSID, Email, Username (the candidate), and AvatarURL. The
+// returned User is the stored row (with the possibly-suffixed username).
+func (s *Store) UpsertUserByWorkOSID(ctx context.Context, u User) (stored User, isNew bool, err error) {
+	existing, err := s.GetUserByWorkOSID(ctx, u.WorkOSID)
+	switch {
+	case err == nil:
+		// Returning user: WorkOS is the source of truth for email/avatar, so
+		// refresh those; never touch the username the user may have chosen.
+		if err := s.refreshUserProfile(ctx, existing.ID, u.Email, u.AvatarURL); err != nil {
+			return User{}, false, err
+		}
+		existing.Email = u.Email
+		existing.AvatarURL = u.AvatarURL
+		return existing, false, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return s.insertUserDedup(ctx, u)
+	default:
+		return User{}, false, err
+	}
+}
+
+// insertUserDedup inserts a new user, walking candidate → candidate-2 → … on a
+// username collision, then a random suffix, so a first login always lands a row.
+func (s *Store) insertUserDedup(ctx context.Context, u User) (User, bool, error) {
+	now := s.Now().UTC()
+	base := u.Username
+	if base == "" {
+		base = "user"
+	}
+
+	candidate := base
+	for attempt := 1; attempt <= maxUsernameSuffix; attempt++ {
+		id, err := s.tryInsertUser(ctx, u.WorkOSID, u.Email, candidate, u.AvatarURL, now)
+		switch {
+		case err == nil:
+			return storedNewUser(u, id, candidate, now), true, nil
+		case isUsernameConflict(err):
+			candidate = withSuffix(base, "-"+strconv.Itoa(attempt+1)) // -2, -3, …
+		case isWorkOSConflict(err):
+			// A concurrent login for the same brand-new user won the insert
+			// race; adopt its row rather than erroring the second login.
+			existing, gerr := s.GetUserByWorkOSID(ctx, u.WorkOSID)
+			if gerr != nil {
+				return User{}, false, gerr
+			}
+			return existing, false, nil
+		default:
+			return User{}, false, fmt.Errorf("insert user: %w", err)
+		}
+	}
+
+	// Deterministic suffixes exhausted — fall back to a random one.
+	candidate = withSuffix(base, "-"+randomSuffix())
+	id, err := s.tryInsertUser(ctx, u.WorkOSID, u.Email, candidate, u.AvatarURL, now)
+	if err != nil {
+		return User{}, false, fmt.Errorf("insert user (random suffix): %w", err)
+	}
+	return storedNewUser(u, id, candidate, now), true, nil
+}
+
+// tryInsertUser attempts a single INSERT, returning the new id or the raw driver
+// error (so the caller can classify a UNIQUE violation).
+func (s *Store) tryInsertUser(ctx context.Context, workosID, email, username, avatar string, now time.Time) (int64, error) {
+	res, err := s.db.ExecContext(ctx,
+		`INSERT INTO users (workos_id, email, username, timezone, avatar_url, created_at, updated_at)
+		 VALUES (?,?,?,'',?,?,?)`,
+		workosID, email, username, avatar, formatTime(now), formatTime(now))
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// refreshUserProfile updates the WorkOS-owned mirror fields on each login.
+func (s *Store) refreshUserProfile(ctx context.Context, id int64, email, avatar string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE users SET email = ?, avatar_url = ?, updated_at = ? WHERE id = ?`,
+		email, avatar, formatTime(s.Now().UTC()), id)
+	if err != nil {
+		return fmt.Errorf("refresh user profile: %w", err)
+	}
+	return nil
+}
+
+// GetUserByWorkOSID returns the user with the given WorkOS id, or sql.ErrNoRows.
+func (s *Store) GetUserByWorkOSID(ctx context.Context, workosID string) (User, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, workos_id, email, username, timezone, avatar_url, created_at, updated_at, username_changed_at
+		 FROM users WHERE workos_id = ?`, workosID)
+	return scanUser(row)
+}
+
+// SetUsername changes a user's username and stamps username_changed_at (which the
+// handler's rate limit reads). Returns ErrUsernameTaken when the new name
+// collides case-insensitively with another user's.
+func (s *Store) SetUsername(ctx context.Context, id int64, username string) error {
+	now := formatTime(s.Now().UTC())
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE users SET username = ?, username_changed_at = ?, updated_at = ? WHERE id = ?`,
+		username, now, now, id)
+	if err != nil {
+		if isUsernameConflict(err) {
+			return ErrUsernameTaken
+		}
+		return fmt.Errorf("set username: %w", err)
+	}
+	return nil
+}
+
+// SetTimezone changes a user's timezone. Unlimited (unlike username changes).
+func (s *Store) SetTimezone(ctx context.Context, id int64, tz string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE users SET timezone = ?, updated_at = ? WHERE id = ?`,
+		tz, formatTime(s.Now().UTC()), id)
+	if err != nil {
+		return fmt.Errorf("set timezone: %w", err)
+	}
+	return nil
+}
+
+// CreateDeletionRequest files a pending account-deletion request for the user. It
+// is idempotent: if the user already has a pending request, it creates nothing
+// and returns created=false, so a double-click never files two.
+func (s *Store) CreateDeletionRequest(ctx context.Context, userID int64, reason string) (created bool, err error) {
+	existing, err := s.PendingDeletionRequest(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+	if existing != nil {
+		return false, nil
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO account_deletion_requests (user_id, requested_at, reason, status)
+		 VALUES (?,?,?,'pending')`,
+		userID, formatTime(s.Now().UTC()), reason)
+	if err != nil {
+		return false, fmt.Errorf("create deletion request: %w", err)
+	}
+	return true, nil
+}
+
+// PendingDeletionRequest returns the user's open deletion request, or (nil, nil)
+// when there is none.
+func (s *Store) PendingDeletionRequest(ctx context.Context, userID int64) (*DeletionRequest, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, user_id, requested_at, reason, status, handled_at
+		 FROM account_deletion_requests
+		 WHERE user_id = ? AND status = 'pending'
+		 ORDER BY id DESC LIMIT 1`, userID)
+	dr, err := scanDeletionRequest(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &dr, nil
+}
+
+// --- helpers ---
+
+// storedNewUser fills in the fields set at insert time on the returned row.
+func storedNewUser(u User, id int64, username string, now time.Time) User {
+	u.ID = id
+	u.Username = username
+	u.Timezone = ""
+	u.CreatedAt = now
+	u.UpdatedAt = now
+	u.UsernameChangedAt = nil
+	return u
+}
+
+func scanUser(sc scanner) (User, error) {
+	var (
+		u                User
+		created, updated string
+		changedAt        sql.NullString
+	)
+	if err := sc.Scan(&u.ID, &u.WorkOSID, &u.Email, &u.Username, &u.Timezone,
+		&u.AvatarURL, &created, &updated, &changedAt); err != nil {
+		return User{}, err
+	}
+	if t, err := parseTime(created); err == nil {
+		u.CreatedAt = t
+	}
+	if t, err := parseTime(updated); err == nil {
+		u.UpdatedAt = t
+	}
+	if changedAt.Valid {
+		if t, err := parseTime(changedAt.String); err == nil {
+			u.UsernameChangedAt = &t
+		}
+	}
+	return u, nil
+}
+
+func scanDeletionRequest(sc scanner) (DeletionRequest, error) {
+	var (
+		dr        DeletionRequest
+		requested string
+		handled   sql.NullString
+	)
+	if err := sc.Scan(&dr.ID, &dr.UserID, &requested, &dr.Reason, &dr.Status, &handled); err != nil {
+		return DeletionRequest{}, err
+	}
+	if t, err := parseTime(requested); err == nil {
+		dr.RequestedAt = t
+	}
+	if handled.Valid {
+		if t, err := parseTime(handled.String); err == nil {
+			dr.HandledAt = &t
+		}
+	}
+	return dr, nil
+}
+
+// withSuffix appends suffix to base, trimming base so the whole stays within
+// usernameMaxLen (the width the app validates).
+func withSuffix(base, suffix string) string {
+	if len(base)+len(suffix) > usernameMaxLen {
+		base = base[:usernameMaxLen-len(suffix)]
+	}
+	return base + suffix
+}
+
+// randomSuffix returns 6 hex characters of randomness for the last-resort
+// username dedupe.
+func randomSuffix() string {
+	b := make([]byte, 3)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failing is catastrophic and near-impossible; a fixed
+		// marker still yields a syntactically valid, retry-able candidate.
+		return "000000"
+	}
+	return hex.EncodeToString(b)
+}
+
+// isUniqueViolation reports whether err is a SQLite UNIQUE constraint failure.
+// Both drivers (modernc.org/sqlite and libsql) surface SQLite's canonical
+// "UNIQUE constraint failed: <table>.<column>" message, which the column-specific
+// helpers below then narrow.
+func isUniqueViolation(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
+}
+
+func isUsernameConflict(err error) bool {
+	return isUniqueViolation(err) && strings.Contains(err.Error(), "username")
+}
+
+func isWorkOSConflict(err error) bool {
+	return isUniqueViolation(err) && strings.Contains(err.Error(), "workos_id")
+}

--- a/apps/api/internal/store/users.go
+++ b/apps/api/internal/store/users.go
@@ -72,12 +72,11 @@ func (s *Store) UpsertUserByWorkOSID(ctx context.Context, u User) (stored User, 
 	case err == nil:
 		// Returning user: WorkOS is the source of truth for email/avatar, so
 		// refresh those; never touch the username the user may have chosen.
-		if err := s.refreshUserProfile(ctx, existing.ID, u.Email, u.AvatarURL); err != nil {
-			return User{}, false, err
+		refreshed, rerr := s.refreshExistingUser(ctx, existing, u)
+		if rerr != nil {
+			return User{}, false, rerr
 		}
-		existing.Email = u.Email
-		existing.AvatarURL = u.AvatarURL
-		return existing, false, nil
+		return refreshed, false, nil
 	case errors.Is(err, sql.ErrNoRows):
 		return s.insertUserDedup(ctx, u)
 	default:
@@ -104,12 +103,17 @@ func (s *Store) insertUserDedup(ctx context.Context, u User) (User, bool, error)
 			candidate = withSuffix(base, "-"+strconv.Itoa(attempt+1)) // -2, -3, …
 		case isWorkOSConflict(err):
 			// A concurrent login for the same brand-new user won the insert
-			// race; adopt its row rather than erroring the second login.
+			// race; adopt its row rather than erroring the second login, and
+			// apply this login's WorkOS email/avatar just like the normal path.
 			existing, gerr := s.GetUserByWorkOSID(ctx, u.WorkOSID)
 			if gerr != nil {
 				return User{}, false, gerr
 			}
-			return existing, false, nil
+			refreshed, rerr := s.refreshExistingUser(ctx, existing, u)
+			if rerr != nil {
+				return User{}, false, rerr
+			}
+			return refreshed, false, nil
 		default:
 			return User{}, false, fmt.Errorf("insert user: %w", err)
 		}
@@ -137,11 +141,28 @@ func (s *Store) tryInsertUser(ctx context.Context, workosID, email, username, av
 	return res.LastInsertId()
 }
 
-// refreshUserProfile updates the WorkOS-owned mirror fields on each login.
-func (s *Store) refreshUserProfile(ctx context.Context, id int64, email, avatar string) error {
+// refreshExistingUser applies the WorkOS-owned mirror fields (email, avatar) to an
+// existing row and returns the in-memory copy kept in sync with the persisted row,
+// including the new updated_at. Shared by the returning-login path and the
+// concurrent-insert adopt path so they refresh identically.
+func (s *Store) refreshExistingUser(ctx context.Context, existing, u User) (User, error) {
+	now := s.Now().UTC()
+	if err := s.refreshUserProfile(ctx, existing.ID, u.Email, u.AvatarURL, now); err != nil {
+		return User{}, err
+	}
+	existing.Email = u.Email
+	existing.AvatarURL = u.AvatarURL
+	existing.UpdatedAt = now
+	return existing, nil
+}
+
+// refreshUserProfile updates the WorkOS-owned mirror fields on each login. now is
+// the timestamp written to updated_at (passed in so the caller can reflect it on
+// the returned row).
+func (s *Store) refreshUserProfile(ctx context.Context, id int64, email, avatar string, now time.Time) error {
 	_, err := s.db.ExecContext(ctx,
 		`UPDATE users SET email = ?, avatar_url = ?, updated_at = ? WHERE id = ?`,
-		email, avatar, formatTime(s.Now().UTC()), id)
+		email, avatar, formatTime(now), id)
 	if err != nil {
 		return fmt.Errorf("refresh user profile: %w", err)
 	}
@@ -185,21 +206,20 @@ func (s *Store) SetTimezone(ctx context.Context, id int64, tz string) error {
 }
 
 // CreateDeletionRequest files a pending account-deletion request for the user. It
-// is idempotent: if the user already has a pending request, it creates nothing
-// and returns created=false, so a double-click never files two.
+// is idempotent: the deletion_requests_pending UNIQUE index allows only one open
+// request per user, so a second (even concurrent) call — a double-click — hits the
+// constraint and returns created=false rather than filing a duplicate. The first
+// request's reason is preserved. A UNIQUE violation is the only way this INSERT can
+// fail on that index; other failures (e.g. the foreign key) surface as errors.
 func (s *Store) CreateDeletionRequest(ctx context.Context, userID int64, reason string) (created bool, err error) {
-	existing, err := s.PendingDeletionRequest(ctx, userID)
-	if err != nil {
-		return false, err
-	}
-	if existing != nil {
-		return false, nil
-	}
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO account_deletion_requests (user_id, requested_at, reason, status)
 		 VALUES (?,?,?,'pending')`,
 		userID, formatTime(s.Now().UTC()), reason)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return false, nil // a pending request already exists — idempotent
+		}
 		return false, fmt.Errorf("create deletion request: %w", err)
 	}
 	return true, nil

--- a/apps/api/internal/store/users_test.go
+++ b/apps/api/internal/store/users_test.go
@@ -2,6 +2,8 @@ package store_test
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -166,5 +168,43 @@ func TestDeletionRequest_Idempotent(t *testing.T) {
 	}
 	if pending == nil || pending.Status != "pending" || pending.Reason != "moving on" {
 		t.Errorf("pending = %+v, want the first request (reason 'moving on')", pending)
+	}
+}
+
+// TestCreateDeletionRequest_ConcurrentSingleWinner locks in the atomic
+// idempotency guaranteed by the deletion_requests_pending UNIQUE index: many
+// simultaneous requests for one user produce exactly one pending row. Without the
+// index the check-then-insert could interleave and file duplicates. Mirrors
+// TestClaimDigestConcurrentSingleWinner; runs under `go test -race`.
+func TestCreateDeletionRequest_ConcurrentSingleWinner(t *testing.T) {
+	s := newStore(t)
+	u, _, err := s.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_del", Email: "d@x.com", Username: "delme"})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	const n = 8
+	var created int64
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ok, err := s.CreateDeletionRequest(ctx, u.ID, "moving on")
+			if err != nil {
+				t.Errorf("CreateDeletionRequest: %v", err)
+			}
+			if ok {
+				atomic.AddInt64(&created, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if created != 1 {
+		t.Fatalf("created = %d, want exactly 1", created)
+	}
+	if pending, err := s.PendingDeletionRequest(ctx, u.ID); err != nil || pending == nil {
+		t.Fatalf("PendingDeletionRequest = (%v, %v), want one pending row", pending, err)
 	}
 }

--- a/apps/api/internal/store/users_test.go
+++ b/apps/api/internal/store/users_test.go
@@ -1,0 +1,170 @@
+package store_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
+)
+
+func TestUpsertUserByWorkOSID_CreatesThenRefreshes(t *testing.T) {
+	s := newStore(t)
+
+	first, isNew, err := s.UpsertUserByWorkOSID(ctx, store.User{
+		WorkOSID:  "wos_1",
+		Email:     "jane@example.com",
+		Username:  "janedoe",
+		AvatarURL: "https://img/1.png",
+	})
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if !isNew {
+		t.Fatalf("first upsert isNew = false, want true")
+	}
+	if first.ID == 0 || first.Username != "janedoe" {
+		t.Fatalf("first upsert = %+v, want id!=0 and username janedoe", first)
+	}
+
+	// A returning login: same workos_id, new email/avatar. The row is refreshed,
+	// not duplicated, and the username is preserved.
+	second, isNew, err := s.UpsertUserByWorkOSID(ctx, store.User{
+		WorkOSID:  "wos_1",
+		Email:     "jane.new@example.com",
+		Username:  "IGNORED-candidate",
+		AvatarURL: "https://img/2.png",
+	})
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if isNew {
+		t.Fatalf("second upsert isNew = true, want false")
+	}
+	if second.ID != first.ID {
+		t.Fatalf("second upsert id = %d, want %d (same row)", second.ID, first.ID)
+	}
+	if second.Username != "janedoe" {
+		t.Errorf("username changed on refresh: got %q, want janedoe", second.Username)
+	}
+	if second.Email != "jane.new@example.com" || second.AvatarURL != "https://img/2.png" {
+		t.Errorf("email/avatar not refreshed: %+v", second)
+	}
+}
+
+func TestUpsertUserByWorkOSID_DedupesUsername(t *testing.T) {
+	s := newStore(t)
+
+	if _, _, err := s.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_a", Email: "a@x.com", Username: "janedoe"}); err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	// Different WorkOS user, colliding candidate in DIFFERENT case: the NOCASE
+	// index treats "JaneDoe" as the same handle, so it must be suffixed.
+	b, _, err := s.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_b", Email: "b@x.com", Username: "JaneDoe"})
+	if err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+	if b.Username != "JaneDoe-2" {
+		t.Fatalf("second janedoe = %q, want JaneDoe-2", b.Username)
+	}
+	// A third collision walks to -3.
+	c, _, err := s.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_c", Email: "c@x.com", Username: "janedoe"})
+	if err != nil {
+		t.Fatalf("insert C: %v", err)
+	}
+	if c.Username != "janedoe-3" {
+		t.Fatalf("third janedoe = %q, want janedoe-3", c.Username)
+	}
+}
+
+func TestUpsertUserByWorkOSID_EmptyCandidateBecomesUser(t *testing.T) {
+	s := newStore(t)
+	u, _, err := s.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_e", Email: "e@x.com", Username: ""})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if u.Username != "user" {
+		t.Errorf("empty candidate = %q, want user", u.Username)
+	}
+}
+
+func TestSetUsername_StampsAndConflicts(t *testing.T) {
+	s := newStore(t)
+	clock := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	setNow := fixedClock(s, clock)
+
+	a, _, _ := s.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_a", Email: "a@x.com", Username: "alice"})
+	b, _, _ := s.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_b", Email: "b@x.com", Username: "bob"})
+
+	// A fresh account has no change stamp.
+	if a.UsernameChangedAt != nil {
+		t.Fatalf("new user UsernameChangedAt = %v, want nil", a.UsernameChangedAt)
+	}
+
+	setNow(clock.Add(48 * time.Hour))
+	if err := s.SetUsername(ctx, a.ID, "alice2"); err != nil {
+		t.Fatalf("SetUsername: %v", err)
+	}
+	got, err := s.GetUserByWorkOSID(ctx, "wos_a")
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Username != "alice2" {
+		t.Errorf("username = %q, want alice2", got.Username)
+	}
+	if got.UsernameChangedAt == nil || !got.UsernameChangedAt.Equal(clock.Add(48*time.Hour)) {
+		t.Errorf("UsernameChangedAt = %v, want %v", got.UsernameChangedAt, clock.Add(48*time.Hour))
+	}
+
+	// Case-insensitive collision with bob's name → ErrUsernameTaken.
+	if err := s.SetUsername(ctx, a.ID, "BOB"); !errors.Is(err, store.ErrUsernameTaken) {
+		t.Fatalf("SetUsername to taken name = %v, want ErrUsernameTaken", err)
+	}
+	_ = b
+}
+
+func TestSetTimezone(t *testing.T) {
+	s := newStore(t)
+	u, _, _ := s.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_tz", Email: "t@x.com", Username: "tzuser"})
+	if err := s.SetTimezone(ctx, u.ID, "America/Los_Angeles"); err != nil {
+		t.Fatalf("SetTimezone: %v", err)
+	}
+	got, _ := s.GetUserByWorkOSID(ctx, "wos_tz")
+	if got.Timezone != "America/Los_Angeles" {
+		t.Errorf("timezone = %q, want America/Los_Angeles", got.Timezone)
+	}
+}
+
+func TestGetUserByWorkOSID_NotFound(t *testing.T) {
+	s := newStore(t)
+	_, err := s.GetUserByWorkOSID(ctx, "nobody")
+	if err == nil {
+		t.Fatal("GetUserByWorkOSID(nobody) = nil error, want sql.ErrNoRows")
+	}
+}
+
+func TestDeletionRequest_Idempotent(t *testing.T) {
+	s := newStore(t)
+	u, _, _ := s.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_d", Email: "d@x.com", Username: "delme"})
+
+	if pending, err := s.PendingDeletionRequest(ctx, u.ID); err != nil || pending != nil {
+		t.Fatalf("initial pending = (%v, %v), want (nil, nil)", pending, err)
+	}
+
+	created, err := s.CreateDeletionRequest(ctx, u.ID, "moving on")
+	if err != nil || !created {
+		t.Fatalf("first CreateDeletionRequest = (%v, %v), want (true, nil)", created, err)
+	}
+	created, err = s.CreateDeletionRequest(ctx, u.ID, "again")
+	if err != nil || created {
+		t.Fatalf("second CreateDeletionRequest = (%v, %v), want (false, nil)", created, err)
+	}
+
+	pending, err := s.PendingDeletionRequest(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("PendingDeletionRequest: %v", err)
+	}
+	if pending == nil || pending.Status != "pending" || pending.Reason != "moving on" {
+		t.Errorf("pending = %+v, want the first request (reason 'moving on')", pending)
+	}
+}


### PR DESCRIPTION
Closes #347. Part of #345 (usernames + settings).

## What

The database foundation for accounts — schema + store, no HTTP wiring.

**Migration `00003_users.sql`:**
- `users` — `workos_id` (unique), `email`, `username`, `timezone`, `avatar_url`, timestamps, `username_changed_at`.
- **Case-insensitive unique username** via `CREATE UNIQUE INDEX … ON users(username COLLATE NOCASE)`, so `JaneDoe` and `janedoe` are the same handle. Display casing is preserved.
- `account_deletion_requests` with a partial `WHERE status = 'pending'` index (users never self-delete; this is the record an admin actions manually).

**Store (`internal/store/users.go`, same style as `InsertEmail`):**
- `UpsertUserByWorkOSID` — inserts on first login with `-2`/`-3`/…/random-suffix dedupe against the unique index; on return logins refreshes WorkOS-owned email/avatar and leaves the chosen username/timezone alone.
- `GetUserByWorkOSID`, `SetUsername` (maps the unique violation to the sentinel `ErrUsernameTaken`, stamps `username_changed_at`), `SetTimezone`.
- `CreateDeletionRequest` / `PendingDeletionRequest` — idempotent; a pending row wins.

## Tests

`internal/store/users_test.go` runs the real store against a temp SQLite file (existing `newStore`/`fixedClock` harness). Covers first-insert vs refresh, **`JaneDoe` colliding with `janedoe`** → `-2`, walk to `-3`, empty candidate → `user`, `SetUsername` stamping + case-insensitive `ErrUsernameTaken`, timezone, not-found, and deletion-request idempotency. Verified `migrate up`/`status`/`down` against a scratch DB.

## Notes

- No `role` column yet — a later `ALTER TABLE ADD COLUMN` when the meetup work needs it.
- Unique-violation detection matches SQLite's canonical `UNIQUE constraint failed: <table>.<col>` message (same text from both the modernc and libsql drivers).