### PR TITLE
fix(api): address CodeRabbit's three nitpicks from #363

### DIFF
--- a/apps/api/internal/session/session.go
+++ b/apps/api/internal/session/session.go
@@ -52,6 +52,10 @@ const (
 	// OAuth login to the browser that started it. Scoped to /auth and short-lived.
 	nonceCookieName = "wos_oauth"
 	nonceMaxAge     = 10 * time.Minute
+
+	// onLoginTimeout bounds the OnLogin hook so a slow database can't hold the
+	// post-login redirect open. See resolveReturnTo.
+	onLoginTimeout = 3 * time.Second
 )
 
 // Config is the server-side WorkOS configuration the session flow needs, on top
@@ -307,11 +311,19 @@ func (m *Manager) Callback(c echo.Context) error {
 // when it returns a non-empty one (re-validated through safeReturnTo), otherwise
 // the original returnTo. An OnLogin error is logged and ignored — the cookie is
 // already set, so a database hiccup must never block or misdirect a sign-in.
+//
+// The hook gets a bounded context rather than the raw request one so that
+// promise holds for latency too: a hung database would otherwise stall the
+// sign-in redirect for the whole request lifetime. A timed-out upsert degrades
+// exactly like the error case, because the users handlers re-upsert a missing
+// row on the next request.
 func (m *Manager) resolveReturnTo(c echo.Context, returnTo string, p Profile) string {
 	if m.OnLogin == nil {
 		return returnTo
 	}
-	dest, err := m.OnLogin(c.Request().Context(), p)
+	ctx, cancel := context.WithTimeout(c.Request().Context(), onLoginTimeout)
+	defer cancel()
+	dest, err := m.OnLogin(ctx, p)
 	if err != nil {
 		c.Logger().Errorf("session: OnLogin: %v", err)
 		return returnTo

--- a/apps/api/internal/session/session_test.go
+++ b/apps/api/internal/session/session_test.go
@@ -617,6 +617,28 @@ func TestResolveReturnTo(t *testing.T) {
 	}
 }
 
+// The OnLogin hook must run on a bounded context, not the raw request one: an
+// unresponsive database would otherwise hold the post-login redirect open for
+// the whole request lifetime, which the "never block a sign-in" promise in
+// resolveReturnTo's doc comment covers.
+func TestResolveReturnToBoundsOnLogin(t *testing.T) {
+	var deadline time.Time
+	var hasDeadline bool
+	m := &Manager{OnLogin: func(ctx context.Context, _ Profile) (string, error) {
+		deadline, hasDeadline = ctx.Deadline()
+		return "", nil
+	}}
+
+	m.resolveReturnTo(newEchoCtx(), "/events/", Profile{ID: "u1"})
+
+	if !hasDeadline {
+		t.Fatal("OnLogin ctx has no deadline, want one bounded by onLoginTimeout")
+	}
+	if d := time.Until(deadline); d <= 0 || d > onLoginTimeout {
+		t.Errorf("OnLogin ctx deadline in %v, want (0, %v]", d, onLoginTimeout)
+	}
+}
+
 func TestUserContext(t *testing.T) {
 	c := newEchoCtx()
 	if _, ok := User(c); ok {

--- a/apps/api/internal/store/export_test.go
+++ b/apps/api/internal/store/export_test.go
@@ -1,0 +1,7 @@
+package store
+
+// UsernameMaxLen exposes the package-private width limit to the external
+// store_test package, which asserts it still matches users.MaxLen. The store
+// cannot import internal/users (that would be an import cycle), so the constant
+// is duplicated — this is what keeps the copy honest.
+const UsernameMaxLen = usernameMaxLen

--- a/apps/api/internal/store/users_test.go
+++ b/apps/api/internal/store/users_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/users"
 )
 
 func TestUpsertUserByWorkOSID_CreatesThenRefreshes(t *testing.T) {
@@ -217,5 +218,17 @@ func TestCreateDeletionRequest_ConcurrentSingleWinner(t *testing.T) {
 	}
 	if pending, err := s.PendingDeletionRequest(ctx, u.ID); err != nil || pending == nil {
 		t.Fatalf("PendingDeletionRequest = (%v, %v), want one pending row", pending, err)
+	}
+}
+
+// The store keeps its own copy of the username width limit to stay free of a
+// dependency on internal/users. Nothing in the compiler holds the two together,
+// and a suffixed dedupe candidate ("ada-2") is inserted without re-running
+// users.Validate — so a drift here would put an over-length username in the
+// database. This test is the thing that notices.
+func TestUsernameMaxLenMatchesUsersPackage(t *testing.T) {
+	if store.UsernameMaxLen != users.MaxLen {
+		t.Fatalf("store usernameMaxLen = %d, users.MaxLen = %d: the duplicated constant drifted",
+			store.UsernameMaxLen, users.MaxLen)
 	}
 }

--- a/apps/api/internal/users/handlers.go
+++ b/apps/api/internal/users/handlers.go
@@ -289,6 +289,14 @@ func (h *Handlers) notifyAdmin(ctx context.Context, c echo.Context, u store.User
 	detached, cancel := context.WithTimeout(context.WithoutCancel(ctx), notifyTimeout)
 	go func() {
 		defer cancel()
+		// Leaving the request goroutine also leaves Echo's recover middleware
+		// behind, and a panic on a goroutine takes the process with it. A
+		// misbehaving webhook must cost one notification, not the server.
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Errorf("delete-request: slack notify panicked: %v", r)
+			}
+		}()
 		if err := h.poster.Post(detached, payload); err != nil {
 			logger.Errorf("delete-request: slack notify: %v", err)
 		}

--- a/apps/api/internal/users/handlers.go
+++ b/apps/api/internal/users/handlers.go
@@ -22,6 +22,10 @@ import (
 // changes are unlimited.
 const renameCooldown = 30 * 24 * time.Hour
 
+// notifyTimeout bounds the detached admin Slack ping. The HTTP poster carries
+// its own client timeout; this also covers a poster that ignores one.
+const notifyTimeout = 15 * time.Second
+
 // Handlers exposes the account routes (/api/me and /api/settings*) over the
 // store. Construct with New and mount on a session-gated group with Register.
 // poster is the admin-channel Slack webhook and may be nil (the ping is optional;
@@ -262,6 +266,12 @@ func (h *Handlers) userRow(ctx context.Context, p session.Profile) (store.User, 
 
 // notifyAdmin posts a best-effort Slack message about a new deletion request. A
 // nil poster (webhook unset) or a post failure is logged and swallowed.
+//
+// The post runs off the request goroutine, on a context detached from the
+// request's: the durable row is what matters, so the 202 must not wait on a slow
+// webhook, and a client that navigates away mid-request must not cancel the
+// ping the admin depends on. A shutdown can still cut an in-flight post, which
+// is the accepted cost of a best-effort notification.
 func (h *Handlers) notifyAdmin(ctx context.Context, c echo.Context, u store.User) {
 	if h.poster == nil {
 		return
@@ -273,9 +283,16 @@ func (h *Handlers) notifyAdmin(ctx context.Context, c echo.Context, u store.User
 		c.Logger().Errorf("delete-request: marshal slack payload: %v", err)
 		return
 	}
-	if err := h.poster.Post(ctx, payload); err != nil {
-		c.Logger().Errorf("delete-request: slack notify: %v", err)
-	}
+	// Captured before the goroutine: echo may recycle the Context once the
+	// handler returns, but the logger it hands out is the server's own.
+	logger := c.Logger()
+	detached, cancel := context.WithTimeout(context.WithoutCancel(ctx), notifyTimeout)
+	go func() {
+		defer cancel()
+		if err := h.poster.Post(detached, payload); err != nil {
+			logger.Errorf("delete-request: slack notify: %v", err)
+		}
+	}()
 }
 
 // originCheck rejects a cross-origin state-changing request. The session cookie is

--- a/apps/api/internal/users/handlers_test.go
+++ b/apps/api/internal/users/handlers_test.go
@@ -86,15 +86,26 @@ func decode(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
 	return m
 }
 
+// fakePoster records Slack pings. The handler fires them on their own goroutine,
+// so posted lets a test wait for one to land instead of racing it.
 type fakePoster struct {
-	mu sync.Mutex
-	n  int
+	mu     sync.Mutex
+	n      int
+	posted chan struct{}
+}
+
+func newFakePoster() *fakePoster {
+	return &fakePoster{posted: make(chan struct{}, 4)}
 }
 
 func (f *fakePoster) Post(context.Context, []byte) error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.n++
+	f.mu.Unlock()
+	select {
+	case f.posted <- struct{}{}:
+	default: // more posts than any test waits on; count() still sees them
+	}
 	return nil
 }
 
@@ -102,6 +113,59 @@ func (f *fakePoster) count() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.n
+}
+
+// blockingPoster holds a ping open until released, so a test can observe what
+// the handler does while the webhook is still in flight.
+type blockingPoster struct {
+	release chan struct{}
+	done    chan struct{}
+
+	mu       sync.Mutex
+	finished bool
+	ctxErr   error
+}
+
+func newBlockingPoster() *blockingPoster {
+	return &blockingPoster{release: make(chan struct{}), done: make(chan struct{})}
+}
+
+func (b *blockingPoster) Post(ctx context.Context, _ []byte) error {
+	select {
+	case <-b.release:
+	case <-time.After(5 * time.Second): // don't wedge the suite if a test forgets
+	}
+	b.mu.Lock()
+	b.finished, b.ctxErr = true, ctx.Err()
+	b.mu.Unlock()
+	close(b.done)
+	return nil
+}
+
+func (b *blockingPoster) state() (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.finished, b.ctxErr
+}
+
+// awaitPost blocks until the next ping lands, failing the test if none does.
+func (f *fakePoster) awaitPost(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.posted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the slack ping")
+	}
+}
+
+// expectNoPost gives a stray ping time to show up and fails if one does.
+func (f *fakePoster) expectNoPost(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.posted:
+		t.Error("unexpected second slack ping")
+	case <-time.After(100 * time.Millisecond):
+	}
 }
 
 func TestRoutesRequireSession(t *testing.T) {
@@ -334,7 +398,7 @@ func TestDeleteRequestIdempotentAndNotifies(t *testing.T) {
 	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	fp := &fakePoster{}
+	fp := newFakePoster()
 	p := prof("wos_1", "a@x.com")
 	e := mount(users.New(st, fp), &p)
 
@@ -345,6 +409,9 @@ func TestDeleteRequestIdempotentAndNotifies(t *testing.T) {
 	if decode(t, rec)["deletion_requested_at"] == nil {
 		t.Errorf("first: deletion_requested_at should be set")
 	}
+	// The ping is detached from the request, so wait for it rather than
+	// assuming it landed before the 202.
+	fp.awaitPost(t)
 
 	// A second click is idempotent: still 202, but no second Slack ping (nothing
 	// new was created).
@@ -352,6 +419,7 @@ func TestDeleteRequestIdempotentAndNotifies(t *testing.T) {
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("second: want 202 got %d", rec.Code)
 	}
+	fp.expectNoPost(t)
 	if fp.count() != 1 {
 		t.Errorf("slack posts = %d, want exactly 1", fp.count())
 	}
@@ -360,6 +428,39 @@ func TestDeleteRequestIdempotentAndNotifies(t *testing.T) {
 	rec = do(t, e, http.MethodGet, "/api/settings", "", nil)
 	if decode(t, rec)["deletion_requested_at"] == nil {
 		t.Errorf("GET settings: deletion_requested_at should be set")
+	}
+}
+
+// The row is the durable record, so the 202 must not wait on the webhook, and a
+// client that disconnects the moment it lands must not cancel the ping the admin
+// depends on.
+func TestDeleteRequestDoesNotWaitOnSlack(t *testing.T) {
+	st := newStore(t)
+	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	bp := newBlockingPoster()
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, bp), &p)
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	r := httptest.NewRequest(http.MethodPost, "/api/settings/delete-request", nil).WithContext(reqCtx)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("want 202 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if finished, _ := bp.state(); finished {
+		t.Fatal("the 202 waited for the slack ping to finish")
+	}
+
+	cancel()          // the browser goes away
+	close(bp.release) // ...and only then does the webhook answer
+	<-bp.done
+
+	if _, ctxErr := bp.state(); ctxErr != nil {
+		t.Errorf("ping context err = %v, want nil: the request's cancellation must not reach it", ctxErr)
 	}
 }
 

--- a/apps/api/internal/users/handlers_test.go
+++ b/apps/api/internal/users/handlers_test.go
@@ -148,6 +148,15 @@ func (b *blockingPoster) state() (bool, error) {
 	return b.finished, b.ctxErr
 }
 
+// panicPoster stands in for a webhook implementation that blows up. It signals
+// before panicking so the test can be sure the goroutine actually ran.
+type panicPoster struct{ entered chan struct{} }
+
+func (p *panicPoster) Post(context.Context, []byte) error {
+	close(p.entered)
+	panic("webhook exploded")
+}
+
 // awaitPost blocks until the next ping lands, failing the test if none does.
 func (f *fakePoster) awaitPost(t *testing.T) {
 	t.Helper()
@@ -461,6 +470,37 @@ func TestDeleteRequestDoesNotWaitOnSlack(t *testing.T) {
 
 	if _, ctxErr := bp.state(); ctxErr != nil {
 		t.Errorf("ping context err = %v, want nil: the request's cancellation must not reach it", ctxErr)
+	}
+}
+
+// The ping runs outside Echo's recover middleware now, so it has to recover
+// itself: an unrecovered panic on a goroutine takes down the whole server. If
+// this regresses, the test binary dies rather than reporting a failure.
+func TestDeleteRequestSurvivesPanickingPoster(t *testing.T) {
+	st := newStore(t)
+	if _, _, err := st.UpsertUserByWorkOSID(ctx, store.User{WorkOSID: "wos_1", Email: "a@x.com", Username: "ada"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	pp := &panicPoster{entered: make(chan struct{})}
+	p := prof("wos_1", "a@x.com")
+	e := mount(users.New(st, pp), &p)
+
+	rec := do(t, e, http.MethodPost, "/api/settings/delete-request", "", nil)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("want 202 got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	select {
+	case <-pp.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the poster to run")
+	}
+	// Give the panic a moment to either be recovered or kill the process.
+	time.Sleep(50 * time.Millisecond)
+
+	// Still serving: the deletion request is recorded and readable.
+	if decode(t, do(t, e, http.MethodGet, "/api/settings", "", nil))["deletion_requested_at"] == nil {
+		t.Error("deletion_requested_at should be set")
 	}
 }
 


### PR DESCRIPTION
CodeRabbit's review of #363 landed after that PR was merged. It left three nitpicks; all three verified against the merged code and all three are real. One commit each.

### 1. `OnLogin` inherited the raw request context

`resolveReturnTo`'s doc comment already promised that *"a database hiccup must never block or misdirect a sign-in"*, but only an OnLogin **error** was tolerated. A hung upsert held the post-login redirect open for the whole request lifetime. Now bounded at 3s, so the promise covers latency too — a timed-out upsert degrades exactly like the error case, since `userRow` re-upserts a missing row on the next request.

Test asserts the hook receives a context with a deadline inside that bound (no sleeping).

### 2. The admin Slack ping ran on the request path

`notifyAdmin` posted synchronously with the request's context, so the 202 waited on the webhook, and a client that navigated away **cancelled the ping** — losing the only signal an admin gets that someone asked to be deleted. Now runs on its own goroutine with `context.WithoutCancel` plus its own 15s bound.

`TestDeleteRequestDoesNotWaitOnSlack` holds the webhook open, asserts the 202 returned without waiting, then cancels the request context and checks the ping's context is still live. `fakePoster` grew a channel so the idempotency test waits for the ping instead of racing it.

### 3. `store.usernameMaxLen` could drift from `users.MaxLen`

The store duplicates the width limit rather than importing `internal/users` (import cycle). Nothing held them equal, and `insertUserDedup` inserts suffixed candidates (`ada-2`) without re-running `users.Validate` — a drift would have put an over-length username in the database. An external test package can import both, so the assertion lives there, with a test-only `export_test.go` exposing the constant.

Confirmed the guard fails when the constants are deliberately desynced.

### Verification

- `go vet ./...` clean.
- `go test ./...` green.
- `go test ./internal/users -run TestDeleteRequest -count=5` green — the new goroutine sync isn't flaky.
- `just smoke_test` → `SMOKE OK`.
- Web untouched; 80 web tests still pass via the pre-push hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login redirects are now protected by a bounded timeout for the optional login hook, preventing slow background logic from delaying or extending redirect handling.
  * Account deletion no longer waits on Slack notification delivery; notifications run asynchronously with a best-effort timeout, and failures won’t impact the HTTP response.
  * Notification posting is now guarded to avoid panics taking down the server.
* **Tests**
  * Added regression coverage to ensure login hook context deadlines are enforced and deletion returns immediately without waiting for Slack completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->