### PR TITLE
feat(ingest): resolve tracking redirects out of deal URLs

### DIFF
--- a/apps/api/internal/ingest/ingest.go
+++ b/apps/api/internal/ingest/ingest.go
@@ -1,11 +1,13 @@
 package ingest
 
 import (
+	"context"
 	"crypto/subtle"
 	"errors"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -20,6 +22,19 @@ import (
 // size.
 const defaultMaxIngestBytes = 25 * 1024 * 1024
 
+// resolveBudget bounds URL resolution for one email's whole batch of deals, so
+// a pathological email full of slow links cannot stall the ingest request.
+// Deals that miss the budget keep their extracted URLs.
+const resolveBudget = 15 * time.Second
+
+// URLResolver cleans one deal URL (following tracking redirects, stripping
+// tracking parameters). Implementations must return a usable URL — the input
+// unchanged on any failure — plus the failure for logging. See
+// internal/resolve.
+type URLResolver interface {
+	Resolve(ctx context.Context, rawURL string) (string, error)
+}
+
 // Handlers holds the email-ingest pipeline dependencies and exposes the Echo
 // handlers + middleware. Construct with New and mount with Register.
 type Handlers struct {
@@ -30,6 +45,10 @@ type Handlers struct {
 
 	// MaxIngestBytes bounds the /api/ingest body; overridable in tests.
 	MaxIngestBytes int64
+
+	// Resolver, when set, cleans each extracted deal URL before it is stored.
+	// nil skips resolution (tests, or a deliberately offline setup).
+	Resolver URLResolver
 }
 
 // New builds the ingest Handlers over an already-open store, an extractor, and a
@@ -125,6 +144,22 @@ func (h *Handlers) Ingest(c echo.Context) error {
 	if err != nil {
 		_ = h.store.SetEmailStatus(ctx, stored.ID, store.StatusExtractFailed, err.Error())
 		return echo.NewHTTPError(http.StatusInternalServerError, "extract deals")
+	}
+
+	// Resolve tracking-redirect URLs to their clean destinations before
+	// storing (see internal/resolve). Strictly best-effort under one shared
+	// budget: a failed or skipped resolution keeps the extracted URL, and a
+	// resolver problem never fails the ingest.
+	if h.Resolver != nil && len(deals) > 0 {
+		rctx, cancel := context.WithTimeout(ctx, resolveBudget)
+		for i := range deals {
+			resolved, rerr := h.Resolver.Resolve(rctx, deals[i].URL)
+			if rerr != nil {
+				c.Logger().Warnf("resolve deal url: %v", rerr)
+			}
+			deals[i].URL = resolved
+		}
+		cancel()
 	}
 
 	repostCutoff := h.store.Now().Add(-h.cfg.RepostAfter)

--- a/apps/api/internal/ingest/ingest_test.go
+++ b/apps/api/internal/ingest/ingest_test.go
@@ -67,6 +67,26 @@ func (f *fakePoster) count() int {
 	return f.n
 }
 
+// fakeResolver maps input URLs to resolved ones; unmapped inputs pass through
+// unchanged, and err (if set) is returned alongside — matching the URLResolver
+// contract of always handing back a usable URL.
+type fakeResolver struct {
+	mu    sync.Mutex
+	byURL map[string]string
+	err   error
+	calls int
+}
+
+func (f *fakeResolver) Resolve(_ context.Context, raw string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if r, ok := f.byURL[raw]; ok {
+		return r, f.err
+	}
+	return raw, f.err
+}
+
 type env struct {
 	e      *echo.Echo
 	h      *ingest.Handlers
@@ -179,6 +199,57 @@ func TestIngestHappyPath(t *testing.T) {
 	}
 	if got.Status != store.StatusExtracted {
 		t.Errorf("email status = %q, want extracted", got.Status)
+	}
+}
+
+func TestIngestResolvesDealURLs(t *testing.T) {
+	// The stored deal carries the resolver's cleaned URL, not the extracted one.
+	e := setup(t)
+	fr := &fakeResolver{byURL: map[string]string{
+		"https://h/a": "https://deals.example/a",
+	}}
+	e.h.Resolver = fr
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<r1@x>", "Deals", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+
+	ctx := context.Background()
+	a, err := e.st.GetDealByDedupeKey(ctx, store.DedupeKey("deals@humblebundle.com", "Bundle A"))
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey A: %v", err)
+	}
+	if a.URL != "https://deals.example/a" {
+		t.Errorf("deal A URL = %q, want the resolved URL", a.URL)
+	}
+	b, err := e.st.GetDealByDedupeKey(ctx, store.DedupeKey("deals@humblebundle.com", "Bundle B"))
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey B: %v", err)
+	}
+	if b.URL != "" {
+		t.Errorf("deal B URL = %q, want empty (no URL extracted)", b.URL)
+	}
+	if fr.calls != 2 {
+		t.Errorf("resolver calls = %d, want 2 (one per deal)", fr.calls)
+	}
+}
+
+func TestIngestResolverErrorKeepsURLAndSucceeds(t *testing.T) {
+	// A failing resolver must not fail the ingest or lose the extracted URL.
+	e := setup(t)
+	e.h.Resolver = &fakeResolver{err: errors.New("resolver down")}
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<r2@x>", "Deals", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+	a, err := e.st.GetDealByDedupeKey(context.Background(), store.DedupeKey("deals@humblebundle.com", "Bundle A"))
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey: %v", err)
+	}
+	if a.URL != "https://h/a" {
+		t.Errorf("deal A URL = %q, want the extracted URL kept", a.URL)
 	}
 }
 

--- a/apps/api/internal/resolve/resolve.go
+++ b/apps/api/internal/resolve/resolve.go
@@ -1,0 +1,189 @@
+// Package resolve turns newsletter deal links into clean canonical URLs. Many
+// newsletters wrap deal links in a click-tracking redirector, so the extracted
+// URL is the tracker, not the deal page; a quick fetch that follows the
+// redirect chain finds the real destination, and known tracking parameters
+// (utm_*, mcID, linkID, …) are stripped from it. Resolution is strictly
+// best-effort: on any failure the input URL is returned unchanged, so a
+// resolver outage can never lose or corrupt a deal.
+//
+// The URLs being fetched come from untrusted email content, so the resolver is
+// hardened against SSRF: only http(s) is fetched, and every connection —
+// including each redirect hop, after DNS resolution — refuses private,
+// loopback, link-local, and otherwise non-public addresses (the server runs
+// inside a Fly private network).
+package resolve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	// maxRedirects bounds the redirect chain. Real trackers use one or two
+	// hops; a longer chain is a loop or abuse.
+	maxRedirects = 5
+
+	// fetchTimeout bounds one Resolve call end to end (dial, TLS, redirects).
+	// Deals are resolved inline during ingest, so slow hosts must give up
+	// quickly and fall back to the extracted URL.
+	fetchTimeout = 4 * time.Second
+
+	// userAgent identifies the fetcher honestly; some hosts reject Go's
+	// default agent outright.
+	userAgent = "codeselfstudy-deals/1.0 (+https://codeselfstudy.com)"
+)
+
+var errTooManyRedirects = errors.New("too many redirects")
+
+// Resolver resolves deal URLs. Construct with New; the zero value is not
+// usable.
+type Resolver struct {
+	client *http.Client
+	// timeout is fetchTimeout in production; tests shorten it.
+	timeout time.Duration
+}
+
+// New returns a Resolver with the SSRF guard enabled.
+func New() *Resolver { return newResolver(false) }
+
+// newResolver optionally disables the non-public-address guard so tests can
+// fetch from httptest servers on loopback.
+func newResolver(allowPrivate bool) *Resolver {
+	dialer := &net.Dialer{Timeout: fetchTimeout}
+	if !allowPrivate {
+		// Control runs after DNS resolution with the literal address being
+		// dialed, so a tracker that redirects (or DNS-rebinds) to an internal
+		// address is refused at the socket, on every hop.
+		dialer.Control = rejectNonPublic
+	}
+	return &Resolver{
+		client: &http.Client{
+			Transport: &http.Transport{
+				DialContext: dialer.DialContext,
+				// One-shot fetches; don't hold idle connections to newsletter
+				// trackers.
+				DisableKeepAlives:   true,
+				TLSHandshakeTimeout: fetchTimeout,
+			},
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= maxRedirects {
+					return errTooManyRedirects
+				}
+				if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+					return fmt.Errorf("refusing redirect to scheme %q", req.URL.Scheme)
+				}
+				return nil
+			},
+		},
+		timeout: fetchTimeout,
+	}
+}
+
+// Resolve follows rawURL's redirect chain and returns the final URL with known
+// tracking parameters stripped. It always returns a usable URL: on any failure
+// (non-http(s) input, timeout, refused address, too many redirects) it returns
+// rawURL unchanged, with a non-nil error the caller may log. Tracking
+// parameters are stripped only after a successful fetch — on an unresolved
+// redirector the query often *is* the destination, so an unfetched URL is left
+// exactly as extracted.
+func (r *Resolver) Resolve(ctx context.Context, rawURL string) (string, error) {
+	if strings.TrimSpace(rawURL) == "" {
+		return rawURL, nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL, fmt.Errorf("parse %q: %w", rawURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		// Not fetchable; deliberate skip rather than a failure.
+		return rawURL, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return rawURL, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return rawURL, fmt.Errorf("fetch %q: %w", rawURL, err)
+	}
+	resp.Body.Close() // the final URL is all we need; the body is never read
+
+	// resp.Request is the last request of the chain, i.e. the destination —
+	// even when that page answers 404, its URL is still the canonical link.
+	final := *resp.Request.URL
+	final.RawQuery = stripTracking(final.RawQuery)
+	if u.Fragment != "" && final.Fragment == "" {
+		// Browsers carry the original fragment across redirects unless a
+		// Location header supplies its own; do the same.
+		final.Fragment = u.Fragment
+	}
+	return final.String(), nil
+}
+
+// stripTracking removes known tracking parameters from a raw query string. It
+// works on the raw string (split on "&") rather than url.Values so the
+// surviving parameters keep their original order and encoding.
+func stripTracking(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	pairs := strings.Split(rawQuery, "&")
+	kept := pairs[:0]
+	for _, p := range pairs {
+		key := p
+		if i := strings.IndexByte(p, '='); i >= 0 {
+			key = p[:i]
+		}
+		if !isTrackingParam(key) {
+			kept = append(kept, p)
+		}
+	}
+	return strings.Join(kept, "&")
+}
+
+// isTrackingParam reports whether a query key is a known tracking parameter.
+// Matching is case-insensitive (newsletters write mcID, mcid, …). The list is
+// deliberately conservative: an unknown parameter might be load-bearing, and
+// the digest's display-time strip removes leftovers from the Slack link anyway.
+func isTrackingParam(key string) bool {
+	k := strings.ToLower(key)
+	if strings.HasPrefix(k, "utm_") {
+		return true
+	}
+	switch k {
+	case "mcid", "linkid", "fbclid", "gclid", "msclkid", "mc_cid", "mc_eid", "igshid", "twclid":
+		return true
+	}
+	return false
+}
+
+// rejectNonPublic is a net.Dialer Control hook that refuses any address that
+// is not public global unicast: loopback, link-local (which covers cloud
+// metadata endpoints), multicast, unspecified, and RFC 1918 / ULA private
+// ranges (which cover Fly's 6PN fdaa::/16).
+func rejectNonPublic(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("resolve: refusing unparseable address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("resolve: refusing non-IP address %q", host)
+	}
+	if !ip.IsGlobalUnicast() || ip.IsPrivate() {
+		return fmt.Errorf("resolve: refusing non-public address %v", ip)
+	}
+	return nil
+}

--- a/apps/api/internal/resolve/resolve.go
+++ b/apps/api/internal/resolve/resolve.go
@@ -134,7 +134,9 @@ func (r *Resolver) Resolve(ctx context.Context, rawURL string) (string, error) {
 
 // stripTracking removes known tracking parameters from a raw query string. It
 // works on the raw string (split on "&") rather than url.Values so the
-// surviving parameters keep their original order and encoding.
+// surviving parameters keep their original order and encoding; only the key's
+// *classification* uses the decoded form, so a percent-encoded tracking key
+// (%75tm_source) can't sneak past the check.
 func stripTracking(rawQuery string) string {
 	if rawQuery == "" {
 		return ""
@@ -145,6 +147,9 @@ func stripTracking(rawQuery string) string {
 		key := p
 		if i := strings.IndexByte(p, '='); i >= 0 {
 			key = p[:i]
+		}
+		if dec, err := url.QueryUnescape(key); err == nil {
+			key = dec
 		}
 		if !isTrackingParam(key) {
 			kept = append(kept, p)
@@ -169,10 +174,15 @@ func isTrackingParam(key string) bool {
 	return false
 }
 
+// cgnat is the RFC 6598 carrier-grade-NAT shared range. It is non-public
+// space some clouds use internally, yet neither IsGlobalUnicast nor IsPrivate
+// covers it, so it needs its own deny.
+var cgnat = &net.IPNet{IP: net.IPv4(100, 64, 0, 0), Mask: net.CIDRMask(10, 32)}
+
 // rejectNonPublic is a net.Dialer Control hook that refuses any address that
 // is not public global unicast: loopback, link-local (which covers cloud
-// metadata endpoints), multicast, unspecified, and RFC 1918 / ULA private
-// ranges (which cover Fly's 6PN fdaa::/16).
+// metadata endpoints), multicast, unspecified, RFC 1918 / ULA private ranges
+// (which cover Fly's 6PN fdaa::/16), and the RFC 6598 CGNAT range.
 func rejectNonPublic(_, address string, _ syscall.RawConn) error {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
@@ -182,7 +192,7 @@ func rejectNonPublic(_, address string, _ syscall.RawConn) error {
 	if ip == nil {
 		return fmt.Errorf("resolve: refusing non-IP address %q", host)
 	}
-	if !ip.IsGlobalUnicast() || ip.IsPrivate() {
+	if !ip.IsGlobalUnicast() || ip.IsPrivate() || cgnat.Contains(ip) {
 		return fmt.Errorf("resolve: refusing non-public address %v", ip)
 	}
 	return nil

--- a/apps/api/internal/resolve/resolve_test.go
+++ b/apps/api/internal/resolve/resolve_test.go
@@ -201,6 +201,10 @@ func TestRejectNonPublic(t *testing.T) {
 		{"[fe80::1]:80", true},         // v6 link-local
 		{"0.0.0.0:80", true},           // unspecified
 		{"224.0.0.1:80", true},         // multicast
+		{"100.64.0.5:80", true},        // CGNAT low end (RFC 6598)
+		{"100.127.255.254:443", true},  // CGNAT high end
+		{"100.63.255.255:80", false},   // just below CGNAT — public
+		{"100.128.0.1:80", false},      // just above CGNAT — public
 		{"example.com:80", true},       // Control sees IPs only; a name here is wrong
 		{"93.184.216.34:443", false},   // public v4
 		{"[2606:2800:220:1:248:1893:25c8:1946]:443", false}, // public v6
@@ -222,6 +226,8 @@ func TestStripTracking(t *testing.T) {
 		{"valueless key", "utm_source&id=9", "id=9"},
 		{"unknown params kept verbatim", "linkID={$linkID}&q=a%20b", "q=a%20b"},
 		{"not a tracking prefix", "utmx=1", "utmx=1"},
+		{"percent-encoded tracking key stripped", "%75tm_source=x&id=9", "id=9"},
+		{"percent-encoded kept param stays encoded", "%69d=9", "%69d=9"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/api/internal/resolve/resolve_test.go
+++ b/apps/api/internal/resolve/resolve_test.go
@@ -1,0 +1,233 @@
+package resolve
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveFollowsRedirectsAndStrips(t *testing.T) {
+	// Tracker-style chain: /click → /hop → the deal page, whose final URL mixes
+	// tracking params with a real one. The real param must survive.
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/click", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/hop", http.StatusFound)
+	})
+	mux.HandleFunc("/hop", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/deal?id=9&utm_source=news&mcID=abc", http.StatusMovedPermanently)
+	})
+	mux.HandleFunc("/deal", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := newResolver(true)
+	got, err := r.Resolve(context.Background(), srv.URL+"/click?linkID=xyz")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := srv.URL + "/deal?id=9"; got != want {
+		t.Errorf("Resolve = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDirectURLStripsTracking(t *testing.T) {
+	// No redirect: the final URL is the input, minus tracking params, with the
+	// fragment kept.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := newResolver(true)
+	got, err := r.Resolve(context.Background(), srv.URL+"/deal?utm_source=x&id=9&fbclid=f#offer")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := srv.URL + "/deal?id=9#offer"; got != want {
+		t.Errorf("Resolve = %q, want %q", got, want)
+	}
+}
+
+func TestResolveOnlyTrackingParamsDropsQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := newResolver(true)
+	got, err := r.Resolve(context.Background(), srv.URL+"/deal?utm_source=x&utm_medium=email")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := srv.URL + "/deal"; got != want {
+		t.Errorf("Resolve = %q, want %q (query should be gone entirely)", got, want)
+	}
+}
+
+func TestResolveFinalErrorStatusStillResolves(t *testing.T) {
+	// A 404 at the destination is still a successful resolution — the chain
+	// ended there, and that URL is the canonical link.
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/click", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/gone?utm_source=x", http.StatusFound)
+	})
+	mux.HandleFunc("/gone", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	r := newResolver(true)
+	got, err := r.Resolve(context.Background(), srv.URL+"/click")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := srv.URL + "/gone"; got != want {
+		t.Errorf("Resolve = %q, want %q", got, want)
+	}
+}
+
+func TestResolveFetchFailureKeepsOriginal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	srv.Close() // dead server: connection refused
+
+	orig := srv.URL + "/deal?utm_source=x"
+	r := newResolver(true)
+	got, err := r.Resolve(context.Background(), orig)
+	if err == nil {
+		t.Fatal("expected an error from a dead server")
+	}
+	if got != orig {
+		t.Errorf("Resolve = %q, want the original %q (params must NOT be stripped without a fetch)", got, orig)
+	}
+}
+
+func TestResolveTimeoutKeepsOriginal(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+	}))
+	defer func() { close(release); srv.Close() }()
+
+	r := newResolver(true)
+	r.timeout = 50 * time.Millisecond
+	orig := srv.URL + "/slow"
+	got, err := r.Resolve(context.Background(), orig)
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if got != orig {
+		t.Errorf("Resolve = %q, want original %q", got, orig)
+	}
+}
+
+func TestResolveTooManyRedirectsKeepsOriginal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.Path+"x", http.StatusFound) // endless chain
+	}))
+	defer srv.Close()
+
+	r := newResolver(true)
+	orig := srv.URL + "/r"
+	got, err := r.Resolve(context.Background(), orig)
+	if err == nil || !strings.Contains(err.Error(), "too many redirects") {
+		t.Fatalf("err = %v, want too-many-redirects", err)
+	}
+	if got != orig {
+		t.Errorf("Resolve = %q, want original %q", got, orig)
+	}
+}
+
+func TestResolveSkipsNonHTTPInput(t *testing.T) {
+	r := newResolver(true)
+	for _, in := range []string{"", "mailto:a@b.example", "ftp://x.example/f", "/relative/path"} {
+		got, err := r.Resolve(context.Background(), in)
+		if err != nil {
+			t.Errorf("Resolve(%q) err = %v, want nil (deliberate skip)", in, err)
+		}
+		if got != in {
+			t.Errorf("Resolve(%q) = %q, want unchanged", in, got)
+		}
+	}
+}
+
+func TestResolveUnparseableInputKeptWithError(t *testing.T) {
+	r := newResolver(true)
+	in := "http://x.example/%zz"
+	got, err := r.Resolve(context.Background(), in)
+	if err == nil {
+		t.Fatal("expected a parse error")
+	}
+	if got != in {
+		t.Errorf("Resolve = %q, want unchanged input", got)
+	}
+}
+
+func TestResolverGuardBlocksLoopback(t *testing.T) {
+	// The production constructor must refuse loopback at the dial layer — this
+	// proves the guard is actually wired into the transport.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := New()
+	orig := srv.URL + "/deal"
+	got, err := r.Resolve(context.Background(), orig)
+	if err == nil {
+		t.Fatal("expected the SSRF guard to refuse a loopback address")
+	}
+	if got != orig {
+		t.Errorf("Resolve = %q, want original %q", got, orig)
+	}
+}
+
+func TestRejectNonPublic(t *testing.T) {
+	cases := []struct {
+		address string
+		wantErr bool
+	}{
+		{"10.0.0.8:80", true},          // RFC 1918
+		{"192.168.1.1:443", true},      // RFC 1918
+		{"127.0.0.1:80", true},         // loopback
+		{"169.254.169.254:80", true},   // link-local (cloud metadata)
+		{"[::1]:443", true},            // v6 loopback
+		{"[fdaa::3]:80", true},         // ULA — Fly 6PN
+		{"[fe80::1]:80", true},         // v6 link-local
+		{"0.0.0.0:80", true},           // unspecified
+		{"224.0.0.1:80", true},         // multicast
+		{"example.com:80", true},       // Control sees IPs only; a name here is wrong
+		{"93.184.216.34:443", false},   // public v4
+		{"[2606:2800:220:1:248:1893:25c8:1946]:443", false}, // public v6
+	}
+	for _, tc := range cases {
+		err := rejectNonPublic("tcp", tc.address, nil)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("rejectNonPublic(%q) err = %v, wantErr %v", tc.address, err, tc.wantErr)
+		}
+	}
+}
+
+func TestStripTracking(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"empty", "", ""},
+		{"mixed order preserved", "b=2&utm_source=x&a=1", "b=2&a=1"},
+		{"case-insensitive mcID", "mcID=102:abc&x=1", "x=1"},
+		{"utm prefix any suffix", "utm_whatever=1&utm_campaign=c", ""},
+		{"valueless key", "utm_source&id=9", "id=9"},
+		{"unknown params kept verbatim", "linkID={$linkID}&q=a%20b", "q=a%20b"},
+		{"not a tracking prefix", "utmx=1", "utmx=1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripTracking(tc.in); got != tc.want {
+				t.Errorf("stripTracking(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/digest"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/extract"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/ingest"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/resolve"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/session"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/users"
@@ -195,7 +196,11 @@ func newIngestFromEnv(ctx context.Context, database *sql.DB) *ingest.Handlers {
 	}
 
 	poster := digest.NewHTTPPoster(cfg.SlackWebhookURL)
-	return ingest.New(cfg, store.New(database), extractor, poster)
+	h := ingest.New(cfg, store.New(database), extractor, poster)
+	// Clean tracking redirects out of deal URLs before they are stored
+	// (best-effort; see internal/resolve).
+	h.Resolver = resolve.New()
+	return h
 }
 
 // newUsersFromEnv builds the account handlers over the shared database and, when

--- a/manual/src/architecture.md
+++ b/manual/src/architecture.md
@@ -24,6 +24,7 @@ codeselfstudy/
 │   │   ├── internal/store/     emails/deals/digests persistence
 │   │   ├── internal/mailparse/ internal/htmltext/  MIME → normalized text
 │   │   ├── internal/extract/   Gemini deal extraction
+│   │   ├── internal/resolve/   deal-URL cleanup (tracking redirects → canonical)
 │   │   ├── internal/digest/    Slack Block Kit digest + HTTP poster
 │   │   └── static/             populated at build time from web's dist/
 │   └── email_receiver/         Cloudflare Worker (TS): email → /api/ingest
@@ -65,7 +66,7 @@ The Go-side auth is opt-in: sign-in needs all five WorkOS variables (`WORKOS_CLI
 An opt-in pipeline turns forwarded "deals" newsletters into a Slack digest:
 
 1. `apps/email_receiver` is a Cloudflare Worker wired to Cloudflare Email Routing. On each message it POSTs the raw RFC822 bytes to the Go server's `POST /api/ingest` (bearer `INGEST_TOKEN`, `Content-Type: message/rfc822`). There is no archive mailbox: an oversize message is rejected with `setReject()`, and a persistent POST failure propagates so Cloudflare fails the delivery and the sender's MTA retries.
-2. `internal/ingest` reads the body (≤25 MB), parses the MIME (`internal/mailparse` + `internal/htmltext`), stores the email (`internal/store`, idempotent on message-id), extracts deals with the Gemini API (`internal/extract`), upserts them (dedup by sender registrable-domain + normalized title), and — best effort — posts a Block Kit digest to Slack (`internal/digest`) at most once per `DIGEST_INTERVAL`. `POST /api/admin/digest` forces one (see [Forcing a Slack digest](./deployment.md#forcing-a-slack-digest)).
+2. `internal/ingest` reads the body (≤25 MB), parses the MIME (`internal/mailparse` + `internal/htmltext`), stores the email (`internal/store`, idempotent on message-id), extracts deals with the Gemini API (`internal/extract`), resolves each deal URL to its clean destination (`internal/resolve` follows tracking redirects and strips tracking params, best-effort with an SSRF guard; a failure keeps the extracted URL), upserts them (dedup by sender registrable-domain + normalized title), and — best effort — posts a Block Kit digest to Slack (`internal/digest`) at most once per `DIGEST_INTERVAL`. `POST /api/admin/digest` forces one (see [Forcing a Slack digest](./deployment.md#forcing-a-slack-digest)).
 3. Mail from an address in `APPROVED_FORWARDING_EMAILS` (comma-separated) skips that wait: its digest posts immediately, flushing every queued deal. A sender matches on either the `From:` header or the Worker's `X-Envelope-From` header, so both a hand-composed forward and an auto-forward rule work. Forcing skips only the interval check — the stale-claim guard still holds, so it stays race-safe. The ingest response carries `"forced":true` when the allowlist matched.
 4. The pipeline is enabled only when `DATABASE_URL` and `INGEST_TOKEN` are set; otherwise the server runs static-only. Extraction needs `GEMINI_API_KEY` (empty ⇒ `/api/ingest` returns 500). The Slack webhook is `SLACK_WEBHOOK_FOR_DEALS_CHANNEL`.
 

--- a/manual/src/project-structure.md
+++ b/manual/src/project-structure.md
@@ -33,6 +33,7 @@ Inside `apps/api/`:
 - `internal/store/`: emails/deals/digests persistence and the once-per-interval digest claim.
 - `internal/mailparse/`, `internal/htmltext/`: raw MIME → normalized text.
 - `internal/extract/`: Gemini deal extraction.
+- `internal/resolve/`: deal-URL cleanup — follows tracking redirects to the canonical page and strips tracking parameters (SSRF-guarded, best-effort).
 - `internal/digest/`: Slack Block Kit rendering + HTTP poster.
 - `static/`: populated at build time from `apps/web/dist/`. Gitignored.
 


### PR DESCRIPTION
## What

Newsletter deal links often point at a click-tracking redirector, so the stored deal URL was the tracker, not the deal page — and the digest's display-time query strip can't fix that (the destination *is* the query). This PR resolves each extracted deal URL at ingest: a quick `GET` follows the redirect chain to the final destination, known tracking parameters (`utm_*`, `mcID`, `linkID`, `fbclid`, `gclid`, …) are stripped from that final URL, and the cleaned URL is what gets stored on the deal.

Nothing is lost by overwriting: the original link survives in `emails.body_text` (`internal/htmltext` renders anchors as `text (href)`), reachable via `deals.email_id`.

Closes #375.

## How

- New `internal/resolve` package: `Resolver.Resolve(ctx, url)` returns the cleaned final URL, or the input unchanged plus an error the caller logs. Bounded at 5 redirect hops and a 4s per-URL timeout; the body is never read.
- Tracking params are stripped **only after a successful fetch** — on an unresolved redirector the query often holds the destination, so a failed fetch keeps the URL exactly as extracted. Stripping works on the raw query string so surviving params keep their order and encoding; matching is case-insensitive with a deliberately conservative list.
- **SSRF:** these URLs come from untrusted email content and the server sits inside Fly's private network. The fetcher allows only http(s) (checked per redirect hop) and uses a `net.Dialer.Control` hook that runs after DNS resolution on every hop, refusing anything that isn't public global unicast — loopback, link-local (cloud metadata), multicast, unspecified, RFC 1918, and ULA (covers Fly 6PN `fdaa::/16`). DNS-rebinding gets the same treatment because the check sees the literal IP being dialed.
- `ingest.Handlers` gains an optional `Resolver URLResolver` field (nil skips resolution); `main.go` wires `resolve.New()`. The whole batch of one email's deals shares a 15s budget so a pathological email can't stall `/api/ingest`; resolver errors are logged and never fail the request.
- Digest path untouched; no migration; dedupe unaffected (`DedupeKey` is from+title). The display-time `stripQueryParams` stays as belt and suspenders.

## Tests

- `internal/resolve`: redirect chain → final URL with real param kept and tracking params gone; direct URL stripped with fragment preserved; all-tracking query drops the `?`; 404 destination still resolves; dead server / timeout / redirect loop all keep the original URL and surface an error; non-http(s) inputs skipped unchanged; `New()` (guard on) refuses a loopback httptest server, proving the guard is wired into the transport; `rejectNonPublic` table covers RFC 1918, loopback, link-local, metadata IP, ULA/Fly 6PN, multicast, unspecified, and public v4/v6; `stripTracking` table (case-insensitivity, `utm_` prefix, valueless keys, unknown params kept verbatim).
- `internal/ingest`: a fake resolver's URL is what lands in the store (and a deal without a URL stays empty); a failing resolver keeps the extracted URL and the ingest still returns 200.
- Full `just test` (Go race + web + worker) green.

## Docs

`manual/src/architecture.md` (pipeline step + package tree) and `manual/src/project-structure.md` list `internal/resolve`.

Related: #374 will fetch the same resolved page to find an expiration date.

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deal URLs are now cleaned by following redirects and removing common tracking parameters.
  * Resolution includes protections against unsafe or non-public destinations.
  * If URL cleanup fails, ingestion continues and preserves the original URL.

* **Documentation**
  * Updated architecture and project structure documentation to describe URL cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->