### PR TITLE
feat(api): server wiring — DB decouple, session OnLogin, settings routes (#349)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,11 +5,12 @@
 
 # PRIVATE SERVER VARS #####################
 
-# Local SQLite file for the migrate CLI (apps/api/cmd/migrate), tests, and —
-# when the email-ingest pipeline is enabled (see below) — the runtime server.
-# In production this is a Turso URL: embed the auth token in the query string
-# (libsql://<db>.turso.io?authToken=<token>) or set TURSO_AUTH_TOKEN separately,
-# in which case a bare libsql://<db>.turso.io works too.
+# Local SQLite file for the migrate CLI (apps/api/cmd/migrate), tests, and the
+# runtime server. Setting DATABASE_URL alone now enables user accounts (usernames
+# + the settings page); the email-ingest pipeline layers INGEST_TOKEN on top (see
+# below). In production this is a Turso URL: embed the auth token in the query
+# string (libsql://<db>.turso.io?authToken=<token>) or set TURSO_AUTH_TOKEN
+# separately, in which case a bare libsql://<db>.turso.io works too.
 DATABASE_URL="dev.db"
 # Prod only: Turso auth token, when not embedded in DATABASE_URL above.
 # TURSO_AUTH_TOKEN=<token>
@@ -27,6 +28,12 @@ WORKOS_API_HOSTNAME=api.workos.com
 WORKOS_API_KEY=sk_test_...
 WORKOS_COOKIE_PASSWORD=<32+ secure random chars>   # seals the session cookie; >= 32 chars
 APP_BASE_URL=https://codeselfstudy.com             # e.g. http://localhost:4321 in dev
+
+# Slack incoming-webhook for the admin channel. A user's "request account
+# deletion" (users never self-delete) writes a durable DB row and best-effort
+# pings this webhook so an admin can action it. Optional: unset => the row is
+# still recorded, only the ping is skipped.
+SLACK_WEBHOOK_FOR_ADMIN_CHANNEL=
 
 
 # EMAIL-INGEST PIPELINE (optional) ########

--- a/apps/api/api_me_test.go
+++ b/apps/api/api_me_test.go
@@ -102,7 +102,7 @@ func startedVerifierFor(t *testing.T, f *meFixture) *auth.Verifier {
 func TestApiMeReturnsClaims(t *testing.T) {
 	f := newMeFixture(t)
 	v := startedVerifierFor(t, f)
-	e := newServer(fixtureDir(t), v, nil, nil)
+	e := newServer(fixtureDir(t), v, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	req.Header.Set(echo.HeaderAuthorization, "Bearer "+f.sign(t))
@@ -131,7 +131,7 @@ func TestApiMeReturnsClaims(t *testing.T) {
 func TestApiMeRejectsMissingToken(t *testing.T) {
 	f := newMeFixture(t)
 	v := startedVerifierFor(t, f)
-	e := newServer(fixtureDir(t), v, nil, nil)
+	e := newServer(fixtureDir(t), v, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	rec := httptest.NewRecorder()
@@ -145,7 +145,7 @@ func TestApiMeRejectsMissingToken(t *testing.T) {
 func TestApiMeHeadHonorsAuth(t *testing.T) {
 	f := newMeFixture(t)
 	v := startedVerifierFor(t, f)
-	e := newServer(fixtureDir(t), v, nil, nil)
+	e := newServer(fixtureDir(t), v, nil, nil, nil)
 
 	cases := []struct {
 		name       string
@@ -187,7 +187,7 @@ func TestSessionWiringMountsAuthAndGatesMe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}
-	e := newServer(fixtureDir(t), v, sess, nil)
+	e := newServer(fixtureDir(t), v, sess, nil, nil)
 
 	t.Run("auth login redirects", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/auth/login?returnTo=/events/", nil)
@@ -215,7 +215,7 @@ func TestApiMeIsDisabledWithoutVerifier(t *testing.T) {
 	// /api/me without a verifier should fall through to the /api/* JSON 404,
 	// not return 401 — that's the smoke-test ergonomics we lean on for
 	// runs without WorkOS env config.
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
 	rec := httptest.NewRecorder()

--- a/apps/api/api_me_users_test.go
+++ b/apps/api/api_me_users_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/auth"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/db"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/session"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/users"
+)
+
+// These end-to-end tests prove newServer's /api/me wiring: with the account DB
+// present the users handlers own /api/me and return the DB username; without it,
+// the session's cookie-profile handler still answers. Reaching the session-gated
+// handler needs a real authenticated request, so the tests mint a valid session
+// cookie the same way session.Manager.Callback does.
+
+const meUsersCookiePw = "0123456789abcdef0123456789abcdef" // >= 32 chars
+
+// sealSession builds a session cookie exactly as internal/session seals one
+// (SHA-256 key derivation, AES-256-GCM with the nonce prepended, and the
+// sessionData JSON tags "at"/"u"). It is deliberately coupled to that format; if
+// the seal changes, this helper must change with it.
+func sealSession(t *testing.T, cookiePw, accessToken string, p session.Profile) string {
+	t.Helper()
+	key := sha256.Sum256([]byte("codeselfstudy:wos-seal:" + cookiePw))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		t.Fatalf("aes: %v", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("gcm: %v", err)
+	}
+	plain, err := json.Marshal(map[string]any{"at": accessToken, "rt": "", "sid": "", "u": p})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		t.Fatalf("nonce: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(aead.Seal(nonce, nonce, plain, nil))
+}
+
+func migratedStore(t *testing.T) *store.Store {
+	t.Helper()
+	d, err := db.Open("file:" + filepath.Join(t.TempDir(), "me.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if err := db.Migrate(t.Context(), d); err != nil {
+		_ = d.Close()
+		t.Fatalf("db.Migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return store.New(d)
+}
+
+func meSessionManager(t *testing.T, v *auth.Verifier) *session.Manager {
+	t.Helper()
+	m, err := session.New(session.Config{
+		ClientID:       "client_test",
+		APIKey:         "sk_test",
+		CookiePassword: meUsersCookiePw,
+		BaseURL:        "https://app.test",
+	}, v)
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	return m
+}
+
+// authedMeRequest issues GET /api/me with a freshly-sealed cookie for the given
+// profile and returns the decoded JSON body.
+func authedMeRequest(t *testing.T, e http.Handler, token string, p session.Profile) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	// The session cookie is named "wos_session" (internal/session.cookieName).
+	req.AddCookie(&http.Cookie{Name: "wos_session", Value: sealSession(t, meUsersCookiePw, token, p)})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	var body map[string]any
+	if rec.Body.Len() > 0 {
+		_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	}
+	return rec.Code, body
+}
+
+func TestApiMeReturnsUsernameWhenUsersWired(t *testing.T) {
+	f := newMeFixture(t)
+	v := startedVerifierFor(t, f)
+	sess := meSessionManager(t, v)
+
+	st := migratedStore(t)
+	if _, _, err := st.UpsertUserByWorkOSID(t.Context(), store.User{
+		WorkOSID: "user_test_42", Email: "alice@example.com", Username: "ada",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	e := newServer(fixtureDir(t), v, sess, nil, users.New(st, nil))
+
+	code, body := authedMeRequest(t, e, f.sign(t), session.Profile{ID: "user_test_42", Email: "alice@example.com"})
+	if code != http.StatusOK {
+		t.Fatalf("want 200 got %d", code)
+	}
+	if body["username"] != "ada" {
+		t.Errorf("username = %v, want ada (the DB-backed handler)", body["username"])
+	}
+}
+
+func TestApiMeFallsBackToCookieProfileWithoutUsers(t *testing.T) {
+	f := newMeFixture(t)
+	v := startedVerifierFor(t, f)
+	sess := meSessionManager(t, v)
+	e := newServer(fixtureDir(t), v, sess, nil, nil) // no users handlers
+
+	code, body := authedMeRequest(t, e, f.sign(t), session.Profile{ID: "user_test_42", Email: "alice@example.com"})
+	if code != http.StatusOK {
+		t.Fatalf("want 200 got %d", code)
+	}
+	if body["email"] != "alice@example.com" {
+		t.Errorf("email = %v, want alice@example.com (cookie profile)", body["email"])
+	}
+	if _, has := body["username"]; has {
+		t.Errorf("cookie-profile /api/me should carry no username, got %v", body["username"])
+	}
+}
+
+// TestAccountsWorkWithoutIngest locks in the decoupling: with the account DB
+// present but the ingest pipeline absent (INGEST_TOKEN unset -> ing == nil), the
+// account routes are mounted and gated while /api/ingest is not mounted at all.
+func TestAccountsWorkWithoutIngest(t *testing.T) {
+	f := newMeFixture(t)
+	v := startedVerifierFor(t, f)
+	sess := meSessionManager(t, v)
+	e := newServer(fixtureDir(t), v, sess, nil, users.New(migratedStore(t), nil))
+
+	// /api/ingest is not mounted -> JSON 404 (the /api/* reservation), not 401.
+	req := httptest.NewRequest(http.MethodPost, "/api/ingest", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("/api/ingest without the pipeline: want 404 got %d", rec.Code)
+	}
+
+	// The account routes ARE mounted, so they gate (401 without a cookie) rather
+	// than falling through to the 404 reservation.
+	req = httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("/api/settings: want 401 (mounted and gated) got %d", rec.Code)
+	}
+}

--- a/apps/api/internal/session/session.go
+++ b/apps/api/internal/session/session.go
@@ -140,6 +140,14 @@ type Manager struct {
 	callbackURL string
 	secure      bool
 
+	// OnLogin, when set, is called in Callback after the session cookie is
+	// sealed. It lets the app create or refresh the local user row and choose a
+	// post-login destination (a non-empty path, validated like any returnTo — a
+	// brand-new user goes to /settings/?welcome=1). Its error is only logged: the
+	// cookie is already set, so a database hiccup must never block a sign-in. A
+	// nil OnLogin keeps the plain returnTo behavior.
+	OnLogin func(ctx context.Context, p Profile) (redirectTo string, err error)
+
 	// refresh exchanges a refresh token for a new access/refresh pair. A field
 	// so tests can substitute the WorkOS call.
 	refresh refreshFunc
@@ -290,7 +298,28 @@ func (m *Manager) Callback(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	m.setCookie(c, sealed)
-	return c.Redirect(http.StatusFound, returnTo)
+	return c.Redirect(http.StatusFound, m.resolveReturnTo(c, returnTo, profileFrom(resp.User)))
+}
+
+// resolveReturnTo hands the freshly-authenticated profile to OnLogin (when set)
+// so the app can upsert the local user row and optionally redirect a first-time
+// user, then decides where Callback sends the browser: the OnLogin-provided path
+// when it returns a non-empty one (re-validated through safeReturnTo), otherwise
+// the original returnTo. An OnLogin error is logged and ignored — the cookie is
+// already set, so a database hiccup must never block or misdirect a sign-in.
+func (m *Manager) resolveReturnTo(c echo.Context, returnTo string, p Profile) string {
+	if m.OnLogin == nil {
+		return returnTo
+	}
+	dest, err := m.OnLogin(c.Request().Context(), p)
+	if err != nil {
+		c.Logger().Errorf("session: OnLogin: %v", err)
+		return returnTo
+	}
+	if dest != "" {
+		return safeReturnTo(dest)
+	}
+	return returnTo
 }
 
 // Logout clears the local cookie and redirects through the WorkOS logout URL so
@@ -376,9 +405,10 @@ func (m *Manager) Middleware() echo.MiddlewareFunc {
 
 // HandleMe returns the signed-in user. It reads the profile the middleware
 // placed on the context (sealed in the cookie at login), so it needs no WorkOS
-// round-trip.
+// round-trip. Used only when the account database is absent; when it is present,
+// the users handlers own /api/me and return the DB-backed username too.
 func (m *Manager) HandleMe(c echo.Context) error {
-	p, ok := c.Get(contextUserKey).(profile)
+	p, ok := User(c)
 	if !ok {
 		return echo.NewHTTPError(http.StatusUnauthorized)
 	}
@@ -390,16 +420,33 @@ func (m *Manager) HandleMe(c echo.Context) error {
 	})
 }
 
+// User returns the authenticated profile the session Middleware placed on the
+// request context, or ok=false when the request is not authenticated. It lets
+// other packages (the users handlers) read the identity without importing the
+// session internals.
+func User(c echo.Context) (Profile, bool) {
+	p, ok := c.Get(contextUserKey).(Profile)
+	return p, ok
+}
+
+// ContextWithUser stores p as the authenticated profile on c, exactly as
+// Middleware does. Exposed so handlers in other packages can be exercised with an
+// authenticated context in tests without running the full cookie flow.
+func ContextWithUser(c echo.Context, p Profile) {
+	c.Set(contextUserKey, p)
+}
+
 // sessionData is the payload sealed into the cookie.
 type sessionData struct {
 	AccessToken  string  `json:"at"`
 	RefreshToken string  `json:"rt"`
 	SessionID    string  `json:"sid"`
-	User         profile `json:"u"`
+	User         Profile `json:"u"`
 }
 
-// profile is the subset of the WorkOS user the frontend renders.
-type profile struct {
+// Profile is the subset of the WorkOS user the frontend renders and the identity
+// other packages read via User(c).
+type Profile struct {
 	ID                string `json:"id"`
 	Email             string `json:"email"`
 	FirstName         string `json:"first_name,omitempty"`
@@ -407,8 +454,8 @@ type profile struct {
 	ProfilePictureURL string `json:"avatar,omitempty"`
 }
 
-func profileFrom(u usermanagement.User) profile {
-	return profile{
+func profileFrom(u usermanagement.User) Profile {
+	return Profile{
 		ID:                u.ID,
 		Email:             u.Email,
 		FirstName:         u.FirstName,

--- a/apps/api/internal/session/session_test.go
+++ b/apps/api/internal/session/session_test.go
@@ -316,7 +316,7 @@ func TestSafeReturnTo(t *testing.T) {
 
 func TestSealUnsealRoundTrip(t *testing.T) {
 	m := newTestManager(t, newJWKSFixture(t))
-	in := sessionData{AccessToken: "at", RefreshToken: "rt", SessionID: "sid", User: profile{ID: "u1", Email: "a@b.com"}}
+	in := sessionData{AccessToken: "at", RefreshToken: "rt", SessionID: "sid", User: Profile{ID: "u1", Email: "a@b.com"}}
 	sealed := mustSeal(t, m, in)
 	out, err := m.unseal(sealed)
 	if err != nil {
@@ -373,7 +373,7 @@ func TestMiddlewareValidCookie(t *testing.T) {
 		AccessToken:  f.signAccess(t, time.Now().Add(5*time.Minute)),
 		RefreshToken: "rt",
 		SessionID:    "sid",
-		User:         profile{ID: "u1", Email: "ada@example.com", FirstName: "Ada", LastName: "Lovelace"},
+		User:         Profile{ID: "u1", Email: "ada@example.com", FirstName: "Ada", LastName: "Lovelace"},
 	})
 
 	rec := serveMe(m, cookie(sealed))
@@ -410,7 +410,7 @@ func TestMiddlewareAcceptsMismatchedIssuer(t *testing.T) {
 		AccessToken:  token,
 		RefreshToken: "rt",
 		SessionID:    "sid",
-		User:         profile{Email: "ada@example.com"},
+		User:         Profile{Email: "ada@example.com"},
 	})
 
 	rec := serveMe(m, cookie(sealed))
@@ -460,7 +460,7 @@ func TestMiddlewareRefreshesExpired(t *testing.T) {
 	sealed := mustSeal(t, m, sessionData{
 		AccessToken:  f.signAccess(t, time.Now().Add(-1*time.Minute)), // expired
 		RefreshToken: "rt_old",
-		User:         profile{Email: "a@b.com"},
+		User:         Profile{Email: "a@b.com"},
 	})
 
 	rec := serveMe(m, cookie(sealed))
@@ -575,5 +575,56 @@ func TestCallbackRejectsBadNonce(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func newEchoCtx() echo.Context {
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback", nil)
+	return echo.New().NewContext(req, httptest.NewRecorder())
+}
+
+// resolveReturnTo is the post-login redirect decision Callback delegates to. It
+// is tested directly because Callback's WorkOS code exchange is not stubbable.
+func TestResolveReturnTo(t *testing.T) {
+	c := newEchoCtx()
+
+	cases := []struct {
+		name    string
+		onLogin func(context.Context, Profile) (string, error)
+		want    string
+	}{
+		{"nil OnLogin keeps returnTo", nil, "/events/"},
+		{"new user goes to welcome",
+			func(context.Context, Profile) (string, error) { return "/settings/?welcome=1", nil },
+			"/settings/?welcome=1"},
+		{"returning user keeps returnTo",
+			func(context.Context, Profile) (string, error) { return "", nil },
+			"/events/"},
+		{"error is ignored, login not blocked",
+			func(context.Context, Profile) (string, error) { return "/settings/", errors.New("db down") },
+			"/events/"},
+		{"hostile dest collapses via safeReturnTo",
+			func(context.Context, Profile) (string, error) { return "//evil.example/x", nil },
+			"/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{OnLogin: tc.onLogin}
+			if got := m.resolveReturnTo(c, "/events/", Profile{ID: "u1"}); got != tc.want {
+				t.Errorf("resolveReturnTo = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUserContext(t *testing.T) {
+	c := newEchoCtx()
+	if _, ok := User(c); ok {
+		t.Error("User on a bare context: ok = true, want false")
+	}
+	want := Profile{ID: "u1", Email: "ada@example.com"}
+	ContextWithUser(c, want)
+	if got, ok := User(c); !ok || got != want {
+		t.Errorf("User = (%+v, %v), want (%+v, true)", got, ok, want)
 	}
 }

--- a/apps/api/internal/store/users.go
+++ b/apps/api/internal/store/users.go
@@ -18,6 +18,12 @@ import (
 // rejects the write, so "JaneDoe" and "janedoe" collide. Callers map this to 409.
 var ErrUsernameTaken = errors.New("store: username already taken")
 
+// ErrUsernameCooldown is returned by SetUsername when the account changed its
+// username too recently: the atomic cooldown predicate in the UPDATE rejected the
+// change. This is the store-level backstop that makes the rename rate limit safe
+// against two concurrent requests both passing a handler check. Callers map it to 429.
+var ErrUsernameCooldown = errors.New("store: username change within cooldown")
+
 // maxUsernameSuffix bounds the deterministic "-2", "-3", … dedupe attempts before
 // falling back to a random suffix. Ten is far more than any real name collides in
 // practice; the random fallback only exists so a pathological run can still insert.
@@ -177,19 +183,32 @@ func (s *Store) GetUserByWorkOSID(ctx context.Context, workosID string) (User, e
 	return scanUser(row)
 }
 
-// SetUsername changes a user's username and stamps username_changed_at (which the
-// handler's rate limit reads). Returns ErrUsernameTaken when the new name
-// collides case-insensitively with another user's.
-func (s *Store) SetUsername(ctx context.Context, id int64, username string) error {
+// SetUsername changes a user's username and stamps username_changed_at, enforcing
+// the rename cooldown atomically: the UPDATE only applies when the current stamp
+// is NULL (never renamed) or at/older than cooldownCutoff. Pass now minus the
+// rename window as cooldownCutoff — a stamp newer than it updates zero rows and
+// yields ErrUsernameCooldown, so two concurrent PATCHes that both passed a
+// handler-level check cannot both slip through. A case-insensitive collision maps
+// to ErrUsernameTaken. The caller must have already confirmed the row exists (so
+// zero rows affected means the cooldown, not a missing user).
+func (s *Store) SetUsername(ctx context.Context, id int64, username string, cooldownCutoff time.Time) error {
 	now := formatTime(s.Now().UTC())
-	_, err := s.db.ExecContext(ctx,
-		`UPDATE users SET username = ?, username_changed_at = ?, updated_at = ? WHERE id = ?`,
-		username, now, now, id)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE users SET username = ?, username_changed_at = ?, updated_at = ?
+		 WHERE id = ? AND (username_changed_at IS NULL OR username_changed_at <= ?)`,
+		username, now, now, id, formatTime(cooldownCutoff.UTC()))
 	if err != nil {
 		if isUsernameConflict(err) {
 			return ErrUsernameTaken
 		}
 		return fmt.Errorf("set username: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("set username rows: %w", err)
+	}
+	if n == 0 {
+		return ErrUsernameCooldown
 	}
 	return nil
 }

--- a/apps/api/internal/store/users_test.go
+++ b/apps/api/internal/store/users_test.go
@@ -103,8 +103,11 @@ func TestSetUsername_StampsAndConflicts(t *testing.T) {
 		t.Fatalf("new user UsernameChangedAt = %v, want nil", a.UsernameChangedAt)
 	}
 
+	const cooldown = 30 * 24 * time.Hour
+
+	// A first rename: no prior stamp, so any cutoff passes.
 	setNow(clock.Add(48 * time.Hour))
-	if err := s.SetUsername(ctx, a.ID, "alice2"); err != nil {
+	if err := s.SetUsername(ctx, a.ID, "alice2", clock.Add(48*time.Hour).Add(-cooldown)); err != nil {
 		t.Fatalf("SetUsername: %v", err)
 	}
 	got, err := s.GetUserByWorkOSID(ctx, "wos_a")
@@ -118,8 +121,16 @@ func TestSetUsername_StampsAndConflicts(t *testing.T) {
 		t.Errorf("UsernameChangedAt = %v, want %v", got.UsernameChangedAt, clock.Add(48*time.Hour))
 	}
 
-	// Case-insensitive collision with bob's name → ErrUsernameTaken.
-	if err := s.SetUsername(ctx, a.ID, "BOB"); !errors.Is(err, store.ErrUsernameTaken) {
+	// A change within the cooldown window (the stamp is newer than the cutoff) is
+	// rejected atomically by the store, not just by a handler check.
+	if err := s.SetUsername(ctx, a.ID, "alice3", clock.Add(48*time.Hour).Add(-cooldown)); !errors.Is(err, store.ErrUsernameCooldown) {
+		t.Fatalf("SetUsername within cooldown = %v, want ErrUsernameCooldown", err)
+	}
+
+	// Case-insensitive collision with bob's name → ErrUsernameTaken. Use a cutoff
+	// at/after the stamp so the cooldown allows the write and the unique index is
+	// what rejects it.
+	if err := s.SetUsername(ctx, a.ID, "BOB", clock.Add(48*time.Hour)); !errors.Is(err, store.ErrUsernameTaken) {
 		t.Fatalf("SetUsername to taken name = %v, want ErrUsernameTaken", err)
 	}
 	_ = b

--- a/apps/api/internal/users/handlers.go
+++ b/apps/api/internal/users/handlers.go
@@ -1,0 +1,314 @@
+package users
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/digest"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/session"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
+)
+
+// renameCooldown is how long a user must wait between username changes. It
+// doubles as anti-squatting — a claimed handle cannot be cycled rapidly. Timezone
+// changes are unlimited.
+const renameCooldown = 30 * 24 * time.Hour
+
+// Handlers exposes the account routes (/api/me and /api/settings*) over the
+// store. Construct with New and mount on a session-gated group with Register.
+// poster is the admin-channel Slack webhook and may be nil (the ping is optional;
+// a deletion request still records its durable row). Mirrors the shape of
+// ingest.Handlers.
+type Handlers struct {
+	store  *store.Store
+	poster digest.WebhookPoster
+}
+
+// New builds the account Handlers over an already-open store and an optional
+// admin-channel webhook poster.
+func New(st *store.Store, poster digest.WebhookPoster) *Handlers {
+	return &Handlers{store: st, poster: poster}
+}
+
+// Register mounts the account routes on api, which MUST already be gated by the
+// session middleware (each handler reads session.User). GET routes accept HEAD
+// too; the mutating routes additionally pass through originCheck, a same-origin
+// guard backing up the session cookie's SameSite=Lax.
+func (h *Handlers) Register(api *echo.Group) {
+	getOrHead := []string{http.MethodGet, http.MethodHead}
+	api.Match(getOrHead, "/me", h.Me)
+	api.Match(getOrHead, "/settings", h.GetSettings)
+	api.PATCH("/settings", h.PatchSettings, originCheck)
+	api.POST("/settings/delete-request", h.DeleteRequest, originCheck)
+}
+
+// Upsert creates or refreshes the account row for a signed-in WorkOS profile,
+// generating a first username for a brand-new user. Returns the stored row and
+// whether it was newly created. main wires this as session.OnLogin; the handlers
+// reuse it to self-heal a row a failed login never created.
+func Upsert(ctx context.Context, st *store.Store, p session.Profile) (store.User, bool, error) {
+	return st.UpsertUserByWorkOSID(ctx, store.User{
+		WorkOSID:  p.ID,
+		Email:     p.Email,
+		Username:  Generate(p.FirstName, p.LastName, p.Email),
+		AvatarURL: p.ProfilePictureURL,
+	})
+}
+
+type meResponse struct {
+	ID       int64  `json:"id"`
+	Email    string `json:"email"`
+	Username string `json:"username"`
+	Avatar   string `json:"avatar"`
+	Timezone string `json:"timezone"`
+}
+
+// Me returns the signed-in user's identity joined with the account row — a single
+// indexed lookup per page load, with the DB as the source of truth for the
+// username, so a rename is never stale. If the row is somehow absent (a login
+// whose OnLogin upsert failed), it degrades to the session profile rather than
+// erroring, so the navbar still renders.
+func (h *Handlers) Me(c echo.Context) error {
+	p, ok := session.User(c)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized)
+	}
+	resp := meResponse{Email: p.Email, Avatar: p.ProfilePictureURL}
+	u, err := h.store.GetUserByWorkOSID(c.Request().Context(), p.ID)
+	switch {
+	case err == nil:
+		resp.ID, resp.Email, resp.Username = u.ID, u.Email, u.Username
+		resp.Avatar, resp.Timezone = u.AvatarURL, u.Timezone
+	case errors.Is(err, sql.ErrNoRows):
+		// degrade to the session profile (username stays empty)
+	default:
+		return err
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+type settingsResponse struct {
+	Username            string     `json:"username"`
+	Email               string     `json:"email"`
+	Timezone            string     `json:"timezone"`
+	DeletionRequestedAt *time.Time `json:"deletion_requested_at"`
+}
+
+// GetSettings returns the caller's editable settings plus any pending deletion
+// request (so the form can show the "deletion pending" state).
+func (h *Handlers) GetSettings(c echo.Context) error {
+	p, ok := session.User(c)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized)
+	}
+	u, err := h.userRow(c.Request().Context(), p)
+	if err != nil {
+		return err
+	}
+	return h.writeSettings(c, u)
+}
+
+type patchRequest struct {
+	Username *string `json:"username"`
+	Timezone *string `json:"timezone"`
+}
+
+// PatchSettings updates the username and/or timezone. Each field is optional
+// (a nil pointer leaves it untouched). Status codes the web form maps to inline
+// messages: 400 invalid/reserved username or invalid timezone, 409 taken, 429
+// within the rename cooldown (with retry_after_days), 200 with the new settings.
+func (h *Handlers) PatchSettings(c echo.Context) error {
+	p, ok := session.User(c)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized)
+	}
+	var req patchRequest
+	if err := c.Bind(&req); err != nil {
+		return errJSON(c, http.StatusBadRequest, "invalid_body")
+	}
+	ctx := c.Request().Context()
+	u, err := h.userRow(ctx, p)
+	if err != nil {
+		return err
+	}
+
+	// Timezone: validated against the tz database so an arbitrary string can't be
+	// stored. Unlimited.
+	if req.Timezone != nil && *req.Timezone != u.Timezone {
+		if _, err := time.LoadLocation(*req.Timezone); err != nil {
+			return errJSON(c, http.StatusBadRequest, "timezone_invalid")
+		}
+		if err := h.store.SetTimezone(ctx, u.ID, *req.Timezone); err != nil {
+			return err
+		}
+	}
+
+	// Username: format + reserved validation, the 30-day rename cooldown, then the
+	// unique-index collision mapped to 409.
+	if req.Username != nil && *req.Username != u.Username {
+		switch err := Validate(*req.Username); {
+		case errors.Is(err, ErrUsernameReserved):
+			return errJSON(c, http.StatusBadRequest, "username_reserved")
+		case err != nil:
+			return errJSON(c, http.StatusBadRequest, "username_invalid")
+		}
+		if u.UsernameChangedAt != nil {
+			if elapsed := h.store.Now().UTC().Sub(*u.UsernameChangedAt); elapsed < renameCooldown {
+				return c.JSON(http.StatusTooManyRequests, map[string]any{
+					"error":            "rate_limited",
+					"retry_after_days": daysUntil(renameCooldown - elapsed),
+				})
+			}
+		}
+		if err := h.store.SetUsername(ctx, u.ID, *req.Username); err != nil {
+			if errors.Is(err, store.ErrUsernameTaken) {
+				return errJSON(c, http.StatusConflict, "username_taken")
+			}
+			return err
+		}
+	}
+
+	// Reflect the persisted state back.
+	u, err = h.store.GetUserByWorkOSID(ctx, p.ID)
+	if err != nil {
+		return err
+	}
+	return h.writeSettings(c, u)
+}
+
+type deleteRequestBody struct {
+	Reason string `json:"reason"`
+}
+
+type deleteResponse struct {
+	DeletionRequestedAt *time.Time `json:"deletion_requested_at"`
+}
+
+// DeleteRequest records a pending account-deletion request (idempotent — a second
+// call never files a duplicate) and best-effort pings the admin Slack channel.
+// Users never self-delete; an admin actions the row manually. A webhook failure
+// is logged but still returns 202, because the row is the durable record.
+func (h *Handlers) DeleteRequest(c echo.Context) error {
+	p, ok := session.User(c)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized)
+	}
+	ctx := c.Request().Context()
+	u, err := h.userRow(ctx, p)
+	if err != nil {
+		return err
+	}
+
+	var body deleteRequestBody
+	_ = c.Bind(&body) // reason is optional; an empty/absent body just means none
+
+	created, err := h.store.CreateDeletionRequest(ctx, u.ID, body.Reason)
+	if err != nil {
+		return err
+	}
+	if created {
+		h.notifyAdmin(ctx, c, u)
+	}
+
+	dr, err := h.store.PendingDeletionRequest(ctx, u.ID)
+	if err != nil {
+		return err
+	}
+	resp := deleteResponse{}
+	if dr != nil {
+		resp.DeletionRequestedAt = &dr.RequestedAt
+	}
+	return c.JSON(http.StatusAccepted, resp)
+}
+
+// writeSettings serializes a user's current settings, including any pending
+// deletion request.
+func (h *Handlers) writeSettings(c echo.Context, u store.User) error {
+	resp := settingsResponse{Username: u.Username, Email: u.Email, Timezone: u.Timezone}
+	dr, err := h.store.PendingDeletionRequest(c.Request().Context(), u.ID)
+	if err != nil {
+		return err
+	}
+	if dr != nil {
+		resp.DeletionRequestedAt = &dr.RequestedAt
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// userRow fetches the caller's account row, self-healing a missing one by
+// upserting from the session profile — the row a login whose OnLogin upsert
+// didn't land would otherwise lack.
+func (h *Handlers) userRow(ctx context.Context, p session.Profile) (store.User, error) {
+	u, err := h.store.GetUserByWorkOSID(ctx, p.ID)
+	if errors.Is(err, sql.ErrNoRows) {
+		u, _, err = Upsert(ctx, h.store, p)
+	}
+	return u, err
+}
+
+// notifyAdmin posts a best-effort Slack message about a new deletion request. A
+// nil poster (webhook unset) or a post failure is logged and swallowed.
+func (h *Handlers) notifyAdmin(ctx context.Context, c echo.Context, u store.User) {
+	if h.poster == nil {
+		return
+	}
+	payload, err := json.Marshal(map[string]string{
+		"text": fmt.Sprintf("Account deletion requested by %s (%s), user id %d — action manually.", u.Username, u.Email, u.ID),
+	})
+	if err != nil {
+		c.Logger().Errorf("delete-request: marshal slack payload: %v", err)
+		return
+	}
+	if err := h.poster.Post(ctx, payload); err != nil {
+		c.Logger().Errorf("delete-request: slack notify: %v", err)
+	}
+}
+
+// originCheck rejects a cross-origin state-changing request. The session cookie is
+// SameSite=Lax, which already stops a cross-site POST/PATCH from carrying it (so
+// this is defense in depth), but adding the check means every future write
+// endpoint mounted here inherits it. It trusts Sec-Fetch-Site when the browser
+// sends it, otherwise compares the Origin header's host to the request host; a
+// request with neither header (a same-origin server call, curl, a test) is
+// allowed.
+func originCheck(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		r := c.Request()
+		if sfs := r.Header.Get("Sec-Fetch-Site"); sfs != "" {
+			if sfs != "same-origin" && sfs != "none" {
+				return echo.NewHTTPError(http.StatusForbidden, "cross-origin request rejected")
+			}
+			return next(c)
+		}
+		if origin := r.Header.Get("Origin"); origin != "" {
+			u, err := url.Parse(origin)
+			if err != nil || u.Host != r.Host {
+				return echo.NewHTTPError(http.StatusForbidden, "cross-origin request rejected")
+			}
+		}
+		return next(c)
+	}
+}
+
+// errJSON writes a structured error the web form maps to a message.
+func errJSON(c echo.Context, status int, code string) error {
+	return c.JSON(status, map[string]string{"error": code})
+}
+
+// daysUntil rounds a remaining duration up to whole days, so a user 29.1 days
+// into the cooldown is told "1 day", never "0".
+func daysUntil(d time.Duration) int {
+	days := int(d / (24 * time.Hour))
+	if d%(24*time.Hour) > 0 {
+		days++
+	}
+	return days
+}

--- a/apps/api/internal/users/handlers.go
+++ b/apps/api/internal/users/handlers.go
@@ -140,38 +140,44 @@ func (h *Handlers) PatchSettings(c echo.Context) error {
 		return err
 	}
 
-	// Timezone: validated against the tz database so an arbitrary string can't be
-	// stored. Unlimited.
-	if req.Timezone != nil && *req.Timezone != u.Timezone {
+	changingTZ := req.Timezone != nil && *req.Timezone != u.Timezone
+	changingName := req.Username != nil && *req.Username != u.Username
+
+	// Validate every field BEFORE writing any of them, so an invalid field can't
+	// leave a partial mutation behind (a bad username must not commit a timezone).
+	if changingTZ {
 		if _, err := time.LoadLocation(*req.Timezone); err != nil {
 			return errJSON(c, http.StatusBadRequest, "timezone_invalid")
 		}
-		if err := h.store.SetTimezone(ctx, u.ID, *req.Timezone); err != nil {
-			return err
-		}
 	}
-
-	// Username: format + reserved validation, the 30-day rename cooldown, then the
-	// unique-index collision mapped to 409.
-	if req.Username != nil && *req.Username != u.Username {
+	if changingName {
 		switch err := Validate(*req.Username); {
 		case errors.Is(err, ErrUsernameReserved):
 			return errJSON(c, http.StatusBadRequest, "username_reserved")
 		case err != nil:
 			return errJSON(c, http.StatusBadRequest, "username_invalid")
 		}
-		if u.UsernameChangedAt != nil {
-			if elapsed := h.store.Now().UTC().Sub(*u.UsernameChangedAt); elapsed < renameCooldown {
-				return c.JSON(http.StatusTooManyRequests, map[string]any{
-					"error":            "rate_limited",
-					"retry_after_days": daysUntil(renameCooldown - elapsed),
-				})
-			}
+	}
+
+	// Writes. Username first, so its 409/429 returns before any timezone write.
+	// The rename cooldown is enforced atomically in the store — a handler-only
+	// check would let two concurrent PATCHes both slip past the window.
+	if changingName {
+		cutoff := h.store.Now().UTC().Add(-renameCooldown)
+		switch err := h.store.SetUsername(ctx, u.ID, *req.Username, cutoff); {
+		case errors.Is(err, store.ErrUsernameCooldown):
+			return c.JSON(http.StatusTooManyRequests, map[string]any{
+				"error":            "rate_limited",
+				"retry_after_days": retryAfterDays(u.UsernameChangedAt, h.store.Now().UTC()),
+			})
+		case errors.Is(err, store.ErrUsernameTaken):
+			return errJSON(c, http.StatusConflict, "username_taken")
+		case err != nil:
+			return err
 		}
-		if err := h.store.SetUsername(ctx, u.ID, *req.Username); err != nil {
-			if errors.Is(err, store.ErrUsernameTaken) {
-				return errJSON(c, http.StatusConflict, "username_taken")
-			}
+	}
+	if changingTZ {
+		if err := h.store.SetTimezone(ctx, u.ID, *req.Timezone); err != nil {
 			return err
 		}
 	}
@@ -301,6 +307,20 @@ func originCheck(next echo.HandlerFunc) echo.HandlerFunc {
 // errJSON writes a structured error the web form maps to a message.
 func errJSON(c echo.Context, status int, code string) error {
 	return c.JSON(status, map[string]string{"error": code})
+}
+
+// retryAfterDays reports whole days left in the rename cooldown given the last
+// change time (nil → the full window, a defensive fallback: the store only
+// returns the cooldown error when a stamp exists) and the current time.
+func retryAfterDays(changedAt *time.Time, now time.Time) int {
+	if changedAt == nil {
+		return daysUntil(renameCooldown)
+	}
+	remaining := renameCooldown - now.Sub(*changedAt)
+	if remaining < 0 {
+		remaining = 0
+	}
+	return daysUntil(remaining)
 }
 
 // daysUntil rounds a remaining duration up to whole days, so a user 29.1 days

--- a/apps/api/internal/users/handlers_test.go
+++ b/apps/api/internal/users/handlers_test.go
@@ -1,0 +1,360 @@
+package users_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/db"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/session"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/users"
+)
+
+var ctx = context.Background()
+
+// newStore opens a fresh migrated temp SQLite database (the same harness the
+// store package's own tests use), so these handler tests run against the real
+// store rather than a mock.
+func newStore(t *testing.T) *store.Store {
+	t.Helper()
+	d, err := db.Open("file:" + filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if err := db.Migrate(ctx, d); err != nil {
+		_ = d.Close()
+		t.Fatalf("db.Migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return store.New(d)
+}
+
+func prof(id, email string) session.Profile {
+	return session.Profile{ID: id, Email: email, FirstName: "Ada", LastName: "Lovelace", ProfilePictureURL: "https://img/a.png"}
+}
+
+// mount builds an Echo with the account routes, gated by a stub middleware that
+// injects p (nil → unauthenticated, so a handler's own session.User check
+// produces the 401 the real middleware would). Faithful enough to exercise the
+// handlers without the full cookie/JWKS flow, which api_me_test covers end-to-end.
+func mount(h *users.Handlers, p *session.Profile) *echo.Echo {
+	e := echo.New()
+	api := e.Group("/api", func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if p != nil {
+				session.ContextWithUser(c, *p)
+			}
+			return next(c)
+		}
+	})
+	h.Register(api)
+	return e
+}
+
+func do(t *testing.T, e *echo.Echo, method, target, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+		r.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	} else {
+		r = httptest.NewRequest(method, target, nil)
+	}
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, r)
+	return rec
+}
+
+func decode(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode %q: %v", rec.Body.String(), err)
+	}
+	return m
+}
+
+type fakePoster struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (f *fakePoster) Post(context.Context, []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.n++
+	return nil
+}
+
+func (f *fakePoster) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.n
+}
+
+func TestRoutesRequireSession(t *testing.T) {
+	h := users.New(newStore(t), nil)
+	e := mount(h, nil) // unauthenticated
+
+	for _, tc := range []struct{ method, target string }{
+		{http.MethodGet, "/api/me"},
+		{http.MethodGet, "/api/settings"},
+		{http.MethodPatch, "/api/settings"},
+		{http.MethodPost, "/api/settings/delete-request"},
+	} {
+		rec := do(t, e, tc.method, tc.target, "", nil)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: want 401 got %d", tc.method, tc.target, rec.Code)
+		}
+	}
+}
+
+func TestMeReturnsUsername(t *testing.T) {
+	st := newStore(t)
+	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, nil), &p)
+
+	rec := do(t, e, http.MethodGet, "/api/me", "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if body["username"] != "ada" {
+		t.Errorf("username = %v, want ada", body["username"])
+	}
+	if body["email"] != "a@x.com" {
+		t.Errorf("email = %v, want a@x.com", body["email"])
+	}
+}
+
+func TestMeDegradesWithoutRow(t *testing.T) {
+	// No row seeded: /api/me must still 200 with the session profile, never error.
+	p := prof("wos_missing", "ghost@x.com")
+	e := mount(users.New(newStore(t), nil), &p)
+
+	rec := do(t, e, http.MethodGet, "/api/me", "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if body["username"] != "" {
+		t.Errorf("username = %v, want empty (degraded)", body["username"])
+	}
+	if body["email"] != "ghost@x.com" {
+		t.Errorf("email = %v, want the session email", body["email"])
+	}
+}
+
+func TestGetSettings(t *testing.T) {
+	st := newStore(t)
+	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := st.SetTimezone(ctx, 1, "America/Los_Angeles"); err != nil {
+		t.Fatalf("tz: %v", err)
+	}
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, nil), &p)
+
+	rec := do(t, e, http.MethodGet, "/api/settings", "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if body["username"] != "ada" || body["timezone"] != "America/Los_Angeles" {
+		t.Errorf("settings = %v, want ada / America/Los_Angeles", body)
+	}
+	if body["deletion_requested_at"] != nil {
+		t.Errorf("deletion_requested_at = %v, want null", body["deletion_requested_at"])
+	}
+}
+
+func TestPatchTimezoneAndUsername(t *testing.T) {
+	st := newStore(t)
+	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, nil), &p)
+
+	rec := do(t, e, http.MethodPatch, "/api/settings", `{"username":"ada-lovelace","timezone":"Europe/London"}`, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if body["username"] != "ada-lovelace" || body["timezone"] != "Europe/London" {
+		t.Errorf("patched = %v, want ada-lovelace / Europe/London", body)
+	}
+}
+
+func TestPatchUsernameValidation(t *testing.T) {
+	st := newStore(t)
+	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, nil), &p)
+
+	cases := []struct {
+		name     string
+		body     string
+		wantCode int
+		wantErr  string
+	}{
+		{"too short", `{"username":"ab"}`, http.StatusBadRequest, "username_invalid"},
+		{"bad char", `{"username":"has space"}`, http.StatusBadRequest, "username_invalid"},
+		{"reserved", `{"username":"admin"}`, http.StatusBadRequest, "username_reserved"},
+		{"bad timezone", `{"timezone":"Mars/Phobos"}`, http.StatusBadRequest, "timezone_invalid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := do(t, e, http.MethodPatch, "/api/settings", tc.body, nil)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("want %d got %d body=%s", tc.wantCode, rec.Code, rec.Body.String())
+			}
+			if got := decode(t, rec)["error"]; got != tc.wantErr {
+				t.Errorf("error = %v, want %s", got, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestPatchUsernameTaken(t *testing.T) {
+	st := newStore(t)
+	for _, u := range []store.User{
+		{WorkOSID: "wos_a", Email: "a@x.com", Username: "alice"},
+		{WorkOSID: "wos_b", Email: "b@x.com", Username: "bob"},
+	} {
+		if _, _, err := st.UpsertUserByWorkOSID(ctx, u); err != nil {
+			t.Fatalf("seed %s: %v", u.Username, err)
+		}
+	}
+	p := prof("wos_a", "a@x.com")
+	e := mount(users.New(st, nil), &p)
+
+	// Case-insensitive collision with bob's handle.
+	rec := do(t, e, http.MethodPatch, "/api/settings", `{"username":"BOB"}`, nil)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := decode(t, rec)["error"]; got != "username_taken" {
+		t.Errorf("error = %v, want username_taken", got)
+	}
+}
+
+func TestPatchUsernameRateLimited(t *testing.T) {
+	st := newStore(t)
+	clock := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	st.Now = func() time.Time { return clock }
+
+	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// First change stamps username_changed_at at the current clock.
+	if err := st.SetUsername(ctx, 1, "ada1"); err != nil {
+		t.Fatalf("SetUsername: %v", err)
+	}
+	// One day later — inside the 30-day cooldown.
+	clock = clock.Add(24 * time.Hour)
+
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, nil), &p)
+
+	rec := do(t, e, http.MethodPatch, "/api/settings", `{"username":"ada2"}`, nil)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("want 429 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if body["error"] != "rate_limited" {
+		t.Errorf("error = %v, want rate_limited", body["error"])
+	}
+	if got, _ := body["retry_after_days"].(float64); got != 29 {
+		t.Errorf("retry_after_days = %v, want 29", body["retry_after_days"])
+	}
+	// The username must be unchanged.
+	if u, _ := st.GetUserByWorkOSID(ctx, "wos_1"); u.Username != "ada1" {
+		t.Errorf("username = %q, want ada1 (rejected change)", u.Username)
+	}
+}
+
+func TestDeleteRequestIdempotentAndNotifies(t *testing.T) {
+	st := newStore(t)
+	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	fp := &fakePoster{}
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, fp), &p)
+
+	rec := do(t, e, http.MethodPost, "/api/settings/delete-request", `{"reason":"moving on"}`, nil)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("first: want 202 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if decode(t, rec)["deletion_requested_at"] == nil {
+		t.Errorf("first: deletion_requested_at should be set")
+	}
+
+	// A second click is idempotent: still 202, but no second Slack ping (nothing
+	// new was created).
+	rec = do(t, e, http.MethodPost, "/api/settings/delete-request", `{"reason":"again"}`, nil)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("second: want 202 got %d", rec.Code)
+	}
+	if fp.count() != 1 {
+		t.Errorf("slack posts = %d, want exactly 1", fp.count())
+	}
+
+	// The pending row now surfaces on GET /settings.
+	rec = do(t, e, http.MethodGet, "/api/settings", "", nil)
+	if decode(t, rec)["deletion_requested_at"] == nil {
+		t.Errorf("GET settings: deletion_requested_at should be set")
+	}
+}
+
+func TestPatchRejectsCrossOrigin(t *testing.T) {
+	st := newStore(t)
+	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, nil), &p)
+
+	cases := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"sec-fetch-site cross-site", map[string]string{"Sec-Fetch-Site": "cross-site"}},
+		{"foreign origin", map[string]string{"Origin": "https://evil.example"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := do(t, e, http.MethodPatch, "/api/settings", `{"timezone":"Europe/London"}`, tc.headers)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("want 403 got %d body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// A same-origin write (Origin host == request host) is allowed through.
+	rec := do(t, e, http.MethodPatch, "/api/settings", `{"timezone":"Europe/London"}`, map[string]string{
+		"Origin": "http://example.com", "Sec-Fetch-Site": "same-origin",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("same-origin: want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/apps/api/internal/users/handlers_test.go
+++ b/apps/api/internal/users/handlers_test.go
@@ -234,6 +234,42 @@ func TestPatchUsernameValidation(t *testing.T) {
 	}
 }
 
+func TestPatchIsAtomicOnInvalidField(t *testing.T) {
+	st := newStore(t)
+	for _, u := range []store.User{
+		{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"},
+		{WorkOSID: "wos_2", Email: "b@x.com", Username: "bob"},
+	} {
+		if _, _, err := st.UpsertUserByWorkOSID(ctx, u); err != nil {
+			t.Fatalf("seed %s: %v", u.Username, err)
+		}
+	}
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, nil), &p)
+
+	// A valid timezone paired with a failing username must not commit the timezone:
+	// all fields are validated, and the username writes first, before any timezone
+	// write.
+	cases := []struct {
+		name, body string
+		wantCode   int
+	}{
+		{"reserved username", `{"timezone":"Europe/London","username":"admin"}`, http.StatusBadRequest},
+		{"taken username", `{"timezone":"Europe/London","username":"bob"}`, http.StatusConflict},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := do(t, e, http.MethodPatch, "/api/settings", tc.body, nil)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("want %d got %d body=%s", tc.wantCode, rec.Code, rec.Body.String())
+			}
+			if u, _ := st.GetUserByWorkOSID(ctx, "wos_1"); u.Timezone != "" {
+				t.Errorf("timezone = %q, want empty (a rejected username must not commit the timezone)", u.Timezone)
+			}
+		})
+	}
+}
+
 func TestPatchUsernameTaken(t *testing.T) {
 	st := newStore(t)
 	for _, u := range []store.User{
@@ -265,8 +301,9 @@ func TestPatchUsernameRateLimited(t *testing.T) {
 	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	// First change stamps username_changed_at at the current clock.
-	if err := st.SetUsername(ctx, 1, "ada1"); err != nil {
+	// First change stamps username_changed_at at the current clock (no prior stamp,
+	// so the cutoff is irrelevant here).
+	if err := st.SetUsername(ctx, 1, "ada1", clock); err != nil {
 		t.Fatalf("SetUsername: %v", err)
 	}
 	// One day later — inside the 30-day cooldown.

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/ingest"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/session"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/users"
 )
 
 const staticDir = "static"
@@ -58,12 +59,18 @@ func main() {
 	// runs; /auth/* and the cookie-gated /api/me are simply off.
 	sess := newSessionFromEnv(v)
 
-	ing, database := newIngestFromEnv(ctx)
+	// One database handle, opened on DATABASE_URL alone, shared by accounts and
+	// (when INGEST_TOKEN is also set) the email pipeline. Accounts must not
+	// require the deals pipeline, so the DB is no longer welded to ingest.
+	database := newDatabaseFromEnv(ctx)
 	if database != nil {
 		defer database.Close()
 	}
 
-	e := newServer(staticDir, v, sess, ing)
+	ing := newIngestFromEnv(ctx, database)
+	usr := newUsersFromEnv(database, sess)
+
+	e := newServer(staticDir, v, sess, ing, usr)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -135,43 +142,51 @@ func newSessionFromEnv(v *auth.Verifier) *session.Manager {
 	return m
 }
 
-// newIngestFromEnv builds the email-ingest handlers from the environment. It
-// returns (nil, nil) when the pipeline is not configured (no DATABASE_URL /
-// INGEST_TOKEN), so the server still runs static-only — mirroring the WorkOS
-// graceful-degrade above. The returned *sql.DB (when non-nil) is owned by the
-// caller, which must Close it on shutdown. Fatal only on a genuinely broken
-// setup (bad duration, unreachable DB, bad Gemini client).
-func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
+// newDatabaseFromEnv opens the shared database when DATABASE_URL is set,
+// returning nil (static-only) otherwise. Accounts need only DATABASE_URL; the
+// ingest pipeline layers INGEST_TOKEN on top. The returned handle is owned by the
+// caller, which must Close it on shutdown. Migrate on boot only for a local
+// SQLite database (dev ergonomics); a remote libsql/Turso database is migrated
+// out of band by `server -migrate` (the Fly release_command), so a migration
+// failure aborts the deploy rather than crash-looping the serving process.
+func newDatabaseFromEnv(ctx context.Context) *sql.DB {
+	if os.Getenv("DATABASE_URL") == "" {
+		log.Printf("db: DATABASE_URL not set; accounts and /api/ingest disabled")
+		return nil
+	}
+	dbURL := db.ResolveURL(os.Getenv("DATABASE_URL"), os.Getenv("TURSO_AUTH_TOKEN"))
+	database, err := db.Open(dbURL)
+	if err != nil {
+		log.Fatalf("db: open: %s", db.RedactToken(err.Error(), dbURL))
+	}
+	if !db.IsRemote(dbURL) {
+		if err := db.Migrate(ctx, database); err != nil {
+			_ = database.Close()
+			log.Fatalf("db: migrate: %s", db.RedactToken(err.Error(), dbURL))
+		}
+	}
+	return database
+}
+
+// newIngestFromEnv builds the email-ingest handlers over the shared database. It
+// returns nil when the pipeline is not configured (no DATABASE_URL / INGEST_TOKEN,
+// or no database), so the server still runs static-only — mirroring the WorkOS
+// graceful-degrade above. Fatal only on a genuinely broken setup (bad duration,
+// bad Gemini client).
+func newIngestFromEnv(ctx context.Context, database *sql.DB) *ingest.Handlers {
 	cfg, err := ingest.Load(os.Getenv)
 	if err != nil {
 		log.Fatalf("ingest: %v", err)
 	}
-	if !cfg.Enabled() {
-		log.Printf("ingest: DATABASE_URL / INGEST_TOKEN not set; /api/ingest disabled")
-		return nil, nil
-	}
-
-	dbURL := db.ResolveURL(cfg.DatabaseURL, os.Getenv("TURSO_AUTH_TOKEN"))
-	database, err := db.Open(dbURL)
-	if err != nil {
-		log.Fatalf("ingest: db open: %s", db.RedactToken(err.Error(), dbURL))
-	}
-	// Migrate on boot only for a local SQLite database (dev ergonomics). A
-	// remote libsql/Turso database is migrated out of band by `server -migrate`
-	// (the Fly release_command), so a migration failure aborts the deploy rather
-	// than crash-looping the serving process.
-	if !db.IsRemote(dbURL) {
-		if err := db.Migrate(ctx, database); err != nil {
-			_ = database.Close()
-			log.Fatalf("ingest: db migrate: %s", db.RedactToken(err.Error(), dbURL))
-		}
+	if !cfg.Enabled() || database == nil {
+		log.Printf("ingest: DATABASE_URL / INGEST_TOKEN not both set; /api/ingest disabled")
+		return nil
 	}
 
 	var extractor extract.Extractor = extract.Disabled{}
 	if cfg.GeminiAPIKey != "" {
 		g, err := extract.NewGemini(ctx, cfg.GeminiAPIKey, cfg.GeminiModel, "")
 		if err != nil {
-			_ = database.Close()
 			log.Fatalf("ingest: gemini: %v", err)
 		}
 		extractor = g
@@ -180,7 +195,41 @@ func newIngestFromEnv(ctx context.Context) (*ingest.Handlers, *sql.DB) {
 	}
 
 	poster := digest.NewHTTPPoster(cfg.SlackWebhookURL)
-	return ingest.New(cfg, store.New(database), extractor, poster), database
+	return ingest.New(cfg, store.New(database), extractor, poster)
+}
+
+// newUsersFromEnv builds the account handlers over the shared database and, when
+// a session Manager is present, wires session.OnLogin to upsert the user row at
+// login (sending a brand-new user to /settings/?welcome=1). Returns nil when
+// there is no database, so /api/me falls back to the session's cookie profile.
+func newUsersFromEnv(database *sql.DB, sess *session.Manager) *users.Handlers {
+	if database == nil {
+		return nil
+	}
+	st := store.New(database)
+	if sess != nil {
+		sess.OnLogin = func(ctx context.Context, p session.Profile) (string, error) {
+			_, isNew, err := users.Upsert(ctx, st, p)
+			if err != nil {
+				return "", err
+			}
+			if isNew {
+				return "/settings/?welcome=1", nil
+			}
+			return "", nil
+		}
+	}
+	return users.New(st, newAdminPosterFromEnv())
+}
+
+// newAdminPosterFromEnv builds the admin-channel Slack poster for deletion-request
+// notifications, or nil when SLACK_WEBHOOK_FOR_ADMIN_CHANNEL is unset (the
+// deletion request still records its durable row; only the ping is skipped).
+func newAdminPosterFromEnv() digest.WebhookPoster {
+	if os.Getenv("SLACK_WEBHOOK_FOR_ADMIN_CHANNEL") == "" {
+		return nil
+	}
+	return digest.NewHTTPPoster(os.Getenv("SLACK_WEBHOOK_FOR_ADMIN_CHANNEL"))
 }
 
 // migrateRequested reports whether the process was asked to apply migrations and
@@ -243,7 +292,7 @@ func handleMe(c echo.Context) error {
 //   - else: /api/me falls through to the /api/* JSON 404.
 //
 // Split out from main so tests can build a server against fixtures.
-func newServer(staticRoot string, v *auth.Verifier, sess *session.Manager, ing *ingest.Handlers) *echo.Echo {
+func newServer(staticRoot string, v *auth.Verifier, sess *session.Manager, ing *ingest.Handlers, usr *users.Handlers) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 
@@ -284,7 +333,14 @@ func newServer(staticRoot string, v *auth.Verifier, sess *session.Manager, ing *
 	case sess != nil:
 		sess.Register(e)
 		api := e.Group("/api", sess.Middleware())
-		api.Match(getOrHead, "/me", sess.HandleMe)
+		// With the account DB present the users handlers own /api/me (DB-backed,
+		// with the username) plus the settings routes; without it, the session's
+		// cookie-profile /api/me keeps the site working.
+		if usr != nil {
+			usr.Register(api)
+		} else {
+			api.Match(getOrHead, "/me", sess.HandleMe)
+		}
 	case v != nil:
 		api := e.Group("/api", auth.Middleware(v))
 		api.Match(getOrHead, "/me", handleMe)

--- a/apps/api/main_test.go
+++ b/apps/api/main_test.go
@@ -41,7 +41,7 @@ func fixtureDir(t *testing.T) string {
 }
 
 func TestHealthzReturns204(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -55,7 +55,7 @@ func TestHealthzReturns204(t *testing.T) {
 }
 
 func TestStaticFileServed(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	cases := []struct {
 		name string
 		path string
@@ -85,7 +85,7 @@ func TestStaticFileServed(t *testing.T) {
 // revalidates and the kill switches can be retired cleanly. Ordinary assets
 // must be left untouched.
 func TestServiceWorkerScriptsSentNoCache(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	cases := []struct {
 		name        string
 		path        string
@@ -122,7 +122,7 @@ func TestMissingServiceWorkerStillNoCache(t *testing.T) {
 			t.Fatalf("seed %s: %v", name, err)
 		}
 	}
-	e := newServer(dir, nil, nil, nil)
+	e := newServer(dir, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/sw.js", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -138,7 +138,7 @@ func TestMissingServiceWorkerStillNoCache(t *testing.T) {
 // healthcheck probes, and ad-hoc monitoring all use HEAD; without explicit
 // support Echo returns 405 instead of mirroring the GET status.
 func TestHeadMirrorsGet(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	cases := []struct {
 		name       string
 		path       string
@@ -164,7 +164,7 @@ func TestHeadMirrorsGet(t *testing.T) {
 }
 
 func TestSSGFallbackOnUnknownPageRoute(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/nonexistent/", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -181,7 +181,7 @@ func TestSSGFallbackOnUnknownPageRoute(t *testing.T) {
 }
 
 func TestApiAndWsRoutesSkipSSGFallback(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	cases := []string{"/api/missing", "/ws"}
 	for _, path := range cases {
 		t.Run(path, func(t *testing.T) {
@@ -203,7 +203,7 @@ func TestApiAndWsRoutesSkipSSGFallback(t *testing.T) {
 // connection hijack a WebSocket upgrade needs. The middleware in newServer
 // skips /ws so Phase 4's hub keeps working.
 func TestGzipSkippedOnWebsocketPath(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	cases := []struct {
 		path     string
 		wantGzip bool
@@ -231,7 +231,7 @@ func TestSSGFallbackHandlesMissing404Html(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("home"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	e := newServer(dir, nil, nil, nil)
+	e := newServer(dir, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/nope/", nil)
 	rec := httptest.NewRecorder()
@@ -243,7 +243,7 @@ func TestSSGFallbackHandlesMissing404Html(t *testing.T) {
 }
 
 func TestTrailingSlashCanonicalization(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	cases := []struct {
 		name     string
 		method   string
@@ -286,7 +286,7 @@ func TestIngestRouteWiredWhenEnabled(t *testing.T) {
 	// unauthenticated request reaches that auth (401), proving the route is wired
 	// and not swallowed by the /api/* JSON-404 reservation.
 	ing := ingest.New(ingest.Config{IngestToken: "t"}, nil, nil, nil)
-	e := newServer(fixtureDir(t), nil, nil, ing)
+	e := newServer(fixtureDir(t), nil, nil, ing, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/ingest", strings.NewReader("x"))
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -298,7 +298,7 @@ func TestIngestRouteWiredWhenEnabled(t *testing.T) {
 func TestIngestRouteAbsentWhenDisabled(t *testing.T) {
 	// With no ingest handler, POST /api/ingest falls through to the /api/* JSON
 	// 404 reservation (the pipeline is disabled).
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/ingest", strings.NewReader("x"))
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)

--- a/apps/api/redirects_test.go
+++ b/apps/api/redirects_test.go
@@ -49,7 +49,7 @@ func TestFindRedirect(t *testing.T) {
 // The legacy map must run before static resolution: /index.html is both a real
 // file in the static root and a mapped redirect to /.
 func TestLegacyRedirectPrecedesStaticFile(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/index.html", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -63,7 +63,7 @@ func TestLegacyRedirectPrecedesStaticFile(t *testing.T) {
 }
 
 func TestLegacyRedirectServedOverHTTP(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	cases := []struct {
 		name    string
 		method  string

--- a/apps/api/www_redirect_test.go
+++ b/apps/api/www_redirect_test.go
@@ -14,7 +14,7 @@ import (
 // request-target — the tests mirror that (origin-form path + explicit Host +
 // XFP header) so req.RequestURI and c.Scheme() match what the app really sees.
 func TestNonWWWRedirect(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	cases := []struct {
 		name    string
 		method  string
@@ -52,7 +52,7 @@ func TestNonWWWRedirect(t *testing.T) {
 
 // A request already on the apex host is served normally — no redirect.
 func TestApexHostNotRedirected(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Host = "codeselfstudy.com"
 	req.Header.Set("X-Forwarded-Proto", "https")
@@ -68,7 +68,7 @@ func TestApexHostNotRedirected(t *testing.T) {
 // Without that header (bare dev over http) the target is http, not https —
 // confirming the header is what selects https in production behind the proxy.
 func TestNonWWWRedirectSchemeFromForwardedProto(t *testing.T) {
-	e := newServer(fixtureDir(t), nil, nil, nil)
+	e := newServer(fixtureDir(t), nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Host = "www.codeselfstudy.com"
 	// no X-Forwarded-Proto set


### PR DESCRIPTION
Closes #349. Part of #345 (usernames + settings).

## What

Makes the users schema/store (#347) and username rules (#348) reachable over HTTP and creates the account row at login. Three coupled changes, one PR.

**Decouple the DB from ingest — `apps/api/main.go`**
- New `newDatabaseFromEnv(ctx)` opens one `*sql.DB` gated on `DATABASE_URL` **alone** (keeps `ResolveURL`/`IsRemote` migrate-on-boot/`RedactToken` behavior). `newIngestFromEnv` now takes the shared handle and stays gated on `DATABASE_URL && INGEST_TOKEN`. `main` owns and closes the single handle. Accounts no longer require the deals pipeline.

**Session — `apps/api/internal/session/session.go`**
- Export `Profile`; add `func User(c echo.Context) (Profile, bool)` so other packages read the identity without importing internals.
- Add optional `Manager.OnLogin`, called in `Callback` after the cookie is sealed. A non-empty return redirects there (re-validated via `safeReturnTo`); an error is only logged — a DB hiccup never blocks a login. A nil hook keeps today's behavior. (Extracted to `resolveReturnTo` so it's unit-testable without the WorkOS code exchange.)

**Handlers — `apps/api/internal/users/handlers.go`** (mirrors `ingest/ingest.go`), mounted on the session-gated `/api` group:

| Route | Behavior |
|---|---|
| `GET /api/me` | DB-backed: joins the `users` row, returns `{id,email,username,avatar,timezone}`. One indexed lookup; degrades to the cookie profile if the row is somehow absent. |
| `GET /api/settings` | `{username,email,timezone,deletion_requested_at}` |
| `PATCH /api/settings` | `{username?,timezone?}` — 400 invalid/reserved (or bad timezone via `time.LoadLocation`), 409 taken, 429 within the 30-day rename cooldown (`retry_after_days`), 200 with the new settings |
| `POST /api/settings/delete-request` | 202, idempotent; best-effort `SLACK_WEBHOOK_FOR_ADMIN_CHANNEL` ping (failure logged, still 202 — the row is the record) |

- `originCheck` (Sec-Fetch-Site, else Origin-host) on the writes backs up the cookie's `SameSite=Lax`.
- `newServer`: when the DB is present the users handlers own `/api/me`; when absent, `sess.HandleMe` still does. `sess.OnLogin` upserts via `store.UpsertUserByWorkOSID` + `users.Generate` and sends a brand-new user to `/settings/?welcome=1`.
- `.env.local.example`: `SLACK_WEBHOOK_FOR_ADMIN_CHANNEL` + note that `DATABASE_URL` alone enables accounts.

## Tests

- `internal/users/handlers_test.go`: 401 without a session, `GET /api/me` (+ degrade), `GET /api/settings`, PATCH invalid/reserved/bad-timezone → 400, taken → 409, within-window → 429, deletion 202 + idempotency (webhook fires exactly once), cross-origin PATCH → 403 (and same-origin allowed).
- `internal/session/session_test.go`: `OnLogin` redirecting a new user / ignored on error / hostile dest collapsed, and `User(c)`.
- `apps/api/api_me_users_test.go`: end-to-end `/api/me` returns `username` when wired vs the cookie profile when not, and accounts mounted while `/api/ingest` isn't (the decoupling).
- `cd apps/api && go test -race ./... && go vet ./...` green; `gofmt` clean. The feature branch was caught up with `main` first.

## Notes

- `/api/me` drops the obsolete `name` field (username is the display name now); the current navbar reads `email`, so it's unaffected — #351 rewires the frontend.
- No live username-availability endpoint (409-on-save, as scoped in #345).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticated account endpoints for viewing and updating settings, including username/time zone updates and idempotent deletion requests.
  - Enforced username validation with case-insensitive uniqueness and a 30-day rename cooldown (with clear retry timing).
  - Improved sign-in flow to optionally upsert account data and support post-login redirect control.

- **Documentation**
  - Updated environment configuration guidance for database behavior and added an optional admin Slack webhook setting.

- **Tests**
  - Expanded coverage for `/api/me`, settings behavior, session/profile fallback, and redirect logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->