### PR TITLE
Follow HubSpot interstitial redirects assigned through a script variable

### DIFF
--- a/apps/api/internal/resolve/resolve.go
+++ b/apps/api/internal/resolve/resolve.go
@@ -5,7 +5,10 @@
 // (utm_*, mcID, linkID, …) are stripped from it. Some trackers (HubSpot among
 // them) end the HTTP chain on a 200 interstitial that redirects via
 // <meta http-equiv="refresh"> or an inline script instead — those body-level
-// redirects are followed too, under their own hop cap. Resolution is strictly
+// redirects are followed too, under their own hop cap. Script redirects are
+// resolved through one level of variable indirection (HubSpot assigns the
+// target to a variable first), with the interstitial's lone no-JS fallback
+// anchor as a last resort. Resolution is strictly
 // best-effort: on any failure the input URL is returned unchanged, so a
 // resolver outage can never lose or corrupt a deal.
 //
@@ -243,11 +246,49 @@ var jsRedirectPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)(?:window\.|document\.|top\.)?location\.(?:replace|assign)\(\s*["']([^"']+)["']\s*\)`),
 }
 
+// jsVarRedirectPatterns match the same location assignments with an identifier
+// on the right-hand side (`window.location.replace(targetURL)`) — the shape
+// HubSpot's bot-check interstitial uses. The captured identifier is then
+// resolved to a URL literal by jsVarTarget.
+var jsVarRedirectPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(?:(?:window|document|top)\.)?\blocation(?:\.href)?\s*=\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*(?:[;\r\n]|$)`),
+	regexp.MustCompile(`(?i)(?:(?:window|document|top)\.)?\blocation\.(?:replace|assign)\(\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*\)`),
+}
+
+// jsVarTarget resolves a location assignment whose right-hand side is a
+// variable: it finds the identifier being assigned to location, then looks for
+// that identifier receiving an absolute http(s) string literal anywhere in the
+// page's scripts (HubSpot parks the literal inside a helper function).
+// detected reports that such an assignment exists even when the identifier
+// could not be resolved — the caller gates the no-JS anchor fallback on it.
+func jsVarTarget(scripts []string) (target string, detected bool) {
+	for _, src := range scripts {
+		for _, re := range jsVarRedirectPatterns {
+			m := re.FindStringSubmatch(src)
+			if m == nil {
+				continue
+			}
+			detected = true
+			lookup := regexp.MustCompile(`\b` + regexp.QuoteMeta(m[1]) + `\s*=\s*["'](https?://[^"']+)["']`)
+			for _, s := range scripts {
+				if lm := lookup.FindStringSubmatch(s); lm != nil {
+					return lm[1], true
+				}
+			}
+		}
+	}
+	return "", detected
+}
+
 // nextHop extracts a body-level redirect target from an HTML page: a
 // <meta http-equiv="refresh"> URL with a small delay or — on small pages only
