### PR TITLE
feat(web): show username in a navbar dropdown, not the email (#351)

### DIFF
--- a/apps/web/src/components/Navbar.test.tsx
+++ b/apps/web/src/components/Navbar.test.tsx
@@ -78,4 +78,28 @@ describe("Navbar", () => {
       within(dialog).queryByRole("button", { name: "Sign In" })
     ).not.toBeInTheDocument();
   });
+
+  test("signed in: shows the username in the top bar, never the email", async () => {
+    // Override the signed-out default from beforeEach with a signed-in /api/me.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          email: "ada@example.com",
+          username: "adalovelace",
+        }),
+      })
+    );
+    render(<Navbar />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Account menu for adalovelace",
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByText("adalovelace")).toBeInTheDocument();
+    expect(screen.queryByText("ada@example.com")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/auth/SignInButton.test.tsx
+++ b/apps/web/src/components/auth/SignInButton.test.tsx
@@ -6,9 +6,11 @@ import SignInButton from "@/components/auth/SignInButton";
 
 // The cookie-gated /api/me is the single source of auth truth: 200 -> signed in,
 // 401 -> signed out. Drive both states through a mocked fetch, and capture
-// window.location.assign to assert the /auth navigations.
+// window.location.assign to assert the /auth navigations. When signed in the
+// control renders UserMenu, so the username shows in the trigger and Sign Out
+// lives inside the opened menu (never the email — see #351).
 
-function meOk(data: { email?: string; name?: string; avatar?: string }) {
+function meOk(data: { email?: string; username?: string; avatar?: string }) {
   return { ok: true, status: 200, json: async () => data };
 }
 const meUnauthorized = { ok: false, status: 401, json: async () => null };
@@ -44,24 +46,28 @@ describe("SignInButton", () => {
       await screen.findByRole("button", { name: "Sign In" })
     ).toBeEnabled();
     expect(
-      screen.queryByRole("button", { name: "Sign Out" })
+      screen.queryByRole("button", { name: /account menu/i })
     ).not.toBeInTheDocument();
   });
 
-  test("signed in: shows the email from /api/me and a Sign Out button", async () => {
+  test("signed in: shows the username, not the email, with Sign Out in the menu", async () => {
     vi.stubGlobal(
       "fetch",
       vi
         .fn()
         .mockResolvedValue(
-          meOk({ email: "ada@example.com", name: "Ada Lovelace" })
+          meOk({ email: "ada@example.com", username: "adalovelace" })
         )
     );
+    const user = userEvent.setup();
     render(<SignInButton />);
 
-    expect(await screen.findByText("ada@example.com")).toBeInTheDocument();
+    expect(await screen.findByText("adalovelace")).toBeInTheDocument();
+    expect(screen.queryByText("ada@example.com")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /account menu/i }));
     expect(
-      screen.getByRole("button", { name: "Sign Out" })
+      await screen.findByRole("menuitem", { name: "Sign Out" })
     ).toBeInTheDocument();
   });
 
@@ -111,15 +117,18 @@ describe("SignInButton", () => {
     );
   });
 
