### PR TITLE
fix: stop the navbar flashing Sign In at signed-in users (#367)

### DIFF
--- a/apps/api/internal/session/session.go
+++ b/apps/api/internal/session/session.go
@@ -53,6 +53,14 @@ const (
 	nonceCookieName = "wos_oauth"
 	nonceMaxAge     = 10 * time.Minute
 
+	// authHintCookieName is a display hint, NOT an auth input. It carries no
+	// secret and grants nothing: Middleware and HandleMe gate solely on the
+	// sealed HttpOnly session cookie above. It is readable by JavaScript so the
+	// navbar can render the right control on its first paint, instead of
+	// flashing Sign In at someone who is already signed in (#367). Never treat
+	// its presence as proof of anything.
+	authHintCookieName = "css_auth"
+
 	// onLoginTimeout bounds the OnLogin hook so a slow database can't hold the
 	// post-login redirect open. See resolveReturnTo.
 	onLoginTimeout = 3 * time.Second
@@ -609,12 +617,26 @@ func refreshKey(refreshToken string) string {
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
+// setCookie and clearCookie always move the auth hint with the session cookie.
+// Keeping both writes in this one pair is what makes the hint trustworthy: it
+// is set exactly when a session starts and cleared exactly when one ends, so it
+// cannot outlive the session it advertises. Every caller — Callback, the silent
+// refresh, Logout, and each unrecoverable-failure path — inherits that for free.
 func (m *Manager) setCookie(c echo.Context, sealed string) {
 	http.SetCookie(c.Response(), &http.Cookie{
 		Name:     cookieName,
 		Value:    sealed,
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   m.secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(cookieMaxAge.Seconds()),
+	})
+	http.SetCookie(c.Response(), &http.Cookie{
+		Name:     authHintCookieName,
+		Value:    "1",
+		Path:     "/",
+		HttpOnly: false, // deliberately readable — see authHintCookieName
 		Secure:   m.secure,
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   int(cookieMaxAge.Seconds()),
@@ -627,6 +649,15 @@ func (m *Manager) clearCookie(c echo.Context) {
 		Value:    "",
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   m.secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+	http.SetCookie(c.Response(), &http.Cookie{
+		Name:     authHintCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: false,
 		Secure:   m.secure,
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   -1,

--- a/apps/api/internal/session/session_test.go
+++ b/apps/api/internal/session/session_test.go
@@ -158,6 +158,17 @@ func cookieFrom(rec *httptest.ResponseRecorder) string {
 	return ""
 }
 
+// hintFrom returns the auth-hint cookie the response set, or nil. Tests care
+// about MaxAge and HttpOnly, not just the value, so this hands back the cookie.
+func hintFrom(rec *httptest.ResponseRecorder) *http.Cookie {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == authHintCookieName {
+			return c
+		}
+	}
+	return nil
+}
+
 // flipFirst mutates the FIRST character of a base64 string, not the last.
 // Everything here is RawURLEncoding (unpadded), so when the encoded length is
 // 2 or 3 mod 4 the final character's low bits map to no output byte and Go's
@@ -497,6 +508,107 @@ func TestMiddlewareRefreshFailureClears(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status: want 401 got %d", rec.Code)
 	}
+}
+
+// The auth hint is a JavaScript-readable flag that lets the navbar paint the
+// right control on its first frame (#367). It is worthless unless it moves in
+// lockstep with the session cookie, so these tests pin it to both halves: set
+// where a session is established, cleared where one ends.
+func TestAuthHintFollowsTheSessionCookie(t *testing.T) {
+	f := newJWKSFixture(t)
+
+	t.Run("set alongside a refreshed session", func(t *testing.T) {
+		m := newTestManager(t, f)
+		fresh := f.signAccess(t, time.Now().Add(5*time.Minute))
+		m.refresh = func(context.Context, string) (string, string, error) {
+			return fresh, "rt_new", nil
+		}
+		sealed := mustSeal(t, m, sessionData{
+			AccessToken:  f.signAccess(t, time.Now().Add(-1*time.Minute)), // expired
+			RefreshToken: "rt_old",
+		})
+
+		rec := serveMe(m, cookie(sealed))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rec.Code)
+		}
+		hint := hintFrom(rec)
+		if hint == nil || hint.Value != "1" {
+			t.Fatalf("hint cookie = %v, want one valued \"1\"", hint)
+		}
+		if hint.HttpOnly {
+			t.Error("hint is HttpOnly: the browser cannot read it, which is its whole purpose")
+		}
+		if hint.MaxAge != int(cookieMaxAge.Seconds()) {
+			t.Errorf("hint MaxAge = %d, want %d (the session's)", hint.MaxAge, int(cookieMaxAge.Seconds()))
+		}
+	})
+
+	// A hint that outlived its session would flash the username at someone who
+	// has been signed out — worse than the flash it exists to fix.
+	t.Run("cleared on every unauthorized path", func(t *testing.T) {
+		m := newTestManager(t, f)
+		m.refresh = func(context.Context, string) (string, string, error) {
+			return "", "", errors.New("refresh rejected")
+		}
+		good := mustSeal(t, m, sessionData{AccessToken: f.signAccess(t, time.Now().Add(5*time.Minute))})
+		expired := mustSeal(t, m, sessionData{
+			AccessToken:  f.signAccess(t, time.Now().Add(-1*time.Minute)),
+			RefreshToken: "rt_old",
+		})
+
+		for _, tc := range []struct {
+			name   string
+			sealed string
+		}{
+			{"tampered", flipFirst(good)},
+			{"refresh rejected", expired},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := serveMe(m, cookie(tc.sealed))
+				if rec.Code != http.StatusUnauthorized {
+					t.Fatalf("want 401 got %d", rec.Code)
+				}
+				hint := hintFrom(rec)
+				if hint == nil || hint.MaxAge >= 0 {
+					t.Errorf("hint = %v, want one expired with MaxAge < 0", hint)
+				}
+			})
+		}
+	})
+
+	t.Run("cleared on logout", func(t *testing.T) {
+		m := newTestManager(t, f)
+		e := echo.New()
+		e.GET("/auth/logout", m.Logout)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/auth/logout?returnTo=/events/", nil))
+
+		if rec.Code != http.StatusFound {
+			t.Fatalf("want 302 got %d", rec.Code)
+		}
+		hint := hintFrom(rec)
+		if hint == nil || hint.MaxAge >= 0 {
+			t.Errorf("hint = %v, want one expired with MaxAge < 0", hint)
+		}
+	})
+
+	// Mirrors the session cookie's own guard: a valid token whose issuer simply
+	// isn't the one we'd have pinned must not look like a logout.
+	t.Run("survives a mismatched issuer", func(t *testing.T) {
+		m := newTestManager(t, f)
+		sealed := mustSeal(t, m, sessionData{
+			AccessToken: f.signAccessIssuer(t, time.Now().Add(5*time.Minute), "https://api.workos.com/"),
+		})
+
+		rec := serveMe(m, cookie(sealed))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rec.Code)
+		}
+		if hint := hintFrom(rec); hint != nil && hint.MaxAge < 0 {
+			t.Error("hint was cleared despite a valid session")
+		}
+	})
 }
 
 func TestLoginRedirectsToWorkOS(t *testing.T) {

--- a/apps/web/src/components/Navbar.test.tsx
+++ b/apps/web/src/components/Navbar.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Navbar from "@/components/Navbar";
+import { AUTH_FLAG_COOKIE, writeAccountHint } from "@/lib/authHint";
 
 // Navbar renders SignInButton, which fetches the cookie-gated /api/me on mount.
 // Stub fetch as signed-out (401) so the nav tests never hit the network (jsdom
@@ -18,6 +19,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  localStorage.clear();
+  document.cookie = `${AUTH_FLAG_COOKIE}=; max-age=0`;
 });
 
 describe("Navbar", () => {
@@ -101,5 +104,18 @@ describe("Navbar", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("adalovelace")).toBeInTheDocument();
     expect(screen.queryByText("ada@example.com")).not.toBeInTheDocument();
+  });
+
+  test("signed in: the username is there on the first frame, no Sign In flash", () => {
+    // #367 end to end: with the server's flag cookie and a cached username, the
+    // navbar must never paint the Sign In button while /api/me is in flight.
+    document.cookie = `${AUTH_FLAG_COOKIE}=1`;
+    writeAccountHint({ username: "adalovelace", avatar: "" });
+    render(<Navbar />); // the beforeEach fetch stub is still pending here
+
+    expect(screen.getByText("adalovelace")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Sign In" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/auth/SignInButton.test.tsx
+++ b/apps/web/src/components/auth/SignInButton.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import SignInButton from "@/components/auth/SignInButton";
@@ -153,7 +153,7 @@ describe("SignInButton", () => {
     );
   });
 
-  test("a failed /api/me request falls back to signed out", async () => {
+  test("a failed /api/me request leaves an unhinted visitor on Sign In", async () => {
     // The API being down must not take the whole navbar with it.
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
     render(<SignInButton />);
@@ -318,16 +318,22 @@ describe("SignInButton", () => {
       expect(readAccountHint()).toBeNull();
     });
 
-    test("a network error keeps the cache for the next attempt", async () => {
-      // The server never said the session was gone, so don't act as if it did:
-      // the server-owned flag cookie is what gates whether the cache gets used.
+    test("a network error changes nothing — no flash on flakiness", async () => {
+      // The server never said the session was gone, so don't act as if it did.
+      // Flipping to Sign In here would be the same bug as #367, just triggered
+      // by a dropped request instead of fetch latency.
       signedInHint({ username: "adalovelace", avatar: "" });
-      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+      const fetchMock = vi.fn().mockRejectedValue(new Error("offline"));
+      vi.stubGlobal("fetch", fetchMock);
       render(<SignInButton />);
 
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
       expect(
-        await screen.findByRole("button", { name: "Sign In" })
-      ).toBeEnabled();
+        screen.getByRole("button", { name: "Account menu for adalovelace" })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Sign In" })
+      ).not.toBeInTheDocument();
       expect(readAccountHint()).toEqual({
         username: "adalovelace",
         avatar: "",

--- a/apps/web/src/components/auth/SignInButton.test.tsx
+++ b/apps/web/src/components/auth/SignInButton.test.tsx
@@ -3,12 +3,28 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import SignInButton from "@/components/auth/SignInButton";
+import {
+  AUTH_FLAG_COOKIE,
+  readAccountHint,
+  writeAccountHint,
+} from "@/lib/authHint";
 
 // The cookie-gated /api/me is the single source of auth truth: 200 -> signed in,
 // 401 -> signed out. Drive both states through a mocked fetch, and capture
 // window.location.assign to assert the /auth navigations. When signed in the
 // control renders UserMenu, so the username shows in the trigger and Sign Out
 // lives inside the opened menu (never the email — see #351).
+//
+// What paints *before* that fetch resolves is the auth hint's job (#367), so the
+// tests below split into two groups: what the first frame shows, and what the
+// fetch reconciles it to.
+
+// signedInHint puts the browser in the state a signed-in visitor arrives with:
+// the server's flag cookie, and optionally a cached username/avatar.
+function signedInHint(hint?: { username: string; avatar: string }) {
+  document.cookie = `${AUTH_FLAG_COOKIE}=1`;
+  if (hint) writeAccountHint(hint);
+}
 
 function meOk(data: { email?: string; username?: string; avatar?: string }) {
   return { ok: true, status: 200, json: async () => data };
@@ -35,6 +51,8 @@ afterEach(() => {
     writable: true,
     value: realLocation,
   });
+  localStorage.clear();
+  document.cookie = `${AUTH_FLAG_COOKIE}=; max-age=0`;
 });
 
 describe("SignInButton", () => {
@@ -196,6 +214,147 @@ describe("SignInButton", () => {
     expect(
       await screen.findByRole("menuitem", { name: "Sign Out" })
     ).toBeInTheDocument();
+  });
+
+  // These assert synchronously, with no await between render and the
+  // expectation: that is the whole point — what the user sees on frame one,
+  // before /api/me has answered.
+  describe("first paint, before /api/me answers", () => {
+    test("no flag cookie: Sign In, immediately", () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(meUnauthorized));
+      render(<SignInButton />);
+
+      expect(screen.getByRole("button", { name: "Sign In" })).toBeEnabled();
+    });
+
+    test("flag cookie plus a cached hint: the username, immediately", () => {
+      // The regression this fixes: a signed-in visitor used to watch Sign In
+      // paint and then get replaced by their own name.
+      signedInHint({ username: "adalovelace", avatar: "https://i/ada.png" });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(meOk({ username: "adalovelace" }))
+      );
+      const { container } = render(<SignInButton />);
+
+      expect(
+        screen.getByRole("button", { name: "Account menu for adalovelace" })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Sign In" })
+      ).not.toBeInTheDocument();
+      expect(container.querySelector("img")).toHaveAttribute(
+        "src",
+        "https://i/ada.png"
+      );
+    });
+
+    test("flag cookie with no cached hint: the generic account menu, not Sign In", () => {
+      // Signed in on another device, or storage cleared. Still must not flash.
+      signedInHint();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(meOk({ username: "adalovelace" }))
+      );
+      render(<SignInButton />);
+
+      expect(
+        screen.getByRole("button", { name: "Account menu" })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Sign In" })
+      ).not.toBeInTheDocument();
+    });
+
+    test("the email is never seeded from the cache", async () => {
+      // The hint deliberately stores no email; only /api/me supplies one.
+      signedInHint({ username: "", avatar: "" });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(meOk({ email: "ada@example.com" }))
+      );
+      render(<SignInButton />);
+
+      expect(screen.queryByText("ada@example.com")).not.toBeInTheDocument();
+      // ...and it appears only once the server actually says so.
+      expect(
+        await screen.findByRole("button", {
+          name: "Account menu for ada@example.com",
+        })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("reconciling with /api/me", () => {
+    test("a 200 caches the username and avatar for the next page load", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          meOk({
+            email: "ada@example.com",
+            username: "adalovelace",
+            avatar: "https://i/ada.png",
+          })
+        )
+      );
+      render(<SignInButton />);
+
+      await screen.findByRole("button", { name: /account menu/i });
+      expect(readAccountHint()).toEqual({
+        username: "adalovelace",
+        avatar: "https://i/ada.png",
+      });
+    });
+
+    test("a stale flag falls back to Sign In and drops the cache", async () => {
+      // Session revoked server-side while the flag lingered in this tab.
+      signedInHint({ username: "adalovelace", avatar: "" });
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(meUnauthorized));
+      render(<SignInButton />);
+
+      expect(
+        await screen.findByRole("button", { name: "Sign In" })
+      ).toBeEnabled();
+      expect(readAccountHint()).toBeNull();
+    });
+
+    test("a network error keeps the cache for the next attempt", async () => {
+      // The server never said the session was gone, so don't act as if it did:
+      // the server-owned flag cookie is what gates whether the cache gets used.
+      signedInHint({ username: "adalovelace", avatar: "" });
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+      render(<SignInButton />);
+
+      expect(
+        await screen.findByRole("button", { name: "Sign In" })
+      ).toBeEnabled();
+      expect(readAccountHint()).toEqual({
+        username: "adalovelace",
+        avatar: "",
+      });
+    });
+
+    test("signing out drops the cached username", async () => {
+      signedInHint({ username: "adalovelace", avatar: "" });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(meOk({ username: "adalovelace" }))
+      );
+      const user = userEvent.setup();
+      render(<SignInButton />);
+
+      await user.click(
+        await screen.findByRole("button", { name: /account menu/i })
+      );
+      await user.click(
+        await screen.findByRole("menuitem", { name: "Sign Out" })
+      );
+
+      expect(readAccountHint()).toBeNull();
+      expect(assignMock).toHaveBeenCalledWith(
+        "/auth/logout?returnTo=%2Fevents%2F"
+      );
+    });
   });
 
   test("ignores a /api/me response that arrives after unmount", async () => {

--- a/apps/web/src/components/auth/SignInButton.tsx
+++ b/apps/web/src/components/auth/SignInButton.tsx
@@ -4,19 +4,49 @@ import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import UserMenu from "@/components/auth/UserMenu";
 import type { Account } from "@/components/auth/UserMenu";
+import {
+  clearAccountHint,
+  isSignedInHint,
+  readAccountHint,
+  writeAccountHint,
+} from "@/lib/authHint";
 
 // Sign-in / sign-out control for the navbar.
 //
-// Auth now lives in a first-party, HTTP-only session cookie that the Go server
-// sets during the WorkOS hosted flow (see apps/api/internal/session). The
-// browser holds no WorkOS tokens, so this component just asks the cookie-gated
-// /api/me who the user is: 200 -> signed in (render avatar + email + Sign Out),
-// 401 -> signed out (render Sign In). Signing in and out are plain navigations
-// to the server's /auth routes, which run the hosted flow and set or clear the
-// cookie, then send the user back to where they were.
+// Auth lives in a first-party, HTTP-only session cookie that the Go server sets
+// during the WorkOS hosted flow (see apps/api/internal/session). The browser
+// holds no WorkOS tokens, so this component asks the cookie-gated /api/me who
+// the user is: 200 -> signed in, 401 -> signed out. Signing in and out are plain
+// navigations to the server's /auth routes, which run the hosted flow and set or
+// clear the cookie, then send the user back to where they were.
+//
+// That fetch takes a round-trip, and rendering Sign In while it is in flight
+// flashed the wrong control at every signed-in visitor (#367). So the first
+// render is seeded from the auth hint instead — a server-managed flag cookie
+// plus a cached username/avatar (see lib/authHint). The hint decides what paints
+// first; /api/me remains the only thing that decides what is true.
+type AuthState = { status: "in"; account: Account } | { status: "out" };
+
+// initialState runs once, synchronously, before the first paint.
+function initialState(): AuthState {
+  if (!isSignedInHint()) return { status: "out" };
+  // Signed in per the server, but the cached detail may be missing (first visit
+  // after signing in on another device, cleared storage). UserMenu renders a
+  // generic "Account" label for an empty profile, so this still paints a real
+  // control rather than a flash.
+  const hint = readAccountHint();
+  return {
+    status: "in",
+    account: {
+      email: "",
+      username: hint?.username ?? "",
+      avatar: hint?.avatar ?? "",
+    },
+  };
+}
+
 export default function SignInButton() {
-  const [status, setStatus] = useState<"loading" | "in" | "out">("loading");
-  const [account, setAccount] = useState<Account | null>(null);
+  const [state, setState] = useState<AuthState>(initialState);
 
   useEffect(() => {
     let cancelled = false;
@@ -30,33 +60,47 @@ export default function SignInButton() {
       .then((data) => {
         if (cancelled) return;
         if (data) {
-          setAccount({
+          const account: Account = {
             email: data.email ?? "",
             username: data.username ?? "",
             avatar: data.avatar ?? "",
+          };
+          setState({ status: "in", account });
+          writeAccountHint({
+            username: account.username,
+            avatar: account.avatar,
           });
-          setStatus("in");
         } else {
-          setStatus("out");
+          // The hint said signed in and the server disagrees, or there was no
+          // hint at all. Either way the cache is now wrong.
+          clearAccountHint();
+          setState({ status: "out" });
         }
       })
       .catch(() => {
         // Network error — treat as signed out rather than crashing the navbar.
-        if (!cancelled) setStatus("out");
+        // The cached detail is left alone: the session may well still be valid,
+        // and the server-owned flag is what decides whether it gets used.
+        if (!cancelled) setState({ status: "out" });
       });
     return () => {
       cancelled = true;
     };
   }, []);
 
-  if (status === "in" && account) {
+  if (state.status === "in") {
     // The username is shown here, never the email — email on a public page is a
     // privacy leak (#351). UserMenu falls back to email only when the server
     // runs without a database and /api/me returns no username.
     return (
       <UserMenu
-        account={account}
-        onSignOut={() => navigateAuth("/auth/logout")}
+        account={state.account}
+        onSignOut={() => {
+          // The server clears the flag cookie on /auth/logout; the cached
+          // username is ours to drop.
+          clearAccountHint();
+          navigateAuth("/auth/logout");
+        }}
       />
     );
   }
@@ -64,7 +108,6 @@ export default function SignInButton() {
   return (
     <button
       type="button"
-      disabled={status === "loading"}
       onClick={() => navigateAuth("/auth/login")}
       className={cn(buttonVariants({ variant: "default", size: "sm" }))}
     >

--- a/apps/web/src/components/auth/SignInButton.tsx
+++ b/apps/web/src/components/auth/SignInButton.tsx
@@ -78,10 +78,12 @@ export default function SignInButton() {
         }
       })
       .catch(() => {
-        // Network error — treat as signed out rather than crashing the navbar.
-        // The cached detail is left alone: the session may well still be valid,
-        // and the server-owned flag is what decides whether it gets used.
-        if (!cancelled) setState({ status: "out" });
+        // Network error. Leave both the state and the cache exactly as seeded:
+        // a fetch that never arrived is not the server saying "signed out", and
+        // flipping to Sign In here would re-create the very flash this fixes,
+        // triggered by flakiness instead of latency. Only a definitive /api/me
+        // answer changes what is displayed. Someone with no hint was already
+        // showing Sign In, so they see no change either.
       });
     return () => {
       cancelled = true;

--- a/apps/web/src/lib/authHint.test.ts
+++ b/apps/web/src/lib/authHint.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  AUTH_FLAG_COOKIE,
+  clearAccountHint,
+  isSignedInHint,
+  readAccountHint,
+  writeAccountHint,
+} from "./authHint";
+
+// jsdom gives real document.cookie and localStorage, so these exercise the same
+// code paths the browser will. Both are process-wide, so reset after each test.
+function setCookie(raw: string) {
+  document.cookie = raw;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+  for (const part of document.cookie.split(";")) {
+    const name = part.split("=")[0]?.trim();
+    if (name) document.cookie = `${name}=; max-age=0`;
+  }
+});
+
+describe("isSignedInHint", () => {
+  test("false when the flag cookie is absent", () => {
+    expect(isSignedInHint()).toBe(false);
+  });
+
+  test("true when the server has set the flag", () => {
+    setCookie(`${AUTH_FLAG_COOKIE}=1`);
+    expect(isSignedInHint()).toBe(true);
+  });
+
+  test("finds the flag among other cookies", () => {
+    setCookie("theme=dark");
+    setCookie(`${AUTH_FLAG_COOKIE}=1`);
+    setCookie("other=x");
+    expect(isSignedInHint()).toBe(true);
+  });
+
+  test("a cookie whose name merely ends with the flag name does not count", () => {
+    // Substring matching here would let an unrelated cookie forge a signed-in
+    // first paint.
+    setCookie(`x${AUTH_FLAG_COOKIE}=1`);
+    expect(isSignedInHint()).toBe(false);
+  });
+});
+
+describe("readAccountHint", () => {
+  test("null when nothing has been stored", () => {
+    expect(readAccountHint()).toBeNull();
+  });
+
+  test("round-trips what writeAccountHint stored", () => {
+    writeAccountHint({ username: "adalovelace", avatar: "https://i/a.png" });
+    expect(readAccountHint()).toEqual({
+      username: "adalovelace",
+      avatar: "https://i/a.png",
+    });
+  });
+
+  test("null when the stored value is not JSON", () => {
+    localStorage.setItem("auth:account", "{not json");
+    expect(readAccountHint()).toBeNull();
+  });
+
+  test("null when the stored JSON is not an object", () => {
+    localStorage.setItem("auth:account", '"adalovelace"');
+    expect(readAccountHint()).toBeNull();
+  });
+
+  test("null when the stored JSON is literal null", () => {
+    localStorage.setItem("auth:account", "null");
+    expect(readAccountHint()).toBeNull();
+  });
+
+  test("null when the fields are the wrong shape", () => {
+    // An older release, another tab, or someone with devtools open.
+    localStorage.setItem("auth:account", '{"username":42,"avatar":"x"}');
+    expect(readAccountHint()).toBeNull();
+    localStorage.setItem("auth:account", '{"username":"ada"}');
+    expect(readAccountHint()).toBeNull();
+  });
+
+  test("null when storage itself throws", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+    expect(readAccountHint()).toBeNull();
+  });
+});
+
+describe("writeAccountHint", () => {
+  test("swallows a storage failure — the hint is an optimization", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    expect(() =>
+      writeAccountHint({ username: "ada", avatar: "" })
+    ).not.toThrow();
+  });
+});
+
+describe("clearAccountHint", () => {
+  test("removes a stored hint", () => {
+    writeAccountHint({ username: "ada", avatar: "" });
+    clearAccountHint();
+    expect(readAccountHint()).toBeNull();
+  });
+
+  test("swallows a storage failure", () => {
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+    expect(() => clearAccountHint()).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/authHint.ts
+++ b/apps/web/src/lib/authHint.ts
@@ -1,0 +1,75 @@
+/**
+ * A synchronously-readable hint about who is signed in, so the navbar can paint
+ * the right control on its first frame instead of flashing Sign In at someone
+ * who is already signed in (#367).
+ *
+ * Two halves, deliberately:
+ *
+ * - The **flag** is a cookie the Go server writes and clears in lockstep with
+ *   the HttpOnly session cookie (see `authHintCookieName` in
+ *   apps/api/internal/session/session.go). Because the server owns it, it
+ *   cannot outlive the session — signing out elsewhere, or a session expiring,
+ *   takes the flag with it.
+ * - The **detail** (username, avatar) lives in localStorage, which no server
+ *   can invalidate. It is only ever trusted behind the flag, where being one
+ *   fetch out of date is harmless.
+ *
+ * Neither half is authentication. The flag carries no secret and grants
+ * nothing; every protected response still depends on the sealed session cookie.
+ *
+ * The email is deliberately NOT cached. Keeping it off public surfaces is the
+ * whole point of the navbar work (#351), and writing it to disk works against
+ * that on a shared machine.
+ */
+
+export const AUTH_FLAG_COOKIE = "css_auth";
+const ACCOUNT_KEY = "auth:account";
+
+export type AccountHint = { username: string; avatar: string };
+
+/**
+ * Whether the server says this browser currently has a session.
+ *
+ * No try/catch: unlike localStorage, `document.cookie` cannot throw, and this
+ * only ever runs in the browser (the navbar island is `client:only`).
+ */
+export function isSignedInHint(): boolean {
+  // Match the full name — a cookie called `xcss_auth` is a different cookie.
+  return document.cookie
+    .split(";")
+    .some((part) => part.trim().startsWith(`${AUTH_FLAG_COOKIE}=`));
+}
+
+/** The last known username/avatar, or null if there is nothing usable stored. */
+export function readAccountHint(): AccountHint | null {
+  try {
+    const raw = localStorage.getItem(ACCOUNT_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    // Anything can be in storage — another tab, an older release, a person with
+    // devtools open. Only a value of the shape we wrote is worth trusting.
+    if (!parsed || typeof parsed !== "object") return null;
+    const { username, avatar } = parsed as Record<string, unknown>;
+    if (typeof username !== "string" || typeof avatar !== "string") return null;
+    return { username, avatar };
+  } catch {
+    /* storage disabled (private mode, blocked cookies), or not JSON */
+    return null;
+  }
+}
+
+export function writeAccountHint(hint: AccountHint): void {
+  try {
+    localStorage.setItem(ACCOUNT_KEY, JSON.stringify(hint));
+  } catch {
+    /* storage full or disabled — the hint is an optimization, not a need */
+  }
+}
+
+export function clearAccountHint(): void {
+  try {
+    localStorage.removeItem(ACCOUNT_KEY);
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
Closes #367.

The session cookie is `HttpOnly`, so the navbar had no way to know it was signed in until `/api/me` answered — and `SignInButton`'s `"loading"` branch rendered the same markup as signed-out. Every signed-in visitor watched **Sign In** paint and then get replaced by their own name.

### Server

A companion cookie, `css_auth=1`, non-`HttpOnly`, same `Path`/`Secure`/`SameSite`/`MaxAge` as the session cookie.

It is written and cleared **inside `setCookie`/`clearCookie` only**. That is the whole design: the hint moves in lockstep with the session it advertises — set exactly where a session starts, cleared exactly where one ends — so `Callback`, the silent refresh, `Logout`, unseal failure and refresh failure all inherit it without changing. A hint that could outlive its session would flash the username at someone who has been signed out, which is worse than the bug being fixed, so the tests pin both halves including the mismatched-issuer case that must *not* clear it.

The flag carries no secret and grants nothing. `Middleware` and `HandleMe` still gate solely on the sealed cookie, and the constant's doc comment says so — this must never become an auth input.

Not written on every `Middleware` success (the issue's original sketch). That would add a `Set-Cookie` to every authenticated API response to backfill sessions predating the deploy — and those backfill on their own, since WorkOS access tokens live minutes and the refresh path calls `setCookie`. Worst case an existing user sees the flash once more.

### Client

New `src/lib/authHint.ts`: reads the flag from `document.cookie` (full-name match — `xcss_auth` is a different cookie) and caches username + avatar in localStorage, every access `try/catch`-guarded the way `ThemeToggle` already does it, and parsed defensively since anything can end up in storage.

**No email is cached.** Keeping it off public surfaces is the point of #351, and writing it to disk works against that on a shared machine. The no-database fallback shows the generic `Account` chip for one round-trip instead.

`SignInButton` now seeds its first render from that hint via a lazily-initialized discriminated union: no flag → Sign In immediately (correct for anonymous visitors); flag → the account menu, with the cached name when there is one and `UserMenu`'s existing `"Account"` fallback when there isn't. `"loading"` and its disabled button are gone. The single `/api/me` fetch is unchanged and still decides what is *true* — it just no longer decides what paints first — writing the cache on 200 and dropping it on 401. A network error leaves the cache alone: the server never said the session was gone, and the server-owned flag is what gates whether the cache gets used at all.

### Verification

- `go vet ./...` clean, `go test ./...` green.
- 103 web tests pass; the `src/lib/**` 100% coverage gate is met.
- New tests assert the first frame **synchronously**, with no `await` between `render` and the expectation — that is the actual regression: no flag → Sign In; flag + cache → the username; flag, no cache → the generic menu; stale flag → falls back and drops the cache.
- `just lint` clean, `just smoke_test` → `SMOKE OK`.

Still worth a human check after deploy: hard-reload while signed in (no flash), sign out in a second tab then reload the first (no stale username), and confirm `css_auth` is present in `document.cookie` while signed in and gone after logout.

### Not addressed

The other flash — blank navbar → navbar — caused by the island being `client:only="react"`. That is a layout pop rather than wrong content, and removing it means prerendering a navbar shell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a lightweight auth-hint mechanism so the navbar/sign-in UI can render cached account info immediately.
  - Cached account details (name/avatar) are synced after successful auth confirmation and drive initial UI state to reduce flashes.
- **Bug Fixes**
  - Auth-hint is now cleared when sessions are invalid/tampered, refresh fails, or on logout redirect, preventing stale UI.
  - Network errors no longer wipe cached hints, improving continuity for retry.
- **Tests**
  - Added coverage for hint synchronization, UI reconciliation, and robust hint parsing/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->