### PR TITLE
Redirect www.* to apex host with a 308 in the Go server

### DIFF
--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -247,6 +247,17 @@ func newServer(staticRoot string, v *auth.Verifier, sess *session.Manager, ing *
 	e := echo.New()
 	e.HideBanner = true
 
+	// Canonical host: 308-redirect every www.* request to the bare apex host,
+	// preserving scheme, path and query (e.g. https://www.codeselfstudy.com/x/
+	// -> https://codeselfstudy.com/x/). Runs in the Pre phase so it fires before
+	// routing, for every path and method. Echo's NonWWWRedirect defaults to 301;
+	// force 308 so the method/body survive, matching the statuses in
+	// redirects.go. c.Scheme() reads X-Forwarded-Proto, so behind Fly's
+	// force_https proxy the redirect target stays https.
+	e.Pre(middleware.NonWWWRedirectWithConfig(middleware.RedirectConfig{
+		Code: http.StatusPermanentRedirect,
+	}))
+
 	e.Use(middleware.Recover())
 	// Gzip wraps the ResponseWriter, which breaks the connection hijack a
 	// future WebSocket upgrade will need. Skip it on /ws so Phase 2's choices

--- a/apps/api/www_redirect_test.go
+++ b/apps/api/www_redirect_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The Go server owns the canonical host: any request whose Host carries the
+// "www." prefix is 308-redirected to the same scheme, path and query on the
+// bare apex host. It's registered as Pre middleware, so it fires before routing
+// for every path and method. Production sits behind Fly's force_https proxy,
+// which sets X-Forwarded-Proto: https and delivers an origin-form
+// request-target — the tests mirror that (origin-form path + explicit Host +
+// XFP header) so req.RequestURI and c.Scheme() match what the app really sees.
+func TestNonWWWRedirect(t *testing.T) {
+	e := newServer(fixtureDir(t), nil, nil, nil)
+	cases := []struct {
+		name    string
+		method  string
+		path    string
+		wantLoc string
+	}{
+		{"root", http.MethodGet, "/", "https://codeselfstudy.com/"},
+		{"path preserved", http.MethodGet, "/events/", "https://codeselfstudy.com/events/"},
+		{"query preserved", http.MethodGet, "/x/?a=1&b=2", "https://codeselfstudy.com/x/?a=1&b=2"},
+		// The host redirect is independent of the legacy /book -> /learn/ map
+		// (which only applies once a request reaches the apex): www./book
+		// redirects to the apex /book verbatim, a single host hop.
+		{"exact path not legacy-remapped", http.MethodGet, "/book", "https://codeselfstudy.com/book"},
+		{"head mirrors get", http.MethodHead, "/", "https://codeselfstudy.com/"},
+		// 308 keeps the method, so a POST to www is told to re-POST to the apex.
+		{"method preserved", http.MethodPost, "/api/ingest", "https://codeselfstudy.com/api/ingest"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Host = "www.codeselfstudy.com"
+			req.Header.Set("X-Forwarded-Proto", "https") // Fly sets this behind force_https
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusPermanentRedirect {
+				t.Fatalf("status: want 308, got %d", rec.Code)
+			}
+			if got := rec.Header().Get("Location"); got != tc.wantLoc {
+				t.Fatalf("Location: want %q, got %q", tc.wantLoc, got)
+			}
+		})
+	}
+}
+
+// A request already on the apex host is served normally — no redirect.
+func TestApexHostNotRedirected(t *testing.T) {
+	e := newServer(fixtureDir(t), nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "codeselfstudy.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rec.Code)
+	}
+}
+
+// The redirect target's scheme comes from c.Scheme(), i.e. X-Forwarded-Proto.
+// Without that header (bare dev over http) the target is http, not https —
+// confirming the header is what selects https in production behind the proxy.
+func TestNonWWWRedirectSchemeFromForwardedProto(t *testing.T) {
+	e := newServer(fixtureDir(t), nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "www.codeselfstudy.com"
+	// no X-Forwarded-Proto set
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPermanentRedirect {
+		t.Fatalf("status: want 308, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "http://codeselfstudy.com/" {
+		t.Fatalf("Location: want %q, got %q", "http://codeselfstudy.com/", got)
+	}
+}


### PR DESCRIPTION
## What

Requests to `https://www.codeselfstudy.com/...` now permanently redirect (**308**) to the same path and query on the bare apex host `https://codeselfstudy.com/...`, so every page has a single canonical URL.

```
www.codeselfstudy.com/events/?q=1  → 308  https://codeselfstudy.com/events/?q=1
www.codeselfstudy.com/             → 308  https://codeselfstudy.com/
codeselfstudy.com/                 → 200  (no redirect)
POST www.codeselfstudy.com/api/... → 308  (method preserved)
```

## Why

The Go server already owns the URL layer (legacy redirects + trailing-slash canonicalization) because a static build can't emit real redirects. The canonical-host rule belongs in the same place — version-controlled and tested alongside the rest.

## How

One `e.Pre(...)` registration in `newServer` using Echo's built-in `NonWWWRedirect`:

- Registered in the **Pre** phase, so it runs *before routing* and covers every path and method (static pages, `/api/*`, `/healthz`, unknown paths).
- Echo's default is **301**; forced to **308** (`http.StatusPermanentRedirect`) to match the statuses in `redirects.go` and to preserve method + body.
- Target scheme comes from `c.Scheme()` (reads `X-Forwarded-Proto`), so it stays `https` behind Fly's `force_https` proxy. `req.RequestURI` preserves the exact path and query.

## Tests

New `apps/api/www_redirect_test.go` — root, path preserved, query preserved, exact-path-not-legacy-remapped, HEAD, method-preserved POST, apex passthrough, and scheme-from-`X-Forwarded-Proto`. `go vet` + `go test ./...` green; also smoke-tested against the built binary with `curl`.

## Reviewer note — deployment prerequisite

Code alone is a **no-op** unless the www subdomain traffic actually reaches the Fly origin. Site is Cloudflare → Fly, so this needs a proxied `www` DNS record, and Cloudflare must **not** already be doing its own www→apex redirect (else the app never sees it). Verify post-deploy with `curl -sI` against the www root.
