### PR TITLE
ci: drop stale WorkOS env from the web build step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,6 @@ jobs:
       # breakage fails the PR. The build script is `astro check && astro build`.
       - name: Build web
         run: bun run --filter web build
-        env:
-          # Public (client-exposed) WorkOS config. The require-workos-env guard
-          # fails `astro build` when these are empty; CI is not a deploy target,
-          # so fall back to a placeholder when the repo Variables aren't set.
-          # Real values live in .env.local for `just deploy`.
-          PUBLIC_WORKOS_CLIENT_ID: ${{ vars.PUBLIC_WORKOS_CLIENT_ID || 'client_ci_placeholder' }}
-          PUBLIC_WORKOS_API_HOSTNAME: ${{ vars.PUBLIC_WORKOS_API_HOSTNAME || 'auth.workos.com' }}
 
       - name: Test web with coverage
         run: bun run --filter web test:coverage


### PR DESCRIPTION
## Summary

The `Build web` step in `.github/workflows/test.yml` still exported `PUBLIC_WORKOS_CLIENT_ID` and `PUBLIC_WORKOS_API_HOSTNAME`, with a comment explaining that the require-workos-env guard fails `astro build` when they're empty. That guard was removed when auth pivoted to a server-side session (#340), and nothing under `apps/web` references `PUBLIC_WORKOS_*` or the guard anymore, so the env block is dead weight in CI.

This removes the env block and its comment. The remaining `PUBLIC_WORKOS_*` references in the repo are unaffected: the Go API reads them as server-side env at deploy time (and its tests set their own values), and the manual documents them for local `.env.local` setup — neither consumes the step-scoped env of the web build step.

## Verification

Ran `bun run --filter web build` (i.e. `astro check && astro build`) locally with both variables explicitly unset and no `.env.local` present: type check clean, 15 pages built, exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the web build workflow to proceed without injecting placeholder authentication environment variables.
  * Kept coverage testing as the next step in the automated validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->