### PR TITLE
feat(digest): drop the footer timestamp from the Slack digest

### DIFF
--- a/apps/api/internal/digest/blocks.go
+++ b/apps/api/internal/digest/blocks.go
@@ -6,14 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
-
-	// tzdata embeds the IANA time-zone database into the binary. The production
-	// runtime is a CGO_ENABLED=0 distroless image with no system zoneinfo, so
-	// without this LoadLocation("America/Los_Angeles") would fail there (it
-	// succeeds on a dev machine with system zoneinfo). Importing it in this
-	// package keeps the digest — and its tests — self-contained.
-	_ "time/tzdata"
 
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
 )
@@ -22,20 +14,6 @@ import (
 // queued for the next one. Slack also limits a message to 50 blocks, and each
 // deal uses two (section + divider), so 25 keeps us well under that.
 const MaxDealsPerDigest = 25
-
-// pacific is the location for the digest footer timestamp. The deals are curated
-// for a California audience, so the footer reads Pacific time (PST/PDT) instead
-// of UTC. It is resolved once; if the tz database can't be read it falls back to
-// UTC, so a lookup failure degrades the label rather than breaking the digest.
-var pacific = loadPacific()
-
-func loadPacific() *time.Location {
-	loc, err := time.LoadLocation("America/Los_Angeles")
-	if err != nil {
-		return time.UTC
-	}
-	return loc
-}
 
 // Slack Block Kit payload types (only the subset we emit).
 type payload struct {
@@ -69,7 +47,8 @@ type contextBlock struct {
 // BuildBlocks renders the deals as a Slack incoming-webhook payload. At most
 // MaxDealsPerDigest deals are shown; if more are supplied, a context line notes
 // how many remain queued. The header count reflects the full set of new deals.
-func BuildBlocks(deals []store.Deal, now time.Time) ([]byte, error) {
+// No timestamp is rendered — Slack already stamps every message.
+func BuildBlocks(deals []store.Deal) ([]byte, error) {
 	shown := deals
 	overflow := 0
 	if len(shown) > MaxDealsPerDigest {
@@ -92,10 +71,6 @@ func BuildBlocks(deals []store.Deal, now time.Time) ([]byte, error) {
 			Elements: []textObject{{Type: "mrkdwn", Text: fmt.Sprintf("+ %d more — they'll stay queued for the next digest", overflow)}},
 		})
 	}
-	blocks = append(blocks, contextBlock{
-		Type:     "context",
-		Elements: []textObject{{Type: "mrkdwn", Text: "deal-digest · " + now.In(pacific).Format("2006-01-02 15:04 MST")}},
-	})
 
 	return json.MarshalIndent(payload{Blocks: blocks}, "", "  ")
 }

--- a/apps/api/internal/digest/blocks_test.go
+++ b/apps/api/internal/digest/blocks_test.go
@@ -54,12 +54,25 @@ func TestBuildBlocksGolden(t *testing.T) {
 func TestBuildBlocksNoTimestampFooter(t *testing.T) {
 	// Slack stamps every message itself, so the payload must not carry its own
 	// timestamp footer (removed with the Pacific-time machinery it needed).
+	// Without overflow, no context block of any kind belongs in the payload —
+	// asserting on block types rather than footer text catches a reworded
+	// footer too.
 	got, err := BuildBlocks([]store.Deal{{Title: "X"}})
 	if err != nil {
 		t.Fatalf("BuildBlocks: %v", err)
 	}
-	if strings.Contains(string(got), "deal-digest") {
-		t.Errorf("payload still contains the footer label:\n%s", got)
+	var p struct {
+		Blocks []struct {
+			Type string `json:"type"`
+		} `json:"blocks"`
+	}
+	if err := json.Unmarshal(got, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, b := range p.Blocks {
+		if b.Type == "context" {
+			t.Errorf("payload still contains a context footer:\n%s", got)
+		}
 	}
 }
 

--- a/apps/api/internal/digest/blocks_test.go
+++ b/apps/api/internal/digest/blocks_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
 )
@@ -16,7 +15,6 @@ import (
 var update = flag.Bool("update", false, "update golden files")
 
 func TestBuildBlocksGolden(t *testing.T) {
-	now := time.Date(2026, 7, 20, 14, 2, 0, 0, time.UTC)
 	deals := []store.Deal{
 		{
 			Title: "Humble Programming Bundle", URL: "https://humblebundle.com/books/prog",
@@ -30,7 +28,7 @@ func TestBuildBlocksGolden(t *testing.T) {
 		},
 	}
 
-	got, err := BuildBlocks(deals, now)
+	got, err := BuildBlocks(deals)
 	if err != nil {
 		t.Fatalf("BuildBlocks: %v", err)
 	}
@@ -53,32 +51,15 @@ func TestBuildBlocksGolden(t *testing.T) {
 	}
 }
 
-func TestBuildBlocksFooterPacific(t *testing.T) {
-	// The footer renders Pacific time, not UTC, and picks up the right DST label:
-	// a summer instant is PDT, a winter instant is PST. tzdata is embedded (see
-	// blocks.go) so this resolves the same on a dev machine and in the distroless
-	// runtime.
-	cases := []struct {
-		name string
-		now  time.Time
-		want string
-	}{
-		{"summer PDT", time.Date(2026, 7, 20, 14, 2, 0, 0, time.UTC), "deal-digest · 2026-07-20 07:02 PDT"},
-		{"winter PST", time.Date(2026, 1, 15, 8, 30, 0, 0, time.UTC), "deal-digest · 2026-01-15 00:30 PST"},
+func TestBuildBlocksNoTimestampFooter(t *testing.T) {
+	// Slack stamps every message itself, so the payload must not carry its own
+	// timestamp footer (removed with the Pacific-time machinery it needed).
+	got, err := BuildBlocks([]store.Deal{{Title: "X"}})
+	if err != nil {
+		t.Fatalf("BuildBlocks: %v", err)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := BuildBlocks([]store.Deal{{Title: "X"}}, tc.now)
-			if err != nil {
-				t.Fatalf("BuildBlocks: %v", err)
-			}
-			if !strings.Contains(string(got), tc.want) {
-				t.Errorf("footer missing %q in\n%s", tc.want, got)
-			}
-			if strings.Contains(string(got), " UTC") {
-				t.Errorf("footer still renders UTC:\n%s", got)
-			}
-		})
+	if strings.Contains(string(got), "deal-digest") {
+		t.Errorf("payload still contains the footer label:\n%s", got)
 	}
 }
 
@@ -87,7 +68,7 @@ func TestBuildBlocksOverflow(t *testing.T) {
 	for i := range deals {
 		deals[i] = store.Deal{Title: fmt.Sprintf("Deal %d", i)}
 	}
-	got, err := BuildBlocks(deals, time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC))
+	got, err := BuildBlocks(deals)
 	if err != nil {
 		t.Fatalf("BuildBlocks: %v", err)
 	}

--- a/apps/api/internal/digest/run.go
+++ b/apps/api/internal/digest/run.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, s *store.Store, poster WebhookPoster, interval, st
 		return false, nil
 	}
 
-	body, err := BuildBlocks(deals, s.Now())
+	body, err := BuildBlocks(deals)
 	if err != nil {
 		_ = s.DeleteDigest(ctx, digestID)
 		return false, fmt.Errorf("build blocks: %w", err)

--- a/apps/api/internal/digest/testdata/golden_blocks.json
+++ b/apps/api/internal/digest/testdata/golden_blocks.json
@@ -36,15 +36,6 @@
     },
     {
       "type": "divider"
-    },
-    {
-      "type": "context",
-      "elements": [
-        {
-          "type": "mrkdwn",
-          "text": "deal-digest · 2026-07-20 07:02 PDT"
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Removes the digest's footer context block ("deal-digest · 2026-07-26 09:15 PDT"). Slack already timestamps every message, localized to each reader, so the footer duplicated information the client shows anyway. The overflow context line ("+ N more — they'll stay queued for the next digest") is untouched.

Closes #376.

## How

- `BuildBlocks` no longer appends the footer block, and its `now time.Time` parameter (footer-only) is gone; the caller in `digest/run.go` updated.
- Everything that existed only for the footer went with it: the `pacific` location, `loadPacific()`, and the embedded `time/tzdata` import (it was needed so `LoadLocation` worked in the distroless image — nothing else in the package touches time zones now).
- This reverts the footer half of #292 (#289): that change made the footer readable; this one removes the need for it.

## Tests

- `TestBuildBlocksFooterPacific` replaced by `TestBuildBlocksNoTimestampFooter`, which asserts the payload carries no footer label.
- Golden file regenerated (`-update`) — the only diff is the removed footer block.
- Full `just test` (Go race + web + worker) green.

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the timestamp footer from Slack deal digest messages.
  * Digest messages continue to display deal details and overflow information.
  * Updated digest generation to work without a timestamp parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->