### PR TITLE
Update licensing information in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,7 @@ The code is licensed under BSD 3-Clause license. Some of the subdirectories are 
 You can use this command to see their locations:
 
 ```bash
-find . -name "LICENSE.md" -not -path "*/node_modules/*"
-```
-
-or with `just`:
-
-```bash
+# see the `justfile` for the exact code that runs
 just find_licenses
 ```
 


### PR DESCRIPTION
Improved instructions for finding LICENSE.md and clarified licensing terms. That way we don't have to update the underlying script in multiple places.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s licensing instructions to direct readers to the `justfile` for the exact command used to locate license files.
  * Retained the explanation distinguishing BSD-licensed code from non-reusable rendered text and images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->