### PR TITLE
feat(web): /settings/ page + SettingsForm island with welcome mode (#350)

### DIFF
--- a/apps/web/src/components/settings/SettingsForm.test.tsx
+++ b/apps/web/src/components/settings/SettingsForm.test.tsx
@@ -1,0 +1,386 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import SettingsForm from "@/components/settings/SettingsForm";
+
+// SettingsForm drives every state off the cookie-gated /api/settings, so each
+// test stubs fetch: the first call is the on-mount load, later calls are the
+// PATCH (save) or the delete-request POST. Location is reset per test because
+// welcome mode reads and rewrites window.location.
+
+type Body = Record<string, unknown> | null;
+
+function res(status: number, data: Body) {
+  return { ok: status >= 200 && status < 300, status, json: async () => data };
+}
+
+function settings(over: Body = {}) {
+  return res(200, {
+    username: "ada",
+    email: "ada@example.com",
+    timezone: "America/Los_Angeles",
+    deletion_requested_at: null,
+    ...over,
+  });
+}
+
+const unauthorized = res(401, null);
+
+function mockFetch(...responses: Array<ReturnType<typeof res>>) {
+  const fn = vi.fn();
+  for (const r of responses) fn.mockResolvedValueOnce(r);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+beforeEach(() => {
+  window.history.replaceState(null, "", "/settings/");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SettingsForm", () => {
+  test("loading: shows a placeholder and no form until /api/settings resolves", () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+    const { container } = render(<SettingsForm />);
+
+    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Username")).not.toBeInTheDocument();
+  });
+
+  test("signed out (401): shows the sign-in panel linking to /auth/login with returnTo", async () => {
+    mockFetch(unauthorized);
+    render(<SettingsForm />);
+
+    expect(
+      await screen.findByText("Sign in to manage your account.")
+    ).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "Sign In" });
+    expect(link).toHaveAttribute("href", "/auth/login?returnTo=%2Fsettings%2F");
+    expect(screen.queryByLabelText("Username")).not.toBeInTheDocument();
+  });
+
+  test("load failure (500): shows an error, not the sign-in panel", async () => {
+    mockFetch(res(500, null));
+    render(<SettingsForm />);
+
+    expect(
+      await screen.findByText(/couldn’t load your settings/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Sign in to manage your account.")
+    ).not.toBeInTheDocument();
+  });
+
+  test("ready: renders the loaded username, read-only email, and timezone", async () => {
+    mockFetch(settings());
+    render(<SettingsForm />);
+
+    expect(await screen.findByLabelText("Username")).toHaveValue("ada");
+    const email = screen.getByLabelText("Email");
+    expect(email).toHaveValue("ada@example.com");
+    expect(email).toHaveAttribute("readonly");
+    expect(screen.getByLabelText("Time zone")).toHaveValue(
+      "America/Los_Angeles"
+    );
+  });
+
+  test("requests /api/settings with same-origin credentials so the cookie is sent", async () => {
+    const fetchMock = mockFetch(settings());
+    render(<SettingsForm />);
+
+    await screen.findByLabelText("Username");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/settings",
+      expect.objectContaining({ credentials: "same-origin" })
+    );
+  });
+
+  test("empty timezone from the API falls back to the browser zone", async () => {
+    mockFetch(settings({ timezone: "" }));
+    render(<SettingsForm />);
+
+    const select = (await screen.findByLabelText(
+      "Time zone"
+    )) as HTMLSelectElement;
+    expect(select.value).not.toBe("");
+  });
+
+  test("saving PATCHes the new username and shows Saved", async () => {
+    const fetchMock = mockFetch(
+      settings(),
+      res(200, {
+        username: "adalovelace",
+        email: "ada@example.com",
+        timezone: "America/Los_Angeles",
+        deletion_requested_at: null,
+      })
+    );
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    const input = await screen.findByLabelText("Username");
+    await user.clear(input);
+    await user.type(input, "adalovelace");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Saved");
+    const patch = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit | undefined)?.method === "PATCH"
+    );
+    expect(patch).toBeTruthy();
+    const opts = patch![1] as RequestInit;
+    expect(opts.credentials).toBe("same-origin");
+    expect(JSON.parse(opts.body as string)).toEqual({
+      username: "adalovelace",
+      timezone: "America/Los_Angeles",
+    });
+  });
+
+  test("409 shows 'That username is taken'", async () => {
+    mockFetch(settings(), res(409, { error: "username_taken" }));
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.clear(await screen.findByLabelText("Username"));
+    await user.type(screen.getByLabelText("Username"), "taken");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText("That username is taken")
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Username")).toHaveAttribute(
+      "aria-invalid",
+      "true"
+    );
+  });
+
+  test("429 shows the retry window from retry_after_days", async () => {
+    mockFetch(
+      settings(),
+      res(429, { error: "rate_limited", retry_after_days: 12 })
+    );
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.clear(await screen.findByLabelText("Username"));
+    await user.type(screen.getByLabelText("Username"), "toosoon");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText("You can change your username again in 12 days")
+    ).toBeInTheDocument();
+  });
+
+  test("400 invalid username shows the character-set hint", async () => {
+    mockFetch(settings(), res(400, { error: "username_invalid" }));
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.clear(await screen.findByLabelText("Username"));
+    await user.type(screen.getByLabelText("Username"), "bad name");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText(/letters, numbers, hyphens and underscores/i)
+    ).toBeInTheDocument();
+  });
+
+  test("a pending deletion from the API shows the pending state, not the button", async () => {
+    mockFetch(settings({ deletion_requested_at: "2026-07-01T00:00:00Z" }));
+    render(<SettingsForm />);
+
+    expect(
+      await screen.findByText(/you’ve requested account deletion/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Request account deletion" })
+    ).not.toBeInTheDocument();
+  });
+
+  test("requesting deletion confirms, POSTs, then shows the pending state", async () => {
+    const fetchMock = mockFetch(
+      settings(),
+      res(202, { deletion_requested_at: "2026-07-24T00:00:00Z" })
+    );
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Request account deletion" })
+    );
+    // Confirmation copy is explicit that an admin actions it manually.
+    expect(
+      screen.getByText(/deletes the account manually/i)
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Yes, request deletion" })
+    );
+
+    expect(
+      await screen.findByText(/you’ve requested account deletion/i)
+    ).toBeInTheDocument();
+    const post = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit | undefined)?.method === "POST"
+    );
+    expect(post?.[0]).toBe("/api/settings/delete-request");
+  });
+
+  test("cancelling the deletion confirm returns to the request button", async () => {
+    mockFetch(settings());
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Request account deletion" })
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.getByRole("button", { name: "Request account deletion" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Yes, request deletion" })
+    ).not.toBeInTheDocument();
+  });
+
+  test("welcome mode focuses and selects the username, then strips ?welcome=1", async () => {
+    window.history.replaceState(null, "", "/settings/?welcome=1");
+    mockFetch(settings({ username: "clever-otter-42" }));
+    render(<SettingsForm />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Pick a username" })
+    ).toBeInTheDocument();
+    const input = (await screen.findByLabelText(
+      "Username"
+    )) as HTMLInputElement;
+
+    await waitFor(() => expect(document.activeElement).toBe(input));
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+    expect(window.location.search).toBe("");
+  });
+
+  test("timezone select still offers the current zone when the runtime lacks supportedValuesOf", async () => {
+    const original = Intl.supportedValuesOf;
+    // @ts-expect-error — simulate an older runtime without the API.
+    Intl.supportedValuesOf = undefined;
+    try {
+      mockFetch(settings({ timezone: "America/Los_Angeles" }));
+      render(<SettingsForm />);
+
+      const select = (await screen.findByLabelText(
+        "Time zone"
+      )) as HTMLSelectElement;
+      expect(select.value).toBe("America/Los_Angeles");
+      expect(
+        screen.getByRole("option", { name: "America/Los_Angeles" })
+      ).toBeInTheDocument();
+    } finally {
+      Intl.supportedValuesOf = original;
+    }
+  });
+
+  test("400 invalid timezone shows the timezone error", async () => {
+    mockFetch(settings(), res(400, { error: "timezone_invalid" }));
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await screen.findByLabelText("Time zone");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText("That time zone isn’t valid")
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Time zone")).toHaveAttribute(
+      "aria-invalid",
+      "true"
+    );
+  });
+
+  test("429 without retry_after_days falls back to the default window", async () => {
+    mockFetch(settings(), res(429, { error: "rate_limited" }));
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.click(await screen.findByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText("You can change your username again in 30 days")
+    ).toBeInTheDocument();
+  });
+
+  test("an unmapped save failure shows a generic error", async () => {
+    mockFetch(settings(), res(500, null));
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.click(await screen.findByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText(/couldn’t save your settings/i)
+    ).toBeInTheDocument();
+  });
+
+  test("a network error while saving shows a generic error", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(settings())
+      .mockRejectedValueOnce(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.click(await screen.findByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText(/couldn’t save your settings/i)
+    ).toBeInTheDocument();
+  });
+
+  test("a failed deletion request surfaces an error and keeps the confirm open", async () => {
+    mockFetch(settings(), res(500, null));
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Request account deletion" })
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Yes, request deletion" })
+    );
+
+    expect(
+      await screen.findByText(/couldn’t submit your request/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Yes, request deletion" })
+    ).toBeInTheDocument();
+  });
+
+  test("a network error while requesting deletion surfaces an error", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(settings())
+      .mockRejectedValueOnce(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Request account deletion" })
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Yes, request deletion" })
+    );
+
+    expect(
+      await screen.findByText(/couldn’t submit your request/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/SettingsForm.test.tsx
+++ b/apps/web/src/components/settings/SettingsForm.test.tsx
@@ -383,4 +383,39 @@ describe("SettingsForm", () => {
       await screen.findByText(/couldn’t submit your request/i)
     ).toBeInTheDocument();
   });
+
+  test("locks the fields while a save is in flight so a late response can't clobber edits", async () => {
+    let resolvePatch: (v: ReturnType<typeof res>) => void = () => {};
+    const patchPending = new Promise<ReturnType<typeof res>>((r) => {
+      resolvePatch = r;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(settings())
+      .mockReturnValueOnce(patchPending);
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    render(<SettingsForm />);
+
+    await screen.findByLabelText("Username");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // In flight: inputs are locked so newer keystrokes can't be overwritten by
+    // the server's echo of the previously submitted values.
+    expect(screen.getByLabelText("Username")).toBeDisabled();
+    expect(screen.getByLabelText("Time zone")).toBeDisabled();
+
+    resolvePatch(
+      res(200, {
+        username: "ada",
+        email: "ada@example.com",
+        timezone: "America/Los_Angeles",
+        deletion_requested_at: null,
+      })
+    );
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Saved");
+    expect(screen.getByLabelText("Username")).toBeEnabled();
+    expect(screen.getByLabelText("Time zone")).toBeEnabled();
+  });
 });

--- a/apps/web/src/components/settings/SettingsForm.tsx
+++ b/apps/web/src/components/settings/SettingsForm.tsx
@@ -311,6 +311,7 @@ export default function SettingsForm() {
             autoComplete="off"
             autoCapitalize="none"
             spellCheck={false}
+            disabled={saving}
             aria-invalid={error?.field === "username" || undefined}
             aria-describedby={
               error?.field === "username" ? "username-error" : undefined
@@ -358,6 +359,7 @@ export default function SettingsForm() {
               setTimezone(e.target.value);
               onEdit();
             }}
+            disabled={saving}
             aria-invalid={error?.field === "timezone" || undefined}
             className={inputClass}
           >

--- a/apps/web/src/components/settings/SettingsForm.tsx
+++ b/apps/web/src/components/settings/SettingsForm.tsx
@@ -1,0 +1,450 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { FormEvent } from "react";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+// SettingsForm is the single React island behind the static /settings/ shell.
+// The site is prerendered, so there is no per-user server render: this component
+// asks the cookie-gated /api/settings who the caller is and renders its own
+// signed-out state, mirroring SignInButton. It reads the DB-backed settings
+// (username is the display name, email is read-only from WorkOS, timezone), lets
+// the user save changes (PATCH, with the store's 400/409/429 mapped to inline
+// copy), and files a manual account-deletion request. In welcome mode
+// (?welcome=1, set by the server right after sign-up) it focuses and selects the
+// auto-generated username so a single keystroke replaces it.
+
+type Settings = {
+  username: string;
+  email: string;
+  timezone: string;
+  deletion_requested_at: string | null;
+};
+
+type Status = "loading" | "signedout" | "error" | "ready";
+type ErrorField = "username" | "timezone" | null;
+type SaveError = { field: ErrorField; text: string };
+
+// browserTimezone is the default for an account that has never set one — the
+// visitor's own zone, resolved by the runtime.
+function browserTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+// timezoneOptions is the full IANA list the runtime knows, with `current`
+// guaranteed present so a controlled <select> always has its value as an option
+// (a runtime without supportedValuesOf still offers at least the current zone).
+function timezoneOptions(current: string): string[] {
+  const list =
+    typeof Intl.supportedValuesOf === "function"
+      ? Intl.supportedValuesOf("timeZone")
+      : [];
+  if (current && !list.includes(current)) return [current, ...list];
+  return list;
+}
+
+// loginHref points at the server's hosted sign-in, carrying the current in-app
+// location as returnTo so the flow lands the user back here. The server
+// re-validates returnTo to a same-origin path (session.safeReturnTo), so a
+// crafted value can't turn this into an open redirect.
+function loginHref(): string {
+  const returnTo =
+    window.location.pathname + window.location.search + window.location.hash;
+  return `/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
+// saveError maps a failed PATCH /api/settings to the field it concerns and the
+// copy shown inline. The status-code contract with the API lives here, in one
+// place: 409 taken, 429 within the rename cooldown (with retry_after_days), 400
+// reserved/invalid username or invalid timezone.
+function saveError(
+  status: number,
+  body: { error?: string; retry_after_days?: number } | null
+): SaveError {
+  if (status === 409) {
+    return { field: "username", text: "That username is taken" };
+  }
+  if (status === 429) {
+    const n = body?.retry_after_days ?? 30;
+    return {
+      field: "username",
+      text: `You can change your username again in ${n} ${n === 1 ? "day" : "days"}`,
+    };
+  }
+  if (status === 400) {
+    switch (body?.error) {
+      case "username_reserved":
+        return { field: "username", text: "That name is reserved" };
+      case "username_invalid":
+        return {
+          field: "username",
+          text: "Usernames can use letters, numbers, hyphens and underscores",
+        };
+      case "timezone_invalid":
+        return { field: "timezone", text: "That time zone isn’t valid" };
+    }
+  }
+  return {
+    field: null,
+    text: "Couldn’t save your settings. Please try again.",
+  };
+}
+
+const inputClass =
+  "border-input bg-background focus-visible:ring-ring/50 aria-invalid:border-destructive w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-[3px] focus-visible:outline-none";
+
+export default function SettingsForm() {
+  const [status, setStatus] = useState<Status>("loading");
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
+  const [timezone, setTimezone] = useState("");
+  const [deletionRequestedAt, setDeletionRequestedAt] = useState<string | null>(
+    null
+  );
+
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<SaveError | null>(null);
+
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const usernameRef = useRef<HTMLInputElement>(null);
+  // Captured once, before the welcome effect strips it from the URL.
+  const [welcome] = useState(
+    () => new URLSearchParams(window.location.search).get("welcome") === "1"
+  );
+
+  // Load the current settings once. 401 -> signed out; any other non-2xx or a
+  // network error -> a transient error state (a 500 must not masquerade as
+  // "please sign in").
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/settings", {
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    })
+      .then(async (res) => {
+        if (cancelled) return;
+        if (res.status === 401) {
+          setStatus("signedout");
+          return;
+        }
+        if (!res.ok) {
+          setStatus("error");
+          return;
+        }
+        const data = (await res.json()) as Partial<Settings>;
+        if (cancelled) return;
+        setEmail(data.email ?? "");
+        setUsername(data.username ?? "");
+        setTimezone(data.timezone || browserTimezone());
+        setDeletionRequestedAt(data.deletion_requested_at ?? null);
+        setStatus("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Welcome mode: once the data is in, focus the username and select its text so
+  // a single keystroke replaces the auto-generated name. Runs after load (keyed
+  // on status), not on mount. Strip ?welcome=1 so a reload doesn't re-trigger.
+  useEffect(() => {
+    if (status !== "ready" || !welcome) return;
+    const el = usernameRef.current;
+    if (el) {
+      el.focus();
+      el.select();
+    }
+    const url = new URL(window.location.href);
+    url.searchParams.delete("welcome");
+    window.history.replaceState(null, "", url.pathname + url.search + url.hash);
+  }, [status, welcome]);
+
+  const zones = useMemo(() => timezoneOptions(timezone), [timezone]);
+
+  async function handleSave(e: FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, timezone }),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as Partial<Settings>;
+        setUsername(data.username ?? username);
+        setTimezone(data.timezone || timezone);
+        setDeletionRequestedAt(data.deletion_requested_at ?? null);
+        setSaved(true);
+      } else {
+        const body = (await res.json().catch(() => null)) as {
+          error?: string;
+          retry_after_days?: number;
+        } | null;
+        setError(saveError(res.status, body));
+      }
+    } catch {
+      setError({
+        field: null,
+        text: "Couldn’t save your settings. Please try again.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/settings/delete-request", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+      if (res.ok) {
+        const data = (await res.json().catch(() => null)) as {
+          deletion_requested_at?: string | null;
+        } | null;
+        setDeletionRequestedAt(data?.deletion_requested_at ?? null);
+        setConfirmingDelete(false);
+      } else {
+        setError({
+          field: null,
+          text: "Couldn’t submit your request. Please try again.",
+        });
+      }
+    } catch {
+      setError({
+        field: null,
+        text: "Couldn’t submit your request. Please try again.",
+      });
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  // Any edit clears the last save's result so stale "Saved"/error copy never
+  // lingers over changed fields.
+  function onEdit() {
+    setSaved(false);
+    setError(null);
+  }
+
+  if (status === "loading") {
+    return (
+      <div
+        className="bg-muted h-64 animate-pulse rounded-md"
+        aria-hidden="true"
+      />
+    );
+  }
+
+  if (status === "signedout") {
+    return (
+      <div className="mx-auto max-w-md text-center">
+        <h1 className="text-2xl font-bold tracking-tight">Account settings</h1>
+        <p className="text-muted-foreground mt-2 text-sm">
+          Sign in to manage your account.
+        </p>
+        <a href={loginHref()} className={cn(buttonVariants(), "mt-6")}>
+          Sign In
+        </a>
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="mx-auto max-w-md text-center">
+        <h1 className="text-2xl font-bold tracking-tight">Account settings</h1>
+        <p className="text-muted-foreground mt-2 text-sm" role="alert">
+          We couldn’t load your settings. Please reload the page.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-10">
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {welcome ? "Pick a username" : "Account settings"}
+        </h1>
+        <p className="text-muted-foreground mt-2 text-sm">
+          {welcome
+            ? "We gave you a starter username. Make it yours — change it now, then again later if you like."
+            : "Manage how you appear on Code Self Study."}
+        </p>
+      </header>
+
+      <form onSubmit={handleSave} className="space-y-6" noValidate>
+        <div className="space-y-1.5">
+          <label htmlFor="username" className="block text-sm font-medium">
+            Username
+          </label>
+          <input
+            id="username"
+            ref={usernameRef}
+            type="text"
+            value={username}
+            onChange={(e) => {
+              setUsername(e.target.value);
+              onEdit();
+            }}
+            autoComplete="off"
+            autoCapitalize="none"
+            spellCheck={false}
+            aria-invalid={error?.field === "username" || undefined}
+            aria-describedby={
+              error?.field === "username" ? "username-error" : undefined
+            }
+            className={inputClass}
+          />
+          <p className="text-muted-foreground text-xs">
+            This is also your display name.
+          </p>
+          {error?.field === "username" && (
+            <p
+              id="username-error"
+              role="alert"
+              className="text-destructive text-sm"
+            >
+              {error.text}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="email" className="block text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            readOnly
+            className={cn(inputClass, "bg-muted text-muted-foreground")}
+          />
+          <p className="text-muted-foreground text-xs">
+            Managed by your sign-in provider.
+          </p>
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="timezone" className="block text-sm font-medium">
+            Time zone
+          </label>
+          <select
+            id="timezone"
+            value={timezone}
+            onChange={(e) => {
+              setTimezone(e.target.value);
+              onEdit();
+            }}
+            aria-invalid={error?.field === "timezone" || undefined}
+            className={inputClass}
+          >
+            {zones.map((z) => (
+              <option key={z} value={z}>
+                {z}
+              </option>
+            ))}
+          </select>
+          {error?.field === "timezone" && (
+            <p role="alert" className="text-destructive text-sm">
+              {error.text}
+            </p>
+          )}
+        </div>
+
+        {error?.field === null && (
+          <p role="alert" className="text-destructive text-sm">
+            {error.text}
+          </p>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className={cn(buttonVariants())}
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+          {saved && (
+            <span role="status" className="text-muted-foreground text-sm">
+              Saved
+            </span>
+          )}
+        </div>
+      </form>
+
+      <section className="border-destructive/30 rounded-md border p-4">
+        <h2 className="text-sm font-semibold">Delete account</h2>
+        {deletionRequestedAt ? (
+          <p className="text-muted-foreground mt-2 text-sm" role="status">
+            You’ve requested account deletion. An admin actions this manually —
+            your account has not been deleted yet.
+          </p>
+        ) : confirmingDelete ? (
+          <div className="mt-2 space-y-3">
+            <p className="text-muted-foreground text-sm">
+              Are you sure? This sends a request to an admin, who deletes the
+              account manually. Nothing is deleted immediately, and you can keep
+              using your account until then.
+            </p>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting}
+                className={cn(buttonVariants({ variant: "destructive" }))}
+              >
+                {deleting ? "Requesting…" : "Yes, request deletion"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(false)}
+                disabled={deleting}
+                className={cn(buttonVariants({ variant: "outline" }))}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <p className="text-muted-foreground mt-2 text-sm">
+              Request that an admin delete your account. This is manual and not
+              immediate.
+            </p>
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(true)}
+              className={cn(buttonVariants({ variant: "destructive" }), "mt-3")}
+            >
+              Request account deletion
+            </button>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/pages/settings.astro
+++ b/apps/web/src/pages/settings.astro
@@ -1,0 +1,15 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import PageWrapper from "@/components/PageWrapper.astro";
+import SettingsForm from "@/components/settings/SettingsForm";
+---
+
+<Layout
+  title="Settings"
+  description="Your Code Self Study account settings"
+  isNoIndex
+>
+  <PageWrapper>
+    <SettingsForm client:only="react" />
+  </PageWrapper>
+</Layout>

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -86,7 +86,7 @@ check_body_contains() { # path needle
 
 echo "Pages (200 at trailing-slash URLs):"
 for p in / /about/ /codewars/ /contact/ /credits/ /discounts/ /events/ \
-  /forum/ /jobs/ /learn/ /puzzles/ /s/ /tools/; do
+  /forum/ /jobs/ /learn/ /puzzles/ /s/ /settings/ /tools/; do
   check_status "$p" 200
 done
 
@@ -100,6 +100,7 @@ check_redirect /index.html 308 /          # precedence over the real file
 
 echo "Other:"
 check_body_contains /s/ noindex
+check_body_contains /settings/ noindex
 check_status /nonexistent-page-xyz/ 404
 check_body_contains /nonexistent-page-xyz/ "Page not found"
 check_status /healthz 204


### PR DESCRIPTION
Part of the usernames + settings epic (#345). Implements **#350** — the `/settings/` page — on top of #349's API. Targets the integration branch, not `main`.

## What this adds

- **`apps/web/src/pages/settings.astro`** — a static, `noindex` shell that mounts one `client:only="react"` island inside `PageWrapper`. The site is prerendered (`trailingSlash: "always"`, directory output), so there's no per-user server render — same shape as the navbar.
- **`apps/web/src/components/settings/SettingsForm.tsx`** — the island. It asks the cookie-gated `/api/settings` (from #349) who the caller is and renders its own states:
  - **loading** — a quiet placeholder, no layout shift
  - **signed out** (401) — a sign-in panel linking to `/auth/login?returnTo=/settings/`
  - **error** — any other non-2xx / network failure (a 500 must not masquerade as "please sign in")
  - **ready** — the form
  - Fields: **username** (also the display name), **email** (read-only, from WorkOS), **timezone** (`<select>` from `Intl.supportedValuesOf("timeZone")`, defaulting to the browser zone when unset).
  - **Save** → `PATCH /api/settings`, mapping the store's status codes to inline copy: `400` reserved/invalid username or invalid timezone, `409` taken, `429` within the rename cooldown (using `retry_after_days`).
  - **Danger area** → `POST /api/settings/delete-request` behind an explicit confirm step; copy makes clear an admin actions it manually and nothing is deleted immediately. Once a request is pending, the pending state replaces the button.
  - **Welcome mode** (`?welcome=1`, set by the server right after sign-up) focuses **and selects** the auto-generated username so one keystroke replaces it, then strips the param with `history.replaceState` so a reload doesn't re-trigger.
- **`scripts/smoke.sh`** — `/settings/` added to the 200 loop plus `check_body_contains /settings/ noindex`.

## Tests

`SettingsForm.test.tsx` (Vitest + Testing Library, modeled on `SignInButton.test.tsx`): loading, signed-out, ready render, successful save (asserts the PATCH body + same-origin credentials), 409/429/400 mapping, deletion request flow + pending state, and welcome mode asserting both `focus` and `selection` (`selectionStart === 0`, `selectionEnd === value.length`), plus the error/network paths and the timezone fallback.

- `bun run --filter web test:coverage` — 68 passing; global branch coverage 90.83% (gate is 90%).
- `bun run --filter web lint` — clean.
- `bun run --filter web build` — `astro check` clean; `/settings/index.html` generated.
- `just smoke_test` — `SMOKE OK` (`/settings/ -> 200`, contains `noindex`).

## Note / follow-up

The acceptance line "the navbar reflects the new username after a reload" lands in **#351**: today `SignInButton` labels itself with `email || name`, so a rename isn't visible in the navbar until #351 swaps it to prefer the username from `/api/me`. The persistence itself works here.

## Not in scope

Navbar `UserMenu` dropdown (#351).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new Settings page to view and update username and time zone (with read-only email).
  - Included account deletion request flow with explicit confirmation, cancellation, and confirmation state updates.
  - Added welcome-mode behavior that focuses and selects the username field on first visit.
- **Bug Fixes**
  - Improved user feedback for failed loads/saves, including unauthorized access, invalid input, username conflicts, and rate-limiting messaging.
  - Ensured time zone display remains resilient with fallbacks for missing/invalid values.
- **Tests**
  - Expanded automated coverage for loading, saving, deletion, error states, welcome mode, and time zone handling.
  - Updated smoke checks to verify the Settings page loads at trailing-slash URLs and remains no-index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->