### PR TITLE
Prevent license finder from searching `.claude/`

### DIFF
--- a/justfile
+++ b/justfile
@@ -105,7 +105,7 @@ db_create name:
 
 # Find all the license files
 find_licenses:
-  find . -name "LICENSE.md" -not -path "*/node_modules/*"
+  find . -name "LICENSE.md" -not -path "*/node_modules/*" -not -path "*/.claude/*"
 
 # View HTML mockups
 mockups:

--- a/manual/src/licensing.md
+++ b/manual/src/licensing.md
@@ -5,7 +5,7 @@ The codebase is licensed under BSD 3-Clause. Some subdirectories have their own 
 To list all license files:
 
 ```bash
-find . -name "LICENSE.md" -not -path "*/node_modules/*"
+find . -name "LICENSE.md" -not -path "*/node_modules/*" -not -path "*/.claude/*"
 ```
 
 Or with the `justfile` script:


### PR DESCRIPTION
This keeps the script out of any `.claude/` dirs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated licensing guidance to exclude the `.claude` directory when locating license files.

* **Chores**
  * Improved license-file searches by excluding both `.claude` and `node_modules` paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->