### PR TITLE
Guard deal deadlines against hallucinated years

### DIFF
--- a/apps/api/internal/digest/blocks.go
+++ b/apps/api/internal/digest/blocks.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/expiry"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
 )
 
@@ -47,8 +49,11 @@ type contextBlock struct {
 // BuildBlocks renders the deals as a Slack incoming-webhook payload. At most
 // MaxDealsPerDigest deals are shown; if more are supplied, a context line notes
 // how many remain queued. The header count reflects the full set of new deals.
-// No timestamp is rendered — Slack already stamps every message.
-func BuildBlocks(deals []store.Deal) ([]byte, error) {
+// No timestamp is rendered — Slack already stamps every message. now is the
+// posting time: a stored deadline already before it is suppressed from the
+// meta line (the deal itself still posts — a past date is more often a wrong
+// date than a dead deal).
+func BuildBlocks(deals []store.Deal, now time.Time) ([]byte, error) {
 	shown := deals
 	overflow := 0
 	if len(shown) > MaxDealsPerDigest {
@@ -61,7 +66,7 @@ func BuildBlocks(deals []store.Deal) ([]byte, error) {
 	}
 	for _, d := range shown {
 		blocks = append(blocks,
-			sectionBlock{Type: "section", Text: textObject{Type: "mrkdwn", Text: dealText(d)}},
+			sectionBlock{Type: "section", Text: textObject{Type: "mrkdwn", Text: dealText(d, now)}},
 			dividerBlock{Type: "divider"},
 		)
 	}
@@ -84,8 +89,8 @@ func headerText(n int) string {
 
 // dealText renders one deal as Slack mrkdwn: a bold linked title, a middot-joined
 // meta line (price · ends <date> · source), and an italic description. Empty
-// fields are omitted.
-func dealText(d store.Deal) string {
+// fields are omitted, as is a deadline already before now (see BuildBlocks).
+func dealText(d store.Deal, now time.Time) string {
 	var lines []string
 
 	title := escapeMrkdwn(d.Title)
@@ -99,7 +104,7 @@ func dealText(d store.Deal) string {
 	if d.Price != "" {
 		meta = append(meta, escapeMrkdwn(d.Price))
 	}
-	if d.EndsAt != "" {
+	if d.EndsAt != "" && expiry.OnOrAfter(d.EndsAt, now) {
 		meta = append(meta, "ends "+escapeMrkdwn(d.EndsAt))
 	}
 	if d.Source != "" {

--- a/apps/api/internal/digest/blocks_test.go
+++ b/apps/api/internal/digest/blocks_test.go
@@ -8,11 +8,16 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
 )
 
 var update = flag.Bool("update", false, "update golden files")
+
+// testNow is a fixed posting time so deadline suppression is deterministic; it
+// sits before every EndsAt used in the fixtures below.
+var testNow = time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 
 func TestBuildBlocksGolden(t *testing.T) {
 	deals := []store.Deal{
@@ -28,7 +33,7 @@ func TestBuildBlocksGolden(t *testing.T) {
 		},
 	}
 
-	got, err := BuildBlocks(deals)
+	got, err := BuildBlocks(deals, testNow)
 	if err != nil {
 		t.Fatalf("BuildBlocks: %v", err)
 	}
@@ -57,7 +62,7 @@ func TestBuildBlocksNoTimestampFooter(t *testing.T) {
 	// Without overflow, no context block of any kind belongs in the payload —
 	// asserting on block types rather than footer text catches a reworded
 	// footer too.
-	got, err := BuildBlocks([]store.Deal{{Title: "X"}})
+	got, err := BuildBlocks([]store.Deal{{Title: "X"}}, testNow)
 	if err != nil {
 		t.Fatalf("BuildBlocks: %v", err)
 	}
@@ -81,7 +86,7 @@ func TestBuildBlocksOverflow(t *testing.T) {
 	for i := range deals {
 		deals[i] = store.Deal{Title: fmt.Sprintf("Deal %d", i)}
 	}
-	got, err := BuildBlocks(deals)
+	got, err := BuildBlocks(deals, testNow)
 	if err != nil {
 		t.Fatalf("BuildBlocks: %v", err)
 	}
@@ -125,16 +130,39 @@ func TestEscapeMrkdwn(t *testing.T) {
 }
 
 func TestDealTextOmitsEmptyFields(t *testing.T) {
-	got := dealText(store.Deal{Title: "Bare"})
+	got := dealText(store.Deal{Title: "Bare"}, testNow)
 	if got != "*Bare*" {
 		t.Errorf("dealText(bare) = %q, want *Bare*", got)
+	}
+}
+
+func TestDealTextDeadlineGuard(t *testing.T) {
+	// A stored deadline already in the past (usually a hallucinated year) must
+	// not render; a current, future, or free-form one must.
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name, endsAt string
+		want         bool // "ends …" rendered?
+	}{
+		{"past hidden", "2025-11-27", false},
+		{"today shown", "2026-07-26", true},
+		{"future shown", "2026-11-27", true},
+		{"free-form shown", "while supplies last", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dealText(store.Deal{Title: "T", EndsAt: tc.endsAt}, now)
+			if rendered := strings.Contains(got, "ends "+tc.endsAt); rendered != tc.want {
+				t.Errorf("dealText with ends_at %q rendered=%v, want %v (text %q)", tc.endsAt, rendered, tc.want, got)
+			}
+		})
 	}
 }
 
 func TestDealTextEscapesURLDelimiters(t *testing.T) {
 	// Any |, <, > that survives param-stripping (e.g. in the path) must not break
 	// Slack's <url|text> syntax.
-	got := dealText(store.Deal{Title: "T", URL: "https://x.example/d|e<f>"})
+	got := dealText(store.Deal{Title: "T", URL: "https://x.example/d|e<f>"}, testNow)
 	if strings.Contains(got, "|e") || strings.Contains(got, "<f>") {
 		t.Errorf("URL delimiters not escaped: %q", got)
 	}
@@ -146,7 +174,7 @@ func TestDealTextEscapesURLDelimiters(t *testing.T) {
 
 func TestDealTextStripsQueryParams(t *testing.T) {
 	// The tracking query attached by newsletters must be gone from the Slack link.
-	got := dealText(store.Deal{Title: "T", URL: "https://x.example/deal?utm_source=news&id=9"})
+	got := dealText(store.Deal{Title: "T", URL: "https://x.example/deal?utm_source=news&id=9"}, testNow)
 	want := "*<https://x.example/deal|T>*"
 	if got != want {
 		t.Errorf("dealText = %q, want %q", got, want)

--- a/apps/api/internal/digest/run.go
+++ b/apps/api/internal/digest/run.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, s *store.Store, poster WebhookPoster, interval, st
 		return false, nil
 	}
 
-	body, err := BuildBlocks(deals)
+	body, err := BuildBlocks(deals, s.Now())
 	if err != nil {
 		_ = s.DeleteDigest(ctx, digestID)
 		return false, fmt.Errorf("build blocks: %w", err)

--- a/apps/api/internal/expiry/expiry.go
+++ b/apps/api/internal/expiry/expiry.go
@@ -3,7 +3,9 @@
 // structured data — schema.org offers embed it as priceValidUntil (or
 // availabilityEnds) in JSON-LD, and some pages use itemprop microdata instead.
 // Extraction is best-effort and purely local: malformed HTML, broken JSON, or
-// an unparseable date all yield "", never an error.
+// an unparseable date all yield "", never an error. The package also owns the
+// deadline plausibility check (OnOrAfter) that ingest and the digest use to
+// catch confidently-wrong extracted dates.
 package expiry
 
 import (
@@ -111,16 +113,43 @@ var dateLayouts = []string{
 // timestamp; the timestamp's own calendar day is kept, without time-zone
 // conversion — close enough for a deal deadline.
 func normalizeDate(s string) string {
+	t, ok := parseDate(s)
+	if !ok {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}
+
+// parseDate tries the dateLayouts in order on a trimmed candidate.
+func parseDate(s string) (time.Time, bool) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return ""
+		return time.Time{}, false
 	}
 	for _, layout := range dateLayouts {
 		if t, err := time.Parse(layout, s); err == nil {
-			return t.Format("2006-01-02")
+			return t, true
 		}
 	}
-	return ""
+	return time.Time{}, false
+}
+
+// OnOrAfter reports whether s names a calendar day on or after ref's. It is the
+// guard against LLM-hallucinated deadlines (an extractor that guesses a year
+// puts the deadline in the past): only a value that parses and falls strictly
+// before ref's own day returns false. Empty or unparseable strings return true —
+// they carry nothing confidently wrong to reject. Days are compared without
+// time-zone conversion, matching normalizeDate's stance.
+func OnOrAfter(s string, ref time.Time) bool {
+	t, ok := parseDate(s)
+	if !ok {
+		return true
+	}
+	ty, tm, td := t.Date()
+	ry, rm, rd := ref.Date()
+	day := time.Date(ty, tm, td, 0, 0, 0, 0, time.UTC)
+	refDay := time.Date(ry, rm, rd, 0, 0, 0, 0, time.UTC)
+	return !day.Before(refDay)
 }
 
 func attr(n *html.Node, name string) string {

--- a/apps/api/internal/expiry/expiry_test.go
+++ b/apps/api/internal/expiry/expiry_test.go
@@ -1,6 +1,9 @@
 package expiry
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func page(inner string) []byte {
 	return []byte("<!doctype html><html><head>" + inner + "</head><body><p>deal</p></body></html>")
@@ -87,5 +90,28 @@ func TestNormalizeDate(t *testing.T) {
 		if got := normalizeDate(tc.in); got != tc.want {
 			t.Errorf("normalizeDate(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestOnOrAfter(t *testing.T) {
+	ref := time.Date(2026, 7, 26, 15, 30, 0, 0, time.UTC)
+	cases := []struct {
+		name, in string
+		want     bool
+	}{
+		{"past day", "2025-11-27", false},
+		{"day before", "2026-07-25", false},
+		{"same day", "2026-07-26", true},
+		{"same day despite earlier timestamp", "2026-07-26T01:00:00Z", true},
+		{"future day", "2026-11-27", true},
+		{"unparseable is not rejected", "while supplies last", true},
+		{"empty is not rejected", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := OnOrAfter(tc.in, ref); got != tc.want {
+				t.Errorf("OnOrAfter(%q, %s) = %v, want %v", tc.in, ref, got, tc.want)
+			}
+		})
 	}
 }

--- a/apps/api/internal/extract/gemini.go
+++ b/apps/api/internal/extract/gemini.go
@@ -25,6 +25,8 @@ Include an offer only when it is about software or software development. Exclude
 For a bundle that mixes software titles with unrelated ones, include it only if it is primarily about software.
 Return one entry per bundle or offer — never one entry per item inside a bundle.
 Set url to the link printed next to that offer if one is present.
+The prompt's Date line is the day the email was sent. When a deadline omits the year, resolve it against that date so the deadline is on or after it: "ends November 27" in an email dated 2026-07-26 means 2026-11-27.
+Copy prices, promo codes, and deadlines only from the email's own text; never invent, infer, or embellish them. Leave a field null when the email does not state it.
 If the email has no software deals (receipts, shipping notices, account or security alerts, plain content newsletters, or only non-software offers), return an empty array.
 Respond only with the JSON array described by the schema.`
 
@@ -79,7 +81,7 @@ func dealGenConfig() *genai.GenerateContentConfig {
 					"title":       {Type: genai.TypeString},
 					"url":         {Type: genai.TypeString, Nullable: genai.Ptr(true)},
 					"price":       {Type: genai.TypeString, Nullable: genai.Ptr(true), Description: `free-form, e.g. "$25 (96% off)", "pay what you want"`},
-					"ends_at":     {Type: genai.TypeString, Nullable: genai.Ptr(true), Description: "ISO 8601 date if stated"},
+					"ends_at":     {Type: genai.TypeString, Nullable: genai.Ptr(true), Description: "ISO 8601 date if stated; a missing year resolves against the Date line, never before it"},
 					"description": {Type: genai.TypeString, Nullable: genai.Ptr(true), Description: "one short sentence"},
 				},
 				Required: []string{"source", "title"},
@@ -118,7 +120,14 @@ func buildUserPrompt(e mailparse.Email) string {
 	if r := []rune(body); len(r) > maxPromptChars {
 		body = string(r[:maxPromptChars])
 	}
-	return fmt.Sprintf("From: %s\nSubject: %s\n\n%s", e.From, e.Subject, body)
+	// The Date line anchors yearless deadlines (see systemInstruction). Kept in
+	// the sender's own zone: that is the calendar the deadline was written
+	// against.
+	date := ""
+	if e.SentAt != nil {
+		date = fmt.Sprintf("Date: %s\n", e.SentAt.Format("2006-01-02"))
+	}
+	return fmt.Sprintf("%sFrom: %s\nSubject: %s\n\n%s", date, e.From, e.Subject, body)
 }
 
 func parseDeals(text string) ([]Deal, error) {

--- a/apps/api/internal/extract/gemini_test.go
+++ b/apps/api/internal/extract/gemini_test.go
@@ -196,6 +196,22 @@ func TestParseDeals(t *testing.T) {
 	}
 }
 
+func TestBuildUserPromptDateLine(t *testing.T) {
+	sent := time.Date(2026, 7, 26, 15, 29, 0, 0, time.UTC)
+	e := mailparse.Email{From: "a@b.com", Subject: "S", Text: "body", SentAt: &sent}
+	got := buildUserPrompt(e)
+	if !strings.HasPrefix(got, "Date: 2026-07-26\n") {
+		t.Errorf("prompt missing Date line:\n%s", got)
+	}
+
+	// Without a parseable Date header there is no line to anchor on — the
+	// prompt must simply omit it rather than invent one.
+	e.SentAt = nil
+	if got := buildUserPrompt(e); strings.Contains(got, "Date:") {
+		t.Errorf("prompt has a Date line without SentAt:\n%s", got)
+	}
+}
+
 func TestBuildUserPromptTruncates(t *testing.T) {
 	long := make([]rune, maxPromptChars+5000)
 	for i := range long {

--- a/apps/api/internal/ingest/ingest.go
+++ b/apps/api/internal/ingest/ingest.go
@@ -208,7 +208,17 @@ func (h *Handlers) Ingest(c echo.Context) error {
 			}
 			d.URL = resolved
 			if len(page) > 0 {
-				d.EndsAt = expiry.FromHTML(page)
+				// The page's structured data gets the same skepticism as the
+				// extractor: shop pages routinely carry a stale
+				// priceValidUntil from an earlier promotion, and a past date
+				// is useless to store (the digest would hide it anyway).
+				// Leaving it empty also keeps ClearEndsAt effective, so a
+				// previously stored bad deadline still gets erased.
+				if candidate := expiry.FromHTML(page); candidate == "" || expiry.OnOrAfter(candidate, ref) {
+					d.EndsAt = candidate
+				} else {
+					c.Logger().Warnf("dropping implausible page deadline %q (email date %s)", candidate, ref.Format("2006-01-02"))
+				}
 			}
 		}
 		cancel()

--- a/apps/api/internal/ingest/ingest.go
+++ b/apps/api/internal/ingest/ingest.go
@@ -162,31 +162,38 @@ func (h *Handlers) Ingest(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "extract deals")
 	}
 
-	// Resolve tracking-redirect URLs to their clean destinations before
-	// storing (see internal/resolve). When the email stated no deadline, the
-	// same fetch also brings back the deal page so its structured data can
-	// fill ends_at (see internal/expiry) — an email-stated deadline is never
-	// overwritten. Strictly best-effort under one shared budget: a failed or
-	// skipped step keeps the extracted values, and a resolver problem never
-	// fails the ingest.
-	if h.Resolver != nil && len(deals) > 0 {
-		// Reference day for the deadline sanity check below: the email's own
-		// send date (the extractor interprets deadlines relative to it),
-		// falling back to the clock for emails without a parseable Date.
-		ref := h.store.Now()
-		if email.SentAt != nil {
-			ref = *email.SentAt
+	// An extracted deadline already past on the email's own send date (the
+	// extractor interprets deadlines relative to it; fall back to the clock
+	// for emails without a parseable Date) is almost always a hallucinated
+	// year, not a real deadline. Drop it before resolution — even with no
+	// resolver wired an impossible date must not be stored — and remember the
+	// drop so the upsert below can erase a previously stored copy of the same
+	// bad date instead of coalescing it back.
+	ref := h.store.Now()
+	if email.SentAt != nil {
+		ref = *email.SentAt
+	}
+	cleared := make([]bool, len(deals))
+	for i := range deals {
+		d := &deals[i]
+		if d.EndsAt != "" && !expiry.OnOrAfter(d.EndsAt, ref) {
+			c.Logger().Warnf("dropping implausible deal deadline %q (email date %s)", d.EndsAt, ref.Format("2006-01-02"))
+			d.EndsAt = ""
+			cleared[i] = true
 		}
+	}
+
+	// Resolve tracking-redirect URLs to their clean destinations before
+	// storing (see internal/resolve). When the email stated no usable
+	// deadline, the same fetch also brings back the deal page so its
+	// structured data can fill ends_at (see internal/expiry) — an email-stated
+	// deadline is never overwritten. Strictly best-effort under one shared
+	// budget: a failed or skipped step keeps the extracted values, and a
+	// resolver problem never fails the ingest.
+	if h.Resolver != nil && len(deals) > 0 {
 		rctx, cancel := context.WithTimeout(ctx, resolveBudget(len(deals)))
 		for i := range deals {
 			d := &deals[i]
-			if d.EndsAt != "" && !expiry.OnOrAfter(d.EndsAt, ref) {
-				// A deadline already past when the email was sent is almost
-				// always a hallucinated year, not a real deadline. Drop it so
-				// the page fetch below can supply the real one.
-				c.Logger().Warnf("dropping implausible deal deadline %q (email date %s)", d.EndsAt, ref.Format("2006-01-02"))
-				d.EndsAt = ""
-			}
 			if d.EndsAt != "" {
 				resolved, rerr := h.Resolver.Resolve(rctx, d.URL)
 				if rerr != nil {
@@ -208,7 +215,7 @@ func (h *Handlers) Ingest(c echo.Context) error {
 	}
 
 	repostCutoff := h.store.Now().Add(-h.cfg.RepostAfter)
-	for _, d := range deals {
+	for i, d := range deals {
 		if err := h.store.UpsertDeal(ctx, store.Deal{
 			EmailID:     stored.ID,
 			DedupeKey:   store.DedupeKey(email.From, d.Title),
@@ -218,6 +225,9 @@ func (h *Handlers) Ingest(c echo.Context) error {
 			Price:       d.Price,
 			EndsAt:      d.EndsAt,
 			Description: d.Description,
+			// A rejected deadline that nothing refilled must overwrite a
+			// stored one — the stored copy is the same hallucination.
+			ClearEndsAt: cleared[i] && d.EndsAt == "",
 		}, repostCutoff); err != nil {
 			return err
 		}

--- a/apps/api/internal/ingest/ingest.go
+++ b/apps/api/internal/ingest/ingest.go
@@ -170,9 +170,23 @@ func (h *Handlers) Ingest(c echo.Context) error {
 	// skipped step keeps the extracted values, and a resolver problem never
 	// fails the ingest.
 	if h.Resolver != nil && len(deals) > 0 {
+		// Reference day for the deadline sanity check below: the email's own
+		// send date (the extractor interprets deadlines relative to it),
+		// falling back to the clock for emails without a parseable Date.
+		ref := h.store.Now()
+		if email.SentAt != nil {
+			ref = *email.SentAt
+		}
 		rctx, cancel := context.WithTimeout(ctx, resolveBudget(len(deals)))
 		for i := range deals {
 			d := &deals[i]
+			if d.EndsAt != "" && !expiry.OnOrAfter(d.EndsAt, ref) {
+				// A deadline already past when the email was sent is almost
+				// always a hallucinated year, not a real deadline. Drop it so
+				// the page fetch below can supply the real one.
+				c.Logger().Warnf("dropping implausible deal deadline %q (email date %s)", d.EndsAt, ref.Format("2006-01-02"))
+				d.EndsAt = ""
+			}
 			if d.EndsAt != "" {
 				resolved, rerr := h.Resolver.Resolve(rctx, d.URL)
 				if rerr != nil {

--- a/apps/api/internal/ingest/ingest_test.go
+++ b/apps/api/internal/ingest/ingest_test.go
@@ -320,6 +320,63 @@ func TestIngestEmailEndsAtNotOverwritten(t *testing.T) {
 	}
 }
 
+func TestIngestImplausibleEndsAtRefilledFromPage(t *testing.T) {
+	// An extracted deadline already in the past when the email was sent (the
+	// fixture's Date is 2026-07-20) is a hallucinated year, not a deadline: it
+	// must be dropped, which routes the deal through the page fetch so the
+	// page's structured data supplies the real date.
+	e := setup(t)
+	e.ex.set([]extract.Deal{
+		{Source: "Manning", Title: "AI Agents in Action", URL: "https://h/m", EndsAt: "2025-11-27"},
+	}, nil)
+	fr := &fakeResolver{
+		page: []byte(`<html><head><script type="application/ld+json">
+			{"@type":"Product","offers":{"priceValidUntil":"2026-11-27"}}
+		</script></head></html>`),
+	}
+	e.h.Resolver = fr
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<x3@x>", "Deals", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+	d, err := e.st.GetDealByDedupeKey(context.Background(), store.DedupeKey("deals@humblebundle.com", "AI Agents in Action"))
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey: %v", err)
+	}
+	if d.EndsAt != "2026-11-27" {
+		t.Errorf("ends_at = %q, want the page's 2026-11-27 replacing the hallucinated 2025-11-27", d.EndsAt)
+	}
+	if fr.pageCalls != 1 {
+		t.Errorf("page calls = %d, want 1 (implausible deadline forces the page fetch)", fr.pageCalls)
+	}
+	if fr.resolveCalls != 0 {
+		t.Errorf("resolve calls = %d, want 0", fr.resolveCalls)
+	}
+}
+
+func TestIngestImplausibleEndsAtDroppedWhenPageHasNoDate(t *testing.T) {
+	// Same hallucinated deadline, but the page offers nothing to mine: the deal
+	// must store an empty ends_at rather than keep the impossible date.
+	e := setup(t)
+	e.ex.set([]extract.Deal{
+		{Source: "Manning", Title: "AI Agents in Action", URL: "https://h/m", EndsAt: "2025-11-27"},
+	}, nil)
+	e.h.Resolver = &fakeResolver{page: []byte(`<html><body>no structured data</body></html>`)}
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<x4@x>", "Deals", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+	d, err := e.st.GetDealByDedupeKey(context.Background(), store.DedupeKey("deals@humblebundle.com", "AI Agents in Action"))
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey: %v", err)
+	}
+	if d.EndsAt != "" {
+		t.Errorf("ends_at = %q, want empty (hallucinated date dropped, page had none)", d.EndsAt)
+	}
+}
+
 func TestIngestResolverErrorKeepsURLAndSucceeds(t *testing.T) {
 	// A failing resolver must not fail the ingest or lose the extracted URL.
 	e := setup(t)

--- a/apps/api/internal/ingest/ingest_test.go
+++ b/apps/api/internal/ingest/ingest_test.go
@@ -377,6 +377,69 @@ func TestIngestImplausibleEndsAtDroppedWhenPageHasNoDate(t *testing.T) {
 	}
 }
 
+func TestIngestImplausibleEndsAtDroppedWithoutResolver(t *testing.T) {
+	// The deadline guard must run even with no resolver wired: an impossible
+	// date never reaches the store.
+	e := setup(t)
+	e.ex.set([]extract.Deal{
+		{Source: "Manning", Title: "AI Agents in Action", URL: "https://h/m", EndsAt: "2025-11-27"},
+	}, nil)
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<x5@x>", "Deals", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+	d, err := e.st.GetDealByDedupeKey(context.Background(), store.DedupeKey("deals@humblebundle.com", "AI Agents in Action"))
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey: %v", err)
+	}
+	if d.EndsAt != "" {
+		t.Errorf("ends_at = %q, want empty (guard runs without a resolver)", d.EndsAt)
+	}
+}
+
+func TestIngestReingestClearsStoredHallucinatedDeadline(t *testing.T) {
+	// A bad deadline stored by an earlier ingest (before the guard existed)
+	// must be erased when the same deal is sighted again and the guard rejects
+	// the same extracted date — plain COALESCE would keep the stored copy.
+	e := setup(t)
+	ctx := context.Background()
+
+	seedEmail, _, err := e.st.InsertEmail(ctx, store.Email{
+		MessageID: "<seed@x>", From: "Humble Bundle <deals@humblebundle.com>", Subject: "Deals", BodyText: "body",
+	})
+	if err != nil {
+		t.Fatalf("InsertEmail: %v", err)
+	}
+	key := store.DedupeKey("deals@humblebundle.com", "AI Agents in Action")
+	if err := e.st.UpsertDeal(ctx, store.Deal{
+		EmailID: seedEmail.ID, DedupeKey: key, Source: "Manning",
+		Title: "AI Agents in Action", URL: "https://h/m", EndsAt: "2025-11-27",
+	}, time.Time{}); err != nil {
+		t.Fatalf("UpsertDeal seed: %v", err)
+	}
+
+	e.ex.set([]extract.Deal{
+		{Source: "Manning", Title: "AI Agents in Action", URL: "https://h/m", EndsAt: "2025-11-27"},
+	}, nil)
+	e.h.Resolver = &fakeResolver{page: []byte(`<html><body>no structured data</body></html>`)}
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<x6@x>", "Deals", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+	d, err := e.st.GetDealByDedupeKey(ctx, key)
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey: %v", err)
+	}
+	if d.EndsAt != "" {
+		t.Errorf("ends_at = %q, want the stored hallucinated date cleared on re-sighting", d.EndsAt)
+	}
+	if d.SeenCount != 2 {
+		t.Errorf("seen_count = %d, want 2", d.SeenCount)
+	}
+}
+
 func TestIngestResolverErrorKeepsURLAndSucceeds(t *testing.T) {
 	// A failing resolver must not fail the ingest or lose the extracted URL.
 	e := setup(t)

--- a/apps/api/internal/ingest/ingest_test.go
+++ b/apps/api/internal/ingest/ingest_test.go
@@ -377,6 +377,33 @@ func TestIngestImplausibleEndsAtDroppedWhenPageHasNoDate(t *testing.T) {
 	}
 }
 
+func TestIngestPastPageDeadlineAlsoDropped(t *testing.T) {
+	// When the extracted deadline is rejected and the fetched page's own
+	// structured data is also in the past (stale priceValidUntil from an
+	// earlier promotion), neither may be stored.
+	e := setup(t)
+	e.ex.set([]extract.Deal{
+		{Source: "Manning", Title: "AI Agents in Action", URL: "https://h/m", EndsAt: "2025-11-27"},
+	}, nil)
+	e.h.Resolver = &fakeResolver{
+		page: []byte(`<html><head><script type="application/ld+json">
+			{"@type":"Product","offers":{"priceValidUntil":"2025-06-01"}}
+		</script></head></html>`),
+	}
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<x7@x>", "Deals", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+	d, err := e.st.GetDealByDedupeKey(context.Background(), store.DedupeKey("deals@humblebundle.com", "AI Agents in Action"))
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey: %v", err)
+	}
+	if d.EndsAt != "" {
+		t.Errorf("ends_at = %q, want empty (both extracted and page deadlines implausible)", d.EndsAt)
+	}
+}
+
 func TestIngestImplausibleEndsAtDroppedWithoutResolver(t *testing.T) {
 	// The deadline guard must run even with no resolver wired: an impossible
 	// date never reaches the store.

--- a/apps/api/internal/store/store.go
+++ b/apps/api/internal/store/store.go
@@ -77,6 +77,13 @@ type Deal struct {
 	LastSeenAt       time.Time
 	SeenCount        int
 	PostedInDigestID *int64
+
+	// ClearEndsAt is a write-only flag for UpsertDeal (never read back from
+	// the database): when set, an empty EndsAt overwrites the stored deadline
+	// with NULL instead of preserving it. Ingest sets it after rejecting an
+	// implausible extracted deadline, so a previously stored copy of the same
+	// bad date cannot survive a re-sighting.
+	ClearEndsAt bool
 }
 
 // Store is a concrete persistence layer over a *sql.DB.
@@ -157,12 +164,18 @@ func (s *Store) SetEmailStatus(ctx context.Context, id int64, status, extractErr
 // UpsertDeal inserts a deal or, when its dedupe_key already exists, bumps
 // last_seen_at and seen_count and refreshes each optional field from the new
 // sighting when it supplies a value (the stored value is kept only when the
-// new one is empty).
+// new one is empty). d.ClearEndsAt is the exception: it makes an empty EndsAt
+// overwrite the stored deadline with NULL rather than preserve it.
 // If the existing deal was last seen before repostCutoff (i.e. unseen for longer
 // than the repost window), its posted_in_digest_id is reset to NULL so the deal
 // re-enters the next digest.
 func (s *Store) UpsertDeal(ctx context.Context, d Deal, repostCutoff time.Time) error {
 	now := formatTime(s.Now().UTC())
+	// The driver may not convert Go bools; bind the flag as 0/1 explicitly.
+	clearEndsAt := 0
+	if d.ClearEndsAt {
+		clearEndsAt = 1
+	}
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO deals
 		   (email_id, dedupe_key, source, title, url, price, ends_at, description, first_seen_at, last_seen_at, seen_count)
@@ -172,13 +185,14 @@ func (s *Store) UpsertDeal(ctx context.Context, d Deal, repostCutoff time.Time) 
 		   seen_count          = deals.seen_count + 1,
 		   url                 = COALESCE(excluded.url, deals.url),
 		   price               = COALESCE(excluded.price, deals.price),
-		   ends_at             = COALESCE(excluded.ends_at, deals.ends_at),
+		   ends_at             = CASE WHEN ? THEN NULL
+		                              ELSE COALESCE(excluded.ends_at, deals.ends_at) END,
 		   description         = COALESCE(excluded.description, deals.description),
 		   posted_in_digest_id = CASE WHEN deals.last_seen_at < ?
 		                              THEN NULL ELSE deals.posted_in_digest_id END`,
 		d.EmailID, d.DedupeKey, d.Source, d.Title,
 		nullString(d.URL), nullString(d.Price), nullString(d.EndsAt), nullString(d.Description),
-		now, now, formatTime(repostCutoff.UTC()),
+		now, now, clearEndsAt, formatTime(repostCutoff.UTC()),
 	)
 	if err != nil {
 		return fmt.Errorf("upsert deal: %w", err)

--- a/apps/api/internal/store/store.go
+++ b/apps/api/internal/store/store.go
@@ -155,7 +155,9 @@ func (s *Store) SetEmailStatus(ctx context.Context, id int64, status, extractErr
 }
 
 // UpsertDeal inserts a deal or, when its dedupe_key already exists, bumps
-// last_seen_at and seen_count and fills any previously-missing optional fields.
+// last_seen_at and seen_count and refreshes each optional field from the new
+// sighting when it supplies a value (the stored value is kept only when the
+// new one is empty).
 // If the existing deal was last seen before repostCutoff (i.e. unseen for longer
 // than the repost window), its posted_in_digest_id is reset to NULL so the deal
 // re-enters the next digest.

--- a/apps/api/internal/store/store_test.go
+++ b/apps/api/internal/store/store_test.go
@@ -157,6 +157,45 @@ func TestUpsertDealBumpsSeenCountAndCoalesces(t *testing.T) {
 	}
 }
 
+func TestUpsertDealClearEndsAt(t *testing.T) {
+	s := newStore(t)
+	e := mustInsertEmail(t, s, "<clr@x>")
+	key := store.DedupeKey("deals@humblebundle.com", "MEAP Book")
+	past := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	seed := store.Deal{EmailID: e.ID, DedupeKey: key, Source: "Manning", Title: "MEAP Book", EndsAt: "2025-11-27"}
+	if err := s.UpsertDeal(ctx, seed, past); err != nil {
+		t.Fatalf("UpsertDeal seed: %v", err)
+	}
+
+	// A plain re-sighting without a deadline preserves the stored one.
+	if err := s.UpsertDeal(ctx, store.Deal{EmailID: e.ID, DedupeKey: key, Source: "Manning", Title: "MEAP Book"}, past); err != nil {
+		t.Fatalf("UpsertDeal keep: %v", err)
+	}
+	got, err := s.GetDealByDedupeKey(ctx, key)
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey: %v", err)
+	}
+	if got.EndsAt != "2025-11-27" {
+		t.Errorf("EndsAt = %q, want stored 2025-11-27 preserved without ClearEndsAt", got.EndsAt)
+	}
+
+	// ClearEndsAt makes the empty deadline overwrite the stored one.
+	if err := s.UpsertDeal(ctx, store.Deal{EmailID: e.ID, DedupeKey: key, Source: "Manning", Title: "MEAP Book", ClearEndsAt: true}, past); err != nil {
+		t.Fatalf("UpsertDeal clear: %v", err)
+	}
+	got, err = s.GetDealByDedupeKey(ctx, key)
+	if err != nil {
+		t.Fatalf("GetDealByDedupeKey: %v", err)
+	}
+	if got.EndsAt != "" {
+		t.Errorf("EndsAt = %q, want cleared", got.EndsAt)
+	}
+	if got.SeenCount != 3 {
+		t.Errorf("SeenCount = %d, want 3", got.SeenCount)
+	}
+}
+
 // seedPostedDeal inserts a deal at seenAt, posts it in a digest, and returns its key.
 func seedPostedDeal(t *testing.T, s *store.Store, set func(time.Time), emailID int64, title string, seenAt time.Time) string {
 	t.Helper()


### PR DESCRIPTION
## What happened

Today's 3:29 PM Slack digest posted a Manning deal with "ends 2025-11-27" — a date eight months in the past — plus a raw HubSpot click-tracking URL, and a Pragmatic Bookshelf description citing promo code NEW2U.

**Correction after production-DB verification** (read-only queries against the prod Turso DB): none of this was an extraction hallucination. Manning's own email body says, verbatim, "Offer ends 27 November 2025. Only at manning.com" — in a message sent 2026-07-26; the vendor shipped a stale year. NEW2U is printed verbatim in PragProg's "You are now subscribed!" welcome email (a real new-subscriber code). The tracking URL is also verbatim from the email (24 HubSpot-wrapped links, zero direct manning.com links in the body). The extractor was faithful on all three counts.

The tracking URL surviving to Slack is timing: #378/#379 merged after the deal was already ingested and stored, and production deploys are manual, so the digest rendered a row stored under the old code.

The real gap this PR fixes: a confidently *wrong* deadline — whether a stale vendor year or a guessed year on a yearless date — sailed through untouched. It blocked the #379 page fetch entirely (the page is only mined when `ends_at` is empty), and nothing downstream sanity-checked the stored date before posting it.

## Changes

Three layers, outermost first:

- **Prompt** (`internal/extract`): the user prompt now carries a `Date:` line from the email's own header, the system instruction resolves yearless deadlines against it (never before it), and it explicitly forbids inventing prices, promo codes, or deadlines not present in the email's text. (Belt-and-suspenders after the verification above, but cheap and still correct for genuinely yearless newsletters.)
- **Ingest** (`internal/expiry` + `internal/ingest`): new `expiry.OnOrAfter` plausibility check, run before (and independent of) URL resolution. An extracted deadline already past on the email's send date is dropped, which routes the deal through `ResolvePage` so the deal page's `priceValidUntil`/`availabilityEnds` supplies the real date — page candidates get the same skepticism (shop pages carry stale dates from earlier promotions). A rejected deadline that nothing refilled sets `ClearEndsAt` on the upsert, writing NULL over a previously stored copy of the same bad date instead of coalescing it back.
- **Render** (`internal/digest`): `BuildBlocks` now takes the posting time and suppresses an `ends <date>` that is already past — the deal still posts, since a past date is more often a wrong date than a dead deal. Unparseable free-form values still render.

Also corrects the `UpsertDeal` doc comment (the SQL prefers the new sighting's optional fields; comment-only).

## Resolver expectations after deploy (verified against the live trackers)

- **HubSpot links will NOT resolve**: `hubspotlinks.com` answers 200 with a JavaScript bot-detection page — no `Location` header, no destination URL in the HTML (same result with a browser User-Agent). Manning links will keep appearing as trackers in the digest; they still work for humans, whose browsers execute the JS redirect. Known limitation of redirect-following; not addressed here.
- **Humble links WILL resolve**: `e.mailer.humblebundle.com` returns a clean 302 chain.

## Tests

- `buildUserPrompt` emits the Date line with `SentAt` and omits it without.
- `OnOrAfter` table: past/day-before/same-day/future/free-form/empty.
- Ingest: past extracted deadline refilled from the fetched page; past page date also rejected; guard runs with no resolver wired; re-sighting clears a previously stored bad date (`ClearEndsAt`); store-level flag test.
- Digest: past deadline hidden, today/future/free-form shown; existing golden unchanged.

`go test -race ./...`, `go vet`, `gofmt` clean on changed files; web suite passes.

## After merge

Production still runs pre-#377 code — a `just deploy` is needed for any of this (including #378/#379) to take effect.