-  test("clicking Sign Out navigates to /auth/logout", async () => {
+  test("Sign Out in the menu navigates to /auth/logout with returnTo", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(meOk({ email: "ada@example.com" }))
+      vi.fn().mockResolvedValue(meOk({ username: "adalovelace" }))
     );
     const user = userEvent.setup();
     render(<SignInButton />);
 
-    await user.click(await screen.findByRole("button", { name: "Sign Out" }));
+    await user.click(
+      await screen.findByRole("button", { name: /account menu/i })
+    );
+    await user.click(await screen.findByRole("menuitem", { name: "Sign Out" }));
 
     expect(assignMock).toHaveBeenCalledWith(
       "/auth/logout?returnTo=%2Fevents%2F"
@@ -136,19 +145,19 @@ describe("SignInButton", () => {
     ).toBeEnabled();
   });
 
-  test("renders the avatar when /api/me returns one", async () => {
+  test("renders the avatar in the trigger when /api/me returns one", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
         meOk({
-          email: "ada@example.com",
+          username: "adalovelace",
           avatar: "https://example.com/ada.png",
         })
       )
     );
     const { container } = render(<SignInButton />);
 
-    await screen.findByRole("button", { name: "Sign Out" });
+    await screen.findByRole("button", { name: /account menu/i });
     // The avatar is decorative (alt=""), so it is not in the a11y tree.
     expect(container.querySelector("img")).toHaveAttribute(
       "src",
@@ -156,27 +165,37 @@ describe("SignInButton", () => {
     );
   });
 
-  test("falls back to the name when /api/me returns no email", async () => {
+  test("falls back to the email label when /api/me returns no username", async () => {
+    // Degrades sensibly when the server runs without a database.
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(meOk({ name: "Ada Lovelace" }))
+      vi.fn().mockResolvedValue(meOk({ email: "ada@example.com" }))
     );
     render(<SignInButton />);
 
-    expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", {
+        name: "Account menu for ada@example.com",
+      })
+    ).toBeInTheDocument();
   });
 
-  test("signed in with an empty profile still renders Sign Out only", async () => {
-    // A 200 with no email, name or avatar is still a valid session; render the
-    // sign-out control without an empty label or a broken image beside it.
+  test("signed in with an empty profile still renders the account menu", async () => {
+    // A 200 with no username, email or avatar is still a valid session; render
+    // the menu trigger (named for assistive tech) without an empty label or a
+    // broken image.
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(meOk({})));
+    const user = userEvent.setup();
     const { container } = render(<SignInButton />);
 
-    expect(
-      await screen.findByRole("button", { name: "Sign Out" })
-    ).toBeInTheDocument();
+    const trigger = await screen.findByRole("button", { name: "Account menu" });
+    expect(trigger).toBeInTheDocument();
     expect(container.querySelector("img")).toBeNull();
-    expect(container.querySelector("span")).toBeNull();
+
+    await user.click(trigger);
+    expect(
+      await screen.findByRole("menuitem", { name: "Sign Out" })
+    ).toBeInTheDocument();
   });
 
   test("ignores a /api/me response that arrives after unmount", async () => {
@@ -194,14 +213,14 @@ describe("SignInButton", () => {
 
     // The `cancelled` flag set by the effect cleanup is what keeps this late
     // resolution from touching state on a component that is already gone.
-    settle(meOk({ email: "ada@example.com" }));
+    settle(meOk({ username: "adalovelace" }));
     await pending;
     await Promise.resolve();
     await Promise.resolve();
 
     expect(consoleError).not.toHaveBeenCalled();
     expect(
-      screen.queryByRole("button", { name: "Sign Out" })
+      screen.queryByRole("button", { name: /account menu/i })
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/components/auth/SignInButton.tsx
+++ b/apps/web/src/components/auth/SignInButton.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-
-type Account = { email: string; name: string; avatar: string };
+import UserMenu from "@/components/auth/UserMenu";
+import type { Account } from "@/components/auth/UserMenu";
 
 // Sign-in / sign-out control for the navbar.
 //
@@ -32,7 +32,7 @@ export default function SignInButton() {
         if (data) {
           setAccount({
             email: data.email ?? "",
-            name: data.name ?? "",
+            username: data.username ?? "",
             avatar: data.avatar ?? "",
           });
           setStatus("in");
@@ -50,25 +50,14 @@ export default function SignInButton() {
   }, []);
 
   if (status === "in" && account) {
-    const label = account.email || account.name;
+    // The username is shown here, never the email — email on a public page is a
+    // privacy leak (#351). UserMenu falls back to email only when the server
+    // runs without a database and /api/me returns no username.
     return (
-      <div className="flex items-center gap-2">
-        {account.avatar && (
-          <img src={account.avatar} alt="" className="h-7 w-7 rounded-full" />
-        )}
-        {label && (
-          <span className="text-foreground hidden text-sm font-medium sm:inline">
-            {label}
-          </span>
-        )}
-        <button
-          type="button"
-          onClick={() => navigateAuth("/auth/logout")}
-          className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
-        >
-          Sign Out
-        </button>
-      </div>
+      <UserMenu
+        account={account}
+        onSignOut={() => navigateAuth("/auth/logout")}
+      />
     );
   }
 

--- a/apps/web/src/components/auth/UserMenu.test.tsx
+++ b/apps/web/src/components/auth/UserMenu.test.tsx
@@ -1,0 +1,123 @@
+import { describe, expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import UserMenu from "@/components/auth/UserMenu";
+
+const account = {
+  email: "ada@example.com",
+  username: "adalovelace",
+  avatar: "https://example.com/ada.png",
+};
+
+describe("UserMenu", () => {
+  test("the trigger shows the username and names itself for assistive tech", () => {
+    render(<UserMenu account={account} onSignOut={() => {}} />);
+
+    const trigger = screen.getByRole("button", {
+      name: "Account menu for adalovelace",
+    });
+    expect(trigger).toBeInTheDocument();
+    expect(screen.getByText("adalovelace")).toBeInTheDocument();
+    // The username is shown, never the email address.
+    expect(screen.queryByText("ada@example.com")).not.toBeInTheDocument();
+  });
+
+  test("the menu is closed until the trigger is clicked", async () => {
+    const user = userEvent.setup();
+    render(<UserMenu account={account} onSignOut={() => {}} />);
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Settings" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Sign Out" })
+    ).toBeInTheDocument();
+  });
+
+  test("opens on keyboard activation of the trigger", async () => {
+    const user = userEvent.setup();
+    render(<UserMenu account={account} onSignOut={() => {}} />);
+
+    screen.getByRole("button", { name: /account menu/i }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+  });
+
+  test("Settings links to /settings/ with the trailing slash", async () => {
+    const user = userEvent.setup();
+    render(<UserMenu account={account} onSignOut={() => {}} />);
+
+    await user.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Settings" })
+    ).toHaveAttribute("href", "/settings/");
+  });
+
+  test("Sign Out invokes the handler", async () => {
+    const onSignOut = vi.fn();
+    const user = userEvent.setup();
+    render(<UserMenu account={account} onSignOut={onSignOut} />);
+
+    await user.click(screen.getByRole("button", { name: /account menu/i }));
+    await user.click(await screen.findByRole("menuitem", { name: "Sign Out" }));
+
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes on Escape", async () => {
+    const user = userEvent.setup();
+    render(<UserMenu account={account} onSignOut={() => {}} />);
+
+    await user.click(screen.getByRole("button", { name: /account menu/i }));
+    await screen.findByRole("menu");
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  test("falls back to the email label when there is no username", () => {
+    render(
+      <UserMenu
+        account={{ email: "ada@example.com", username: "", avatar: "" }}
+        onSignOut={() => {}}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Account menu for ada@example.com" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("ada@example.com")).toBeInTheDocument();
+  });
+
+  test("renders the avatar when the account has one", () => {
+    const { container } = render(
+      <UserMenu account={account} onSignOut={() => {}} />
+    );
+
+    // Decorative (alt=""), so assert on the element rather than the a11y tree.
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://example.com/ada.png"
+    );
+  });
+
+  test("still names the trigger when the account is entirely empty", () => {
+    render(
+      <UserMenu
+        account={{ email: "", username: "", avatar: "" }}
+        onSignOut={() => {}}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Account menu" })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/auth/UserMenu.test.tsx
+++ b/apps/web/src/components/auth/UserMenu.test.tsx
@@ -119,5 +119,23 @@ describe("UserMenu", () => {
     expect(
       screen.getByRole("button", { name: "Account menu" })
     ).toBeInTheDocument();
+    // A visible "Account" fallback keeps the trigger a real affordance.
+    expect(screen.getByText("Account")).toBeInTheDocument();
+  });
+
+  test("shows a visible label with no avatar (mobile has no other affordance)", () => {
+    const { container } = render(
+      <UserMenu
+        account={{
+          email: "ada@example.com",
+          username: "adalovelace",
+          avatar: "",
+        }}
+        onSignOut={() => {}}
+      />
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText("adalovelace")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -1,0 +1,54 @@
+import { buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuLinkItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+// Account is the shape SignInButton reads from /api/me and hands to the menu.
+// The label prefers the username (public-safe) and only falls back to the email
+// when the server runs without a database and returns no username.
+export type Account = { email: string; username: string; avatar: string };
+
+// UserMenu is the signed-in navbar control: an avatar + username trigger that
+// opens a dropdown to the settings page and sign-out. SignInButton still owns
+// the single /api/me fetch and passes the resolved account down, so the
+// one-request-per-load invariant (see Navbar.tsx) is unchanged. Keyboard and
+// screen-reader behaviour come from the Menu primitive.
+export default function UserMenu({
+  account,
+  onSignOut,
+}: {
+  account: Account;
+  onSignOut: () => void;
+}) {
+  const label = account.username || account.email;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label={label ? `Account menu for ${label}` : "Account menu"}
+        className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
+      >
+        {account.avatar && (
+          <img src={account.avatar} alt="" className="h-6 w-6 rounded-full" />
+        )}
+        {label && (
+          <span className="hidden max-w-[16ch] truncate sm:inline">
+            {label}
+          </span>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        {label && <DropdownMenuLabel>{label}</DropdownMenuLabel>}
+        <DropdownMenuLinkItem href="/settings/">Settings</DropdownMenuLinkItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onSignOut}>Sign Out</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -37,11 +37,10 @@ export default function UserMenu({
         {account.avatar && (
           <img src={account.avatar} alt="" className="h-6 w-6 rounded-full" />
         )}
-        {label && (
-          <span className="hidden max-w-[16ch] truncate sm:inline">
-            {label}
-          </span>
-        )}
+        {/* Always visible so the trigger stays a real affordance even with no
+            avatar (e.g. on mobile); falls back to "Account" for an empty
+            profile. */}
+        <span className="max-w-[16ch] truncate">{label || "Account"}</span>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         {label && <DropdownMenuLabel>{label}</DropdownMenuLabel>}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import * as React from "react";
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+
+import { cn } from "@/lib/utils";
+
+// House-style dropdown menu over @base-ui/react's Menu primitive, matching the
+// Sheet wrapper in ui/sheet.tsx (base-vega style, see components.json). The
+// primitive owns keyboard navigation, focus management and dismiss-on-outside /
+// Escape, so consumers only supply content. Written by hand rather than via the
+// shadcn CLI, whose default registry emits Radix, not the @base-ui primitives
+// this codebase standardizes on.
+
+const itemClass =
+  "data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm no-underline outline-none select-none hover:no-underline data-disabled:pointer-events-none data-disabled:opacity-50";
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 8,
+  align = "end",
+  children,
+  ...props
+}: MenuPrimitive.Popup.Props & {
+  sideOffset?: number;
+  align?: "start" | "center" | "end";
+}) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        data-slot="dropdown-menu-positioner"
+        className="z-50"
+        sideOffset={sideOffset}
+        align={align}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 min-w-56 rounded-md border p-1 shadow-md outline-none",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </MenuPrimitive.Popup>
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuItem({ className, ...props }: MenuPrimitive.Item.Props) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(itemClass, className)}
+      {...props}
+    />
+  );
+}
+
+// DropdownMenuLinkItem is a menu item that navigates — it renders an <a>, so it
+// gets native link semantics (open in new tab, copy link) on top of the menu
+// item's keyboard handling.
+function DropdownMenuLinkItem({
+  className,
+  ...props
+}: MenuPrimitive.LinkItem.Props) {
+  return (
+    <MenuPrimitive.LinkItem
+      data-slot="dropdown-menu-link-item"
+      className={cn(itemClass, className)}
+      {...props}
+    />
+  );
+}
+
+// DropdownMenuLabel is a non-interactive header (e.g. the signed-in username).
+function DropdownMenuLabel({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dropdown-menu-label"
+      className={cn(
+        "text-muted-foreground px-2 py-1.5 text-xs font-medium",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLinkItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+};


### PR DESCRIPTION
Part of the usernames + settings epic (#345). Implements **#351** — the change the feature is named for — on top of #349 (`/api/me` returns `username`) and #350 (the Settings page). Targets the integration branch, not `main`. **Last sub-issue of the epic.**

## What & why

The signed-in navbar rendered the user's **email address** on every public page — a privacy leak. It now shows the **username** behind a dropdown that also gives `/settings/` a home.

- **`apps/web/src/components/ui/dropdown-menu.tsx`** (new) — a house-style wrapper over `@base-ui/react`'s `Menu` primitive, matching `ui/sheet.tsx` (base-vega style, per `components.json`). Hand-written rather than `bunx shadcn add` because the shadcn default registry emits Radix, not the `@base-ui` primitives this codebase standardizes on. Keyboard navigation, focus management, and dismiss-on-Escape / outside-click all come from the primitive.
- **`apps/web/src/components/auth/UserMenu.tsx`** (new) — the signed-in control: an avatar + username trigger (accessible-named `Account menu for <label>`) opening a menu with a username header, **Settings → `/settings/`** (trailing slash), and **Sign Out**. The label is `username || email`, so it degrades sensibly when the server runs without a database and `/api/me` returns no username.
- **`apps/web/src/components/auth/SignInButton.tsx`** — unchanged responsibilities: it still owns the single `/api/me` fetch and the loading/in/out logic (the one-request-per-load invariant documented in `Navbar.tsx` is preserved). Its signed-in branch now renders `<UserMenu account={account} onSignOut={…} />`, and the `Account` type carries `username` in place of the never-populated `name`.

## Acceptance criteria

- ✅ A signed-in user sees their username, never their email (when a username exists)
- ✅ Dropdown opens on click **and** keyboard; closes on Escape and outside click (primitive-driven)
- ✅ Settings → `/settings/` (trailing slash); Sign Out still round-trips `/auth/logout?returnTo=…`
- ✅ Still exactly one `/api/me` request per page load (fetch stays in `SignInButton`)
- ✅ New `UserMenu.test.tsx` covers open, Settings href, Sign Out; `SignInButton.test.tsx` and `Navbar.test.tsx` moved off the email label onto the username

## Verification

- `bun run --filter web test:coverage` — 79 passing; branch coverage 91.24% (gate 90%).
- `bun run --filter web lint` — clean.
- `bun run --filter web build` — `astro check` 0 errors; static build succeeds.
- `just smoke_test` — `SMOKE OK`.

## Note

An unrelated pre-existing `ts(6385): 'FormEvent' is deprecated` warning in `SettingsForm.tsx` (from merged #350) is **not** touched here to keep this PR to the navbar; it's tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an account menu for signed-in users in the navigation bar.
  * Displays the username, with email fallback when no username is available.
  * Added avatar support, Settings navigation, and a Sign Out action.
  * Account menu supports mouse and keyboard interactions, including Escape to close.

* **Improvements**
  * Updated sign-out navigation to work through the account menu.
  * Improved account menu accessibility and handling of incomplete profile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->