-// (jsSniffLimit) — an inline-script location assignment. It returns nil when
-// the page carries no such redirect, the target does not resolve to http(s),
-// or the target is the page itself (a self-refresh, not a redirect).
+// (jsSniffLimit) — an inline-script location assignment, resolved through one
+// level of variable indirection when the assignment's right-hand side is an
+// identifier. When a variable assignment is detected but its URL can't be
+// found, the page's single absolute-http(s) anchor (the interstitial's no-JS
+// "click here" fallback) is used instead. It returns nil when the page carries
+// no such redirect, the target does not resolve to http(s), or the target is
+// the page itself (a self-refresh, not a redirect).
 func nextHop(body []byte, base *url.URL) *url.URL {
 	doc, err := html.Parse(bytes.NewReader(body))
 	if err != nil {
@@ -257,6 +298,7 @@ func nextHop(body []byte, base *url.URL) *url.URL {
 	sniffScripts := len(body) <= jsSniffLimit
 	var target string
 	var scripts []string
+	var anchors []string
 	var walk func(*html.Node)
 	walk = func(n *html.Node) {
 		if target != "" {
@@ -274,6 +316,12 @@ func nextHop(body []byte, base *url.URL) *url.URL {
 			case "script":
 				if sniffScripts && n.FirstChild != nil {
 					scripts = append(scripts, n.FirstChild.Data)
+				}
+			case "a":
+				if sniffScripts {
+					if h := attr(n, "href"); h != "" {
+						anchors = append(anchors, h)
+					}
 				}
 			}
 		}
@@ -294,6 +342,17 @@ func nextHop(body []byte, base *url.URL) *url.URL {
 			if target != "" {
 				break
 			}
+		}
+	}
+	if target == "" {
+		var varRedirect bool
+		target, varRedirect = jsVarTarget(scripts)
+		// The page clearly redirects via a script we couldn't decode; take its
+		// no-JS fallback anchor — but only when there is exactly one anchor and
+		// it is absolute, so a genuine content page can never be misread as a
+		// redirector.
+		if target == "" && varRedirect && len(anchors) == 1 && isAbsHTTP(anchors[0]) {
+			target = anchors[0]
 		}
 	}
 	if target == "" {
@@ -335,6 +394,12 @@ func parseRefreshContent(content string) string {
 		return ""
 	}
 	return strings.Trim(strings.TrimSpace(rest[i+len("url="):]), `'"`)
+}
+
+// isAbsHTTP reports whether s is an absolute http(s) URL.
+func isAbsHTTP(s string) bool {
+	u, err := url.Parse(s)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
 }
 
 // attr returns the named attribute's value, matching the name
@@ -385,6 +450,10 @@ func isTrackingParam(key string) bool {
 	}
 	switch k {
 	case "mcid", "linkid", "fbclid", "gclid", "msclkid", "mc_cid", "mc_eid", "igshid", "twclid":
+		return true
+	// HubSpot email params. ecid is the recipient's contact ID, so leaving it
+	// in a stored URL would also leak who received the newsletter.
+	case "_hsenc", "_hsmi", "_hsfp", "ecid":
 		return true
 	}
 	return false

--- a/apps/api/internal/resolve/resolve.go
+++ b/apps/api/internal/resolve/resolve.go
@@ -396,10 +396,12 @@ func parseRefreshContent(content string) string {
 	return strings.Trim(strings.TrimSpace(rest[i+len("url="):]), `'"`)
 }
 
-// isAbsHTTP reports whether s is an absolute http(s) URL.
+// isAbsHTTP reports whether s is an absolute http(s) URL. The host check
+// matters: url.Parse("https:foo") yields Scheme "https" with an empty Host
+// (scheme:opaque form), and that is not a followable absolute URL.
 func isAbsHTTP(s string) bool {
 	u, err := url.Parse(s)
-	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
 }
 
 // attr returns the named attribute's value, matching the name

--- a/apps/api/internal/resolve/resolve_test.go
+++ b/apps/api/internal/resolve/resolve_test.go
@@ -376,6 +376,144 @@ func TestResolveJSWallHop(t *testing.T) {
 	}
 }
 
+func TestResolveJSVarWallHop(t *testing.T) {
+	// The location assignment's right-hand side is a variable; the URL literal
+	// it was assigned must be found and followed.
+	scripts := []string{
+		`var u = "%s/deal?id=5&utm_source=n"; window.location.replace(u);`,
+		`var u = "%s/deal?id=5&utm_source=n"; document.location = u;`,
+	}
+	for _, script := range scripts {
+		mux := http.NewServeMux()
+		srv := httptest.NewServer(mux)
+		mux.HandleFunc("/wall", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, `<html><body><script>`+script+`</script></body></html>`, srv.URL)
+		})
+		mux.HandleFunc("/deal", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		r := newResolver(true)
+		got, err := r.Resolve(context.Background(), srv.URL+"/wall")
+		if err != nil {
+			t.Errorf("script %q: Resolve: %v", script, err)
+		}
+		if want := srv.URL + "/deal?id=5"; got != want {
+			t.Errorf("script %q: Resolve = %q, want %q", script, got, want)
+		}
+		srv.Close()
+	}
+}
+
+func TestResolveJSVarInHelperFunction(t *testing.T) {
+	// HubSpot's shape: the URL literal lives inside a helper function, the
+	// variable actually assigned to location is built at runtime. The literal
+	// must still be found by identifier name.
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/wall", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><head><script>
+function getTargetURLWithState(state) {
+  var targetURL = "%s/deal?id=7&utm_source=n";
+  return targetURL.substring(0, targetURL.length - 2) + state;
+}
+var targetURL;
+try { targetURL = getTargetURLWithState("1"); } catch(e) { targetURL = getTargetURLWithState("-1"); }
+if (/Android/.test(window.navigator.userAgent)) {
+  document.location = targetURL;
+} else {
+  window.location.replace(targetURL);
+}
+</script></head><body><p>You're being redirected</p><a href="%s/deal?id=7&utm_source=n">click here</a></body></html>`, srv.URL, srv.URL)
+	})
+	mux.HandleFunc("/deal", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := newResolver(true)
+	got, err := r.Resolve(context.Background(), srv.URL+"/wall")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := srv.URL + "/deal?id=7"; got != want {
+		t.Errorf("Resolve = %q, want %q", got, want)
+	}
+}
+
+func TestResolveAnchorFallbackAfterUnresolvableJS(t *testing.T) {
+	// A script redirect through a variable whose URL is built at runtime (no
+	// literal anywhere) must fall back to the page's single absolute anchor —
+	// the interstitial's no-JS path.
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/wall", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><script>var u = base + path; window.location.replace(u);</script>
+<a href="%s/deal?id=3&utm_source=n">click here</a></body></html>`, srv.URL)
+	})
+	mux.HandleFunc("/deal", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := newResolver(true)
+	got, err := r.Resolve(context.Background(), srv.URL+"/wall")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := srv.URL + "/deal?id=3"; got != want {
+		t.Errorf("Resolve = %q, want %q", got, want)
+	}
+}
+
+func TestResolveAnchorFallbackNeedsSingleAnchor(t *testing.T) {
+	// Same unresolvable script redirect, but two anchors: ambiguous, no hop.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><body><script>var u = base + path; window.location.replace(u);</script>
+<a href="https://a.example/x">one</a> <a href="https://b.example/y">two</a></body></html>`))
+	}))
+	defer srv.Close()
+
+	r := newResolver(true)
+	got, err := r.Resolve(context.Background(), srv.URL+"/wall")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if want := srv.URL + "/wall"; got != want {
+		t.Errorf("Resolve = %q, want %q (multiple anchors must not hop)", got, want)
+	}
+}
+
+func TestResolveAnchorFallbackNeedsDetectedJSRedirect(t *testing.T) {
+	// A small page with one anchor but no script redirect is content, not an
+	// interstitial; it must not hop. Likewise a lone *relative* anchor even
+	// with the redirect detected.
+	pages := []string{
+		`<html><body><a href="https://a.example/x">a link</a></body></html>`,
+		`<html><body><script>var u = base + path; window.location.replace(u);</script><a href="/x">rel</a></body></html>`,
+	}
+	for _, page := range pages {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			w.Write([]byte(page))
+		}))
+
+		r := newResolver(true)
+		got, err := r.Resolve(context.Background(), srv.URL+"/page")
+		if err != nil {
+			t.Errorf("page %q: Resolve: %v", page, err)
+		}
+		if want := srv.URL + "/page"; got != want {
+			t.Errorf("page %q: Resolve = %q, want %q (must not hop)", page, got, want)
+		}
+		srv.Close()
+	}
+}
+
 func TestResolveMetaRefreshRelativeQuoted(t *testing.T) {
 	// A quoted, uppercase URL= with a relative target must resolve against the
 	// interstitial's own URL.
@@ -589,6 +727,8 @@ func TestStripTracking(t *testing.T) {
 		{"not a tracking prefix", "utmx=1", "utmx=1"},
 		{"percent-encoded tracking key stripped", "%75tm_source=x&id=9", "id=9"},
 		{"percent-encoded kept param stays encoded", "%69d=9", "%69d=9"},
+		{"hubspot email params stripped", "_hsenc=p2ANqtz&_hsmi=430&_hsfp=123&ecid=ACsprv&id=9", "id=9"},
+		{"hubspot params case-insensitive", "_HsEnc=x&ECID=y&id=9", "id=9"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/api/internal/resolve/resolve_test.go
+++ b/apps/api/internal/resolve/resolve_test.go
@@ -495,6 +495,8 @@ func TestResolveAnchorFallbackNeedsDetectedJSRedirect(t *testing.T) {
 	pages := []string{
 		`<html><body><a href="https://a.example/x">a link</a></body></html>`,
 		`<html><body><script>var u = base + path; window.location.replace(u);</script><a href="/x">rel</a></body></html>`,
+		// scheme:opaque form — url.Parse gives it Scheme https but no Host.
+		`<html><body><script>var u = base + path; window.location.replace(u);</script><a href="https:foo">opaque</a></body></html>`,
 	}
 	for _, page := range pages {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
Closes #396. Follow-up to #388: Manning deal links still arrived as `hubspotlinks.com/Ctc/…` tracking URLs.

## Root cause

HubSpot's interstitial is a bot-check page whose redirect script assigns a **variable**, not a string literal — `window.location.replace(targetURL)` (or `document.location = targetURL` on Android), with the URL literal parked inside a helper function. The `jsRedirectPatterns` shipped in #388 only match quoted literals, and the page has no meta refresh, so `nextHop` found nothing and resolution stopped at the interstitial.

## Fix

- **Variable indirection** in `nextHop`: when a location assignment's right-hand side is an identifier, resolve that identifier to the absolute http(s) string literal it is assigned anywhere in the page's scripts.
- **No-JS anchor fallback, tightly gated**: when such an assignment is detected but the identifier can't be resolved to a literal, and the page has exactly one anchor with an absolute http(s) href, hop via that anchor — HubSpot's own "If you're not redirected… click here" path. The gate (small page per `jsSniffLimit` + detected script redirect + single absolute anchor) keeps content pages from ever being misread as redirectors.
- **Strip HubSpot email params** from resolved URLs: `_hsenc`, `_hsmi`, `_hsfp`, and `ecid`. `ecid` is the recipient's contact ID, so storing it would also leak who received the newsletter.

All existing guards are unchanged: hop cap, self-refresh check, scheme check, SSRF dialer.

## Verification

- `go vet ./... && go test -race ./...` green; new cases cover both variable shapes, the helper-function shape, the anchor fallback, its multi-anchor/relative/no-script negative gates, and the new strip params.
- Live check against the reported Manning link (temporary opt-in test, not committed): resolves to `https://48055234.hs-sites.com/save-half-sitewide-1` — that link's true destination with all tracking stripped. A book-CTA link resolves the same way to its `manning.com/books/…` page.

No backfill: already-stored deals keep their tracking URLs; only future ingests are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved handling of JavaScript-based redirect pages, including HubSpot-style interstitials where the redirect target is assigned via a variable.
  - Added a safe anchor-based fallback when the JavaScript target can’t be decoded, using only when the page has a single compatible absolute link.
  - Enhanced redirect detection to better avoid following links on ordinary content pages that don’t match the redirect pattern.
  - Expanded tracking cleanup to strip additional HubSpot email query parameters (`_hsenc`, `_hsmi`, `_hsfp`, `ecid`), with case-insensitive handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->