### PR TITLE
Collapse one promotion into one deal entry

### DIFF
--- a/apps/api/internal/extract/gemini.go
+++ b/apps/api/internal/extract/gemini.go
@@ -24,6 +24,7 @@ A deal is a discounted or time-limited offer whose subject is software or softwa
 Include an offer only when it is about software or software development. Exclude everything else, even when discounted: video games and game bundles, comics, art or asset bundles, tabletop/RPG material, and books or courses on non-technical topics.
 For a bundle that mixes software titles with unrelated ones, include it only if it is primarily about software.
 Return one entry per bundle or offer — never one entry per item inside a bundle.
+When one promotion spans several product categories or tiers — a sitewide or storewide sale covering books, subscriptions, and other products — return a single entry describing the whole promotion, not one entry per category or tier. Still return a separate entry for each individually featured product, such as a specific book on sale, even when the same promotion also covers it. Never return an entry whose offer merely restates a piece of another entry's broader promotion.
 Set url to the link printed next to that offer if one is present.
 The prompt's Date line is the day the email was sent. When a deadline omits the year, resolve it against that date so the deadline is on or after it: "ends November 27" in an email dated 2026-07-26 means 2026-11-27.
 Copy prices, promo codes, and deadlines only from the email's own text; never invent, infer, or embellish them. Leave a field null when the email does not state it.

--- a/apps/api/internal/extract/gemini_test.go
+++ b/apps/api/internal/extract/gemini_test.go
@@ -353,3 +353,59 @@ func TestSystemInstructionScopesToSoftware(t *testing.T) {
 		}
 	}
 }
+
+// TestSystemInstructionCollapsesPromotions locks the overlap rule — one
+// promotion spanning categories yields one umbrella entry, with individually
+// featured products kept separate — so the prompt can't silently regress. The
+// model-based behaviour itself is verified by
+// TestExtractLiveCollapsesPromotions.
+func TestSystemInstructionCollapsesPromotions(t *testing.T) {
+	lower := strings.ToLower(systemInstruction)
+	for _, want := range []string{"promotion", "category or tier", "individually featured"} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("systemInstruction missing %q", want)
+		}
+	}
+}
+
+// TestExtractLiveCollapsesPromotions hits the real Gemini API; run with
+// GEMINI_LIVE_TEST=1 and a key. A Manning-shaped email — one sitewide sale
+// restated per category plus one individually featured book — must collapse to
+// exactly two deals: the umbrella promotion and the book.
+func TestExtractLiveCollapsesPromotions(t *testing.T) {
+	if os.Getenv("GEMINI_LIVE_TEST") != "1" {
+		t.Skip("set GEMINI_LIVE_TEST=1 and GEMINI_API_KEY to run")
+	}
+	g, err := NewGemini(ctx, os.Getenv("GEMINI_API_KEY"), "gemini-3.5-flash-lite", "")
+	if err != nil {
+		t.Fatalf("NewGemini: %v", err)
+	}
+
+	email := mailparse.Email{
+		From:    "Manning Publications <promo@manning.com>",
+		Subject: "Deal of the Day: Lean Software Engineering",
+		Text: `Deal of the Day: Lean Software Engineering — half off today. https://www.manning.com/books/lean-software-engineering
+Our summer sale is on: save half sitewide on all Manning books, get any liveProject or liveVideo for $10, or a year of Manning Online Pro for $199.99. Sale ends July 31. https://www.manning.com/sale
+All liveProjects and liveVideos $10! https://www.manning.com/liveprojects
+liveProjects and liveVideos bestsellers, $10 each. https://www.manning.com/livevideos
+Manning Online Pro annual subscription $199.99 (save $50). https://www.manning.com/pro`,
+	}
+
+	deals, err := g.Extract(ctx, email)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	t.Logf("got %d deals: %+v", len(deals), deals)
+	if len(deals) != 2 {
+		t.Errorf("expected exactly 2 deals (umbrella sale + featured book), got %d", len(deals))
+	}
+	books := 0
+	for _, d := range deals {
+		if strings.Contains(strings.ToLower(d.Title), "lean") {
+			books++
+		}
+	}
+	if books != 1 {
+		t.Errorf("expected exactly one entry for the featured book, got %d", books)
+	}
+}


### PR DESCRIPTION
Closes #398. Companion to #397 (both fix the Manning digest quality issues).

## Problem

A single Manning email produced five deal entries where two suffice: the umbrella "Summer Sale" entry (50% off books, $10 liveProjects/liveVideos, $199.99 Online Pro) arrived alongside three entries restating its facets, plus the one genuinely distinct featured book.

## Fix

The extraction `systemInstruction` already forbids one entry per item inside a bundle, but said nothing about one promotion spanning several product categories or tiers. Added the overlap rule:

> When one promotion spans several product categories or tiers — a sitewide or storewide sale covering books, subscriptions, and other products — return a single entry describing the whole promotion, not one entry per category or tier. Still return a separate entry for each individually featured product, such as a specific book on sale, even when the same promotion also covers it. Never return an entry whose offer merely restates a piece of another entry's broader promotion.

There is no post-hoc layer that could judge semantic subsumption reliably, so the prompt is the right place for this.

## Verification

- `go vet ./... && go test -race ./...` green.
- `TestSystemInstructionCollapsesPromotions` locks the rule's presence so it can't silently regress (same style as the software-scope lock).
- `TestExtractLiveCollapsesPromotions` (opt-in: `GEMINI_LIVE_TEST=1` + `GEMINI_API_KEY`) sends a Manning-shaped email — sitewide sale restated per category plus one featured book — and requires exactly two deals, exactly one of them the book. No key is available in this environment, so this needs a maintainer run:

  ```
  cd apps/api && GEMINI_LIVE_TEST=1 go test ./internal/extract -run TestExtractLiveCollapsesPromotions -v
  ```

No backfill: already-stored duplicates stay; only future ingests are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved promotion extraction so overlapping category or tier offers are consolidated into one sitewide promotion.
  * Preserved separate entries for individually featured products within broader promotions.
  * Prevented duplicate entries that merely repeat a broader promotion’s details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->