### PR TITLE
Replace deprecated FormEvent type in SettingsForm

### DIFF
--- a/apps/web/src/components/settings/SettingsForm.tsx
+++ b/apps/web/src/components/settings/SettingsForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { FormEvent } from "react";
+import type { SyntheticEvent } from "react";
 
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -167,7 +167,7 @@ export default function SettingsForm() {
 
   const zones = useMemo(() => timezoneOptions(timezone), [timezone]);
 
-  async function handleSave(e: FormEvent) {
+  async function handleSave(e: SyntheticEvent) {
     e.preventDefault();
     setSaving(true);
     setSaved(false);


### PR DESCRIPTION
Part of the usernames + settings epic (#345) — a tiny type-only fix into the integration branch, same workflow as #350/#351.

## What

`astro check` emitted `ts(6385): 'FormEvent' is deprecated` for `SettingsForm.tsx`. @types/react 19 marks `FormEvent`/`FormEventHandler` as `@deprecated` ("doesn't actually exist").

The `handleSave` argument is retyped from `FormEvent` to `SyntheticEvent` — the non-deprecated base type, which still exposes `preventDefault()` — and the import is swapped to match. No behavior change.

## Verification

- `bun run --filter web build` → `astro check`: 0 errors, 0 warnings, 0 hints
- `bun run --filter web test` → 8 files, 69 tests passed