### PR TITLE
Resolve deal URLs concurrently so large emails can't starve late-batch deals

### DIFF
--- a/apps/api/internal/ingest/ingest.go
+++ b/apps/api/internal/ingest/ingest.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -42,6 +43,13 @@ func resolveBudget(deals int) time.Duration {
 	}
 	return budget
 }
+
+// resolveConcurrency bounds how many deal URLs resolve at once. Resolution is
+// network-bound against external trackers, so a small pool turns a batch of
+// per-deal fetch timeouts into a few waves of wall clock — without it, a large
+// email spends the whole shared budget on its first few deals and the rest
+// keep their tracker URLs.
+const resolveConcurrency = 5
 
 // URLResolver cleans one deal URL (following tracking redirects, stripping
 // tracking parameters). Implementations must return a usable URL — the input
@@ -199,50 +207,74 @@ func (h *Handlers) Ingest(c echo.Context) error {
 	// email-stated value is never overwritten. Strictly best-effort under one
 	// shared budget: a failed or skipped step keeps the extracted values, and
 	// a resolver problem never fails the ingest.
+	//
+	// Resolution runs first, concurrently across the batch: it is the
+	// load-bearing step (the stored link), while mining and enrichment are
+	// optional fill. Run sequentially, a large email spends the whole budget
+	// on its early deals — each tracker chain costs up to a fetch timeout and
+	// each model call several seconds more — and the remaining deals keep
+	// their tracker URLs.
 	if h.Resolver != nil && len(deals) > 0 {
 		rctx, cancel := context.WithTimeout(ctx, resolveBudget(len(deals)))
+		pages := make([][]byte, len(deals))
+		errs := make([]error, len(deals))
+		sem := make(chan struct{}, resolveConcurrency)
+		var wg sync.WaitGroup
 		for i := range deals {
-			d := &deals[i]
-			if d.EndsAt != "" && d.Price != "" {
-				resolved, rerr := h.Resolver.Resolve(rctx, d.URL)
-				if rerr != nil {
-					c.Logger().Warnf("resolve deal url: %v", rerr)
+			wg.Add(1)
+			sem <- struct{}{}
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				d := &deals[i]
+				if d.EndsAt != "" && d.Price != "" {
+					// Nothing left to mine; only the clean URL is wanted.
+					d.URL, errs[i] = h.Resolver.Resolve(rctx, d.URL)
+					return
 				}
-				d.URL = resolved
-				continue
-			}
-			resolved, page, rerr := h.Resolver.ResolvePage(rctx, d.URL)
+				d.URL, pages[i], errs[i] = h.Resolver.ResolvePage(rctx, d.URL)
+			}()
+		}
+		wg.Wait()
+		for _, rerr := range errs {
 			if rerr != nil {
 				c.Logger().Warnf("resolve deal url: %v", rerr)
 			}
-			d.URL = resolved
-			if len(page) > 0 {
-				mined := expiry.Mine(page)
-				if d.EndsAt == "" {
-					// The page's structured data gets the same skepticism as
-					// the extractor: shop pages routinely carry a stale
-					// priceValidUntil from an earlier promotion, and a past
-					// date is useless to store (the digest would hide it
-					// anyway). Leaving it empty also keeps ClearEndsAt
-					// effective, so a previously stored bad deadline still
-					// gets erased.
-					if mined.EndsAt == "" || expiry.OnOrAfter(mined.EndsAt, ref) {
-						d.EndsAt = mined.EndsAt
-					} else {
-						c.Logger().Warnf("dropping implausible page deadline %q (email date %s)", mined.EndsAt, ref.Format("2006-01-02"))
-					}
+		}
+
+		// Mining and model enrichment run on whatever budget remains; running
+		// dry here loses only the optional deadline/price fill, never a URL.
+		for i := range deals {
+			d := &deals[i]
+			page := pages[i]
+			if len(page) == 0 {
+				continue
+			}
+			mined := expiry.Mine(page)
+			if d.EndsAt == "" {
+				// The page's structured data gets the same skepticism as
+				// the extractor: shop pages routinely carry a stale
+				// priceValidUntil from an earlier promotion, and a past
+				// date is useless to store (the digest would hide it
+				// anyway). Leaving it empty also keeps ClearEndsAt
+				// effective, so a previously stored bad deadline still
+				// gets erased.
+				if mined.EndsAt == "" || expiry.OnOrAfter(mined.EndsAt, ref) {
+					d.EndsAt = mined.EndsAt
+				} else {
+					c.Logger().Warnf("dropping implausible page deadline %q (email date %s)", mined.EndsAt, ref.Format("2006-01-02"))
 				}
-				if d.Price == "" {
-					d.Price = mined.Price
-				}
-				// Last tier: when structured data left the deadline unfilled,
-				// ask the model to read the page text (many pages state a
-				// deadline only as prose). Model output gets the same
-				// OnOrAfter skepticism as every other source, and a missing
-				// price rides along on the same call.
-				if d.EndsAt == "" && h.Enricher != nil {
-					h.enrichFromPage(rctx, c, d, page, ref)
-				}
+			}
+			if d.Price == "" {
+				d.Price = mined.Price
+			}
+			// Last tier: when structured data left the deadline unfilled,
+			// ask the model to read the page text (many pages state a
+			// deadline only as prose). Model output gets the same
+			// OnOrAfter skepticism as every other source, and a missing
+			// price rides along on the same call.
+			if d.EndsAt == "" && h.Enricher != nil {
+				h.enrichFromPage(rctx, c, d, page, ref)
 			}
 		}
 		cancel()

--- a/apps/api/internal/ingest/ingest_test.go
+++ b/apps/api/internal/ingest/ingest_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -70,17 +71,21 @@ func (f *fakePoster) count() int {
 // fakeResolver maps input URLs to resolved ones; unmapped inputs pass through
 // unchanged, and err (if set) is returned alongside — matching the URLResolver
 // contract of always handing back a usable URL. ResolvePage additionally hands
-// back the canned page (nil for an empty URL, like the real resolver).
+// back the canned page (nil for an empty URL, like the real resolver). delay,
+// when set, is slept before the lock so concurrent calls overlap the way real
+// network fetches do.
 type fakeResolver struct {
 	mu           sync.Mutex
 	byURL        map[string]string
 	page         []byte
 	err          error
+	delay        time.Duration
 	resolveCalls int
 	pageCalls    int
 }
 
 func (f *fakeResolver) Resolve(_ context.Context, raw string) (string, error) {
+	time.Sleep(f.delay)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.resolveCalls++
@@ -88,6 +93,7 @@ func (f *fakeResolver) Resolve(_ context.Context, raw string) (string, error) {
 }
 
 func (f *fakeResolver) ResolvePage(_ context.Context, raw string) (string, []byte, error) {
+	time.Sleep(f.delay)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.pageCalls++
@@ -253,6 +259,94 @@ func TestIngestResolvesDealURLs(t *testing.T) {
 	}
 	if fr.pageCalls != 2 {
 		t.Errorf("resolver page calls = %d, want 2 (one per deal; both lack ends_at)", fr.pageCalls)
+	}
+}
+
+func TestIngestResolvesLargeBatchConcurrently(t *testing.T) {
+	// A big email must not resolve URLs one after another: run sequentially, a
+	// batch of slow trackers exhausts the shared budget and the later deals
+	// keep their tracker URLs. With ten deals at 200ms each, the sequential
+	// floor is 2s; the concurrent pool finishes in a few waves. Every deal —
+	// including the last — must carry its resolved URL.
+	e := setup(t)
+	const n = 10
+	deals := make([]extract.Deal, n)
+	byURL := make(map[string]string, n)
+	for i := range deals {
+		tracker := fmt.Sprintf("https://t/%d", i)
+		deals[i] = extract.Deal{
+			Source: "Manning", Title: fmt.Sprintf("Deal %d", i), URL: tracker,
+			Price: "$10", EndsAt: "2027-01-01",
+		}
+		byURL[tracker] = fmt.Sprintf("https://clean/%d", i)
+	}
+	e.ex.set(deals, nil)
+	fr := &fakeResolver{byURL: byURL, delay: 200 * time.Millisecond}
+	e.h.Resolver = fr
+
+	start := time.Now()
+	rec := e.post(t, "/api/ingest", token, rawEmail("<big@x>", "Roundup", "body"))
+	elapsed := time.Since(start)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+	// Sequential resolution would need n*delay = 2s; leave slack for slow CI
+	// while still ruling the serial path out.
+	if elapsed > 1500*time.Millisecond {
+		t.Errorf("ingest took %v, want well under the %v sequential floor", elapsed, n*200*time.Millisecond)
+	}
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		d, err := e.st.GetDealByDedupeKey(ctx, store.DedupeKey("deals@humblebundle.com", fmt.Sprintf("Deal %d", i)))
+		if err != nil {
+			t.Fatalf("GetDealByDedupeKey %d: %v", i, err)
+		}
+		if want := fmt.Sprintf("https://clean/%d", i); d.URL != want {
+			t.Errorf("deal %d URL = %q, want %q (no positional starvation)", i, d.URL, want)
+		}
+	}
+}
+
+// gateEnricher implements extract.PageEnricher and records how many resolver
+// page fetches had completed when its first call arrived.
+type gateEnricher struct {
+	fr               *fakeResolver
+	pageCallsAtFirst int32
+}
+
+func (g *gateEnricher) EnrichFromPage(context.Context, string, string, *time.Time) (extract.Enrichment, error) {
+	g.fr.mu.Lock()
+	seen := g.fr.pageCalls
+	g.fr.mu.Unlock()
+	atomic.CompareAndSwapInt32(&g.pageCallsAtFirst, -1, int32(seen))
+	return extract.Enrichment{}, nil
+}
+
+func TestIngestEnrichmentRunsAfterAllURLsResolved(t *testing.T) {
+	// Model enrichment consumes the same shared budget as resolution, so it
+	// must not start until every deal's URL is resolved — otherwise a slow
+	// model call starves the deals behind it of their URLs.
+	e := setup(t)
+	const n = 6
+	deals := make([]extract.Deal, n)
+	for i := range deals {
+		deals[i] = extract.Deal{
+			Source: "Manning", Title: fmt.Sprintf("Deal %d", i),
+			URL: fmt.Sprintf("https://t/%d", i),
+		}
+	}
+	e.ex.set(deals, nil)
+	fr := &fakeResolver{page: []byte(`<html><body>a sale page</body></html>`)}
+	e.h.Resolver = fr
+	ge := &gateEnricher{fr: fr, pageCallsAtFirst: -1}
+	e.h.Enricher = ge
+
+	rec := e.post(t, "/api/ingest", token, rawEmail("<gate@x>", "Roundup", "body"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body)
+	}
+	if got := atomic.LoadInt32(&ge.pageCallsAtFirst); got != n {
+		t.Errorf("first enrichment saw %d completed page fetches, want all %d (resolution must finish first)", got, n)
 	}
 }
 


### PR DESCRIPTION
Closes #401. Follow-up to #397: explains and prevents tracker URLs surviving on large newsletters even with a working resolver.

## Problem

`resolveBudget` (15s + 5s/deal, **capped at 45s** — reached at six deals) is shared by one context across an email's whole batch for URL resolution, page mining, and Gemini enrichment, processed **sequentially**. On a Manning Weekly Roundup (8–15 deals), each HubSpot link costs up to the 4s fetch timeout across its interstitial chain and each deal missing a deadline adds a model call with retry backoffs — so the context expires partway through the batch. Every remaining deal's `Resolve` fails instantly with `context deadline exceeded` and its tracker URL is stored. Later-positioned deals lose systematically, and roundup items are one-shot titles, so the upsert's `COALESCE` self-heal never repairs them.

(The tracker link reported on 2026-07-30 itself predates the v85 deploy of #397 — the deployed resolver handles it, verified live — but this starvation is the mechanism that would reproduce the same symptom on future large emails.)

## Fix

Two phases under the same budget context, in `Handlers` ingest flow:

1. **Resolve all URLs concurrently** — bounded worker pool (`resolveConcurrency = 5`, plain `sync.WaitGroup` + channel semaphore, no new dependency). Same per-deal `Resolve` vs `ResolvePage` choice as before; results land in per-index slots (race-free by construction); errors are logged after the join. Each fetch is already self-capped at 4s inside the resolver, so a 15-deal batch resolves in ~3 waves instead of up to 60s serial.
2. **Mining + enrichment, sequential, unchanged logic** — `expiry.Mine`, the `OnOrAfter` gate, and `enrichFromPage` run exactly as before on whatever budget remains. Budget exhaustion now costs only the optional deadline/price fill, never a URL.

`resolveBudget` formula is unchanged.

## Verification

- `go vet ./... && go test -race ./...` green (the concurrent writes run under the race detector).
- `TestIngestResolvesLargeBatchConcurrently`: ten deals on a 200ms-per-call resolver — every deal, including the last, stores its resolved URL, and the request finishes well under the 2s sequential floor.
- `TestIngestEnrichmentRunsAfterAllURLsResolved`: the first enrichment call observes all page fetches already completed, locking the phase ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Deal URL resolution now runs concurrently, reducing processing time for large batches.
  * Resolution concurrency is capped to maintain reliable system performance.

* **Reliability**
  * Page enrichment now begins only after all deal URLs have been resolved, improving consistency and preventing incomplete processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->