### PR TITLE
Make deadline-guard comments cause-neutral

### DIFF
--- a/apps/api/internal/digest/blocks_test.go
+++ b/apps/api/internal/digest/blocks_test.go
@@ -137,7 +137,7 @@ func TestDealTextOmitsEmptyFields(t *testing.T) {
 }
 
 func TestDealTextDeadlineGuard(t *testing.T) {
-	// A stored deadline already in the past (usually a hallucinated year) must
+	// A stored deadline already in the past (a stale or guessed year) must
 	// not render; a current, future, or free-form one must.
 	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
 	cases := []struct {

--- a/apps/api/internal/expiry/expiry.go
+++ b/apps/api/internal/expiry/expiry.go
@@ -135,8 +135,9 @@ func parseDate(s string) (time.Time, bool) {
 }
 
 // OnOrAfter reports whether s names a calendar day on or after ref's. It is the
-// guard against LLM-hallucinated deadlines (an extractor that guesses a year
-// puts the deadline in the past): only a value that parses and falls strictly
+// guard against impossible deadlines — a stale year in the vendor's own copy,
+// or an extractor that guesses a year for a yearless date — either way the
+// deadline lands in the past: only a value that parses and falls strictly
 // before ref's own day returns false. Empty or unparseable strings return true —
 // they carry nothing confidently wrong to reject. Days are compared without
 // time-zone conversion, matching normalizeDate's stance.

--- a/apps/api/internal/ingest/ingest.go
+++ b/apps/api/internal/ingest/ingest.go
@@ -164,8 +164,9 @@ func (h *Handlers) Ingest(c echo.Context) error {
 
 	// An extracted deadline already past on the email's own send date (the
 	// extractor interprets deadlines relative to it; fall back to the clock
-	// for emails without a parseable Date) is almost always a hallucinated
-	// year, not a real deadline. Drop it before resolution — even with no
+	// for emails without a parseable Date) carries a stale or guessed year
+	// — vendors ship last year's copy, extractors guess a year for yearless
+	// dates — not a real deadline. Drop it before resolution — even with no
 	// resolver wired an impossible date must not be stored — and remember the
 	// drop so the upsert below can erase a previously stored copy of the same
 	// bad date instead of coalescing it back.
@@ -236,7 +237,7 @@ func (h *Handlers) Ingest(c echo.Context) error {
 			EndsAt:      d.EndsAt,
 			Description: d.Description,
 			// A rejected deadline that nothing refilled must overwrite a
-			// stored one — the stored copy is the same hallucination.
+			// stored one — the stored copy is the same bad date.
 			ClearEndsAt: cleared[i] && d.EndsAt == "",
 		}, repostCutoff); err != nil {
 			return err

--- a/apps/api/internal/ingest/ingest_test.go
+++ b/apps/api/internal/ingest/ingest_test.go
@@ -322,7 +322,7 @@ func TestIngestEmailEndsAtNotOverwritten(t *testing.T) {
 
 func TestIngestImplausibleEndsAtRefilledFromPage(t *testing.T) {
 	// An extracted deadline already in the past when the email was sent (the
-	// fixture's Date is 2026-07-20) is a hallucinated year, not a deadline: it
+	// fixture's Date is 2026-07-20) carries a stale or guessed year, not a deadline: it
 	// must be dropped, which routes the deal through the page fetch so the
 	// page's structured data supplies the real date.
 	e := setup(t)
@@ -345,7 +345,7 @@ func TestIngestImplausibleEndsAtRefilledFromPage(t *testing.T) {
 		t.Fatalf("GetDealByDedupeKey: %v", err)
 	}
 	if d.EndsAt != "2026-11-27" {
-		t.Errorf("ends_at = %q, want the page's 2026-11-27 replacing the hallucinated 2025-11-27", d.EndsAt)
+		t.Errorf("ends_at = %q, want the page's 2026-11-27 replacing the impossible 2025-11-27", d.EndsAt)
 	}
 	if fr.pageCalls != 1 {
 		t.Errorf("page calls = %d, want 1 (implausible deadline forces the page fetch)", fr.pageCalls)
@@ -356,7 +356,7 @@ func TestIngestImplausibleEndsAtRefilledFromPage(t *testing.T) {
 }
 
 func TestIngestImplausibleEndsAtDroppedWhenPageHasNoDate(t *testing.T) {
-	// Same hallucinated deadline, but the page offers nothing to mine: the deal
+	// Same impossible deadline, but the page offers nothing to mine: the deal
 	// must store an empty ends_at rather than keep the impossible date.
 	e := setup(t)
 	e.ex.set([]extract.Deal{
@@ -373,7 +373,7 @@ func TestIngestImplausibleEndsAtDroppedWhenPageHasNoDate(t *testing.T) {
 		t.Fatalf("GetDealByDedupeKey: %v", err)
 	}
 	if d.EndsAt != "" {
-		t.Errorf("ends_at = %q, want empty (hallucinated date dropped, page had none)", d.EndsAt)
+		t.Errorf("ends_at = %q, want empty (impossible date dropped, page had none)", d.EndsAt)
 	}
 }
 
@@ -460,7 +460,7 @@ func TestIngestReingestClearsStoredHallucinatedDeadline(t *testing.T) {
 		t.Fatalf("GetDealByDedupeKey: %v", err)
 	}
 	if d.EndsAt != "" {
-		t.Errorf("ends_at = %q, want the stored hallucinated date cleared on re-sighting", d.EndsAt)
+		t.Errorf("ends_at = %q, want the stored impossible date cleared on re-sighting", d.EndsAt)
 	}
 	if d.SeenCount != 2 {
 		t.Errorf("seen_count = %d, want 2", d.SeenCount)


### PR DESCRIPTION
Comment-only follow-up to #380, which the maintainer merged before this landed on its branch.

Production-DB verification showed the guard's first real catch was not an extractor hallucination: Manning's own email says "Offer ends 27 November 2025" in a message sent 2026-07-26 (stale vendor copy), and the suspected-invented promo code is printed verbatim in the source email. This rewords the code comments that pinned past deadlines on the LLM — the `OnOrAfter` guard treats a stale vendor year and a guessed year identically. No functional changes; `go test -race ./...` green.