### PR TITLE
Condense each Slack digest to per-source essentials

### DIFF
--- a/apps/api/internal/digest/blocks.go
+++ b/apps/api/internal/digest/blocks.go
@@ -87,6 +87,47 @@ func headerText(n int) string {
 	return fmt.Sprintf("%d new deals", n)
 }
 
+// buildCondensedBlocks renders condensed groups: one section per source with a
+// bold source name and minimal linked bullets. Each bullet's link comes from
+// the stored deal its DealID cites (see Condenser); the header counts bullets,
+// not consumed deals. overflow notes deals beyond MaxDealsPerDigest that stay
+// queued, same as BuildBlocks.
+func buildCondensedBlocks(groups []CondensedGroup, queued []store.Deal, overflow int) ([]byte, error) {
+	urlByID := make(map[int64]string, len(queued))
+	for _, d := range queued {
+		urlByID[d.ID] = d.URL
+	}
+
+	blocks := []any{
+		headerBlock{Type: "header", Text: textObject{Type: "plain_text", Text: headerText(countBullets(groups))}},
+	}
+	for _, g := range groups {
+		var lines []string
+		if g.Source != "" {
+			lines = append(lines, "*"+escapeMrkdwn(g.Source)+"*")
+		}
+		for _, b := range g.Bullets {
+			text := escapeMrkdwn(b.Text)
+			if u := urlByID[b.DealID]; u != "" {
+				lines = append(lines, fmt.Sprintf("• <%s|%s>", escapeLinkURL(stripQueryParams(u)), text))
+			} else {
+				lines = append(lines, "• "+text)
+			}
+		}
+		blocks = append(blocks,
+			sectionBlock{Type: "section", Text: textObject{Type: "mrkdwn", Text: strings.Join(lines, "\n")}},
+			dividerBlock{Type: "divider"},
+		)
+	}
+	if overflow > 0 {
+		blocks = append(blocks, contextBlock{
+			Type:     "context",
+			Elements: []textObject{{Type: "mrkdwn", Text: fmt.Sprintf("+ %d more — they'll stay queued for the next digest", overflow)}},
+		})
+	}
+	return json.MarshalIndent(payload{Blocks: blocks}, "", "  ")
+}
+
 // dealText renders one deal as Slack mrkdwn: a bold linked title, a middot-joined
 // meta line (price · ends <date> · source), and an italic description. Empty
 // fields are omitted, as is a deadline already before now (see BuildBlocks).

--- a/apps/api/internal/digest/condense.go
+++ b/apps/api/internal/digest/condense.go
@@ -65,20 +65,26 @@ func condenseDeals(ctx context.Context, s *store.Store, c Condenser, queued []st
 }
 
 // sanitizeGroups enforces the Condenser contract on model output: bullets must
-// cite a queued deal and carry text. Offending bullets are dropped, as are
-// groups left empty.
+// cite a queued deal, carry text, and not repeat an (id, text) pair already
+// emitted. Offending bullets are dropped, as are groups left empty. A repeated
+// id with *different* text is allowed — several facets of one promotion can
+// legitimately share the umbrella deal's link.
 func sanitizeGroups(groups []CondensedGroup, queued []store.Deal) []CondensedGroup {
 	known := make(map[int64]bool, len(queued))
 	for _, d := range queued {
 		known[d.ID] = true
 	}
+	seen := make(map[Bullet]bool)
 	var out []CondensedGroup
 	for _, g := range groups {
 		var bullets []Bullet
 		for _, b := range g.Bullets {
-			if known[b.DealID] && strings.TrimSpace(b.Text) != "" {
-				bullets = append(bullets, b)
+			b.Text = strings.TrimSpace(b.Text)
+			if !known[b.DealID] || b.Text == "" || seen[b] {
+				continue
 			}
+			seen[b] = true
+			bullets = append(bullets, b)
 		}
 		if len(bullets) > 0 {
 			out = append(out, CondensedGroup{Source: g.Source, Bullets: bullets})

--- a/apps/api/internal/digest/condense.go
+++ b/apps/api/internal/digest/condense.go
@@ -1,0 +1,97 @@
+package digest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
+)
+
+const (
+	// suppressionWindow is how far back already-posted deals are shown to the
+	// condenser as "already announced", so an ongoing promotion re-extracted
+	// from a later email under new wording is not re-posted.
+	suppressionWindow = 7 * 24 * time.Hour
+
+	// maxRecentForCondense caps the already-announced list fed to the model;
+	// a week of digests fits comfortably, and the prompt stays bounded.
+	maxRecentForCondense = 25
+
+	// condenseTimeout bounds the model call. Past it the digest posts in the
+	// uncondensed format rather than stall the posting path.
+	condenseTimeout = 20 * time.Second
+)
+
+// Bullet is one line of a condensed digest. DealID cites the queued deal the
+// line is about — that deal's stored URL becomes the link — and Text is the
+// short offer description ("50% off all books").
+type Bullet struct {
+	DealID int64
+	Text   string
+}
+
+// CondensedGroup is one source's bullets.
+type CondensedGroup struct {
+	Source  string
+	Bullets []Bullet
+}
+
+// Condenser condenses a batch of queued deals into per-source essentials:
+// equivalent rewordings merge into one bullet, products merely carrying an
+// umbrella discount drop, and offers equivalent to something in recent
+// (already announced) are omitted entirely. Implementations must cite only
+// deal ids from queued and must not invent prices or dates; Run drops any
+// bullet citing an unknown id.
+type Condenser interface {
+	Condense(ctx context.Context, queued, recent []store.Deal) ([]CondensedGroup, error)
+}
+
+// condenseDeals loads the recently-announced context and runs the condenser
+// over the queued deals, returning sanitized groups.
+func condenseDeals(ctx context.Context, s *store.Store, c Condenser, queued []store.Deal) ([]CondensedGroup, error) {
+	cctx, cancel := context.WithTimeout(ctx, condenseTimeout)
+	defer cancel()
+	recent, err := s.RecentlyPostedDeals(cctx, s.Now().Add(-suppressionWindow), maxRecentForCondense)
+	if err != nil {
+		return nil, fmt.Errorf("load recent deals: %w", err)
+	}
+	groups, err := c.Condense(cctx, queued, recent)
+	if err != nil {
+		return nil, fmt.Errorf("condense: %w", err)
+	}
+	return sanitizeGroups(groups, queued), nil
+}
+
+// sanitizeGroups enforces the Condenser contract on model output: bullets must
+// cite a queued deal and carry text. Offending bullets are dropped, as are
+// groups left empty.
+func sanitizeGroups(groups []CondensedGroup, queued []store.Deal) []CondensedGroup {
+	known := make(map[int64]bool, len(queued))
+	for _, d := range queued {
+		known[d.ID] = true
+	}
+	var out []CondensedGroup
+	for _, g := range groups {
+		var bullets []Bullet
+		for _, b := range g.Bullets {
+			if known[b.DealID] && strings.TrimSpace(b.Text) != "" {
+				bullets = append(bullets, b)
+			}
+		}
+		if len(bullets) > 0 {
+			out = append(out, CondensedGroup{Source: g.Source, Bullets: bullets})
+		}
+	}
+	return out
+}
+
+// countBullets returns the total bullets across groups.
+func countBullets(groups []CondensedGroup) int {
+	n := 0
+	for _, g := range groups {
+		n += len(g.Bullets)
+	}
+	return n
+}

--- a/apps/api/internal/digest/run.go
+++ b/apps/api/internal/digest/run.go
@@ -17,11 +17,20 @@ import (
 // and the digest row are marked posted; on a failed post the digest is marked
 // failed and the deals stay queued for a later attempt (the error is returned).
 //
+// With a non-nil condenser the shown deals are condensed to per-source
+// essentials first. Condensation is strictly best-effort: on any condenser
+// failure the digest posts in the plain per-deal format and Run reports the
+// condense error alongside posted=true so the caller can log it. When the
+// condenser finds nothing new to say (every queued offer is equivalent to one
+// already announced), nothing posts to Slack, but the deals are still marked
+// posted so they stop re-queueing — the digest row then records a postless
+// cycle, and Run returns posted=false.
+//
 // Residual limitation: if the Slack post succeeds but marking the digest posted
 // fails every retry, Run returns (true, err) with the row still "claimed". Once
 // staleWindow elapses a later run can re-post the same deals (a duplicate, never
 // a loss). The retry below shrinks that window to a transient-DB-error edge case.
-func Run(ctx context.Context, s *store.Store, poster WebhookPoster, interval, staleWindow time.Duration, force bool) (posted bool, err error) {
+func Run(ctx context.Context, s *store.Store, poster WebhookPoster, interval, staleWindow time.Duration, force bool, condenser Condenser) (posted bool, err error) {
 	digestID, ok, err := s.ClaimDigest(ctx, interval, staleWindow, force)
 	if err != nil {
 		return false, fmt.Errorf("claim digest: %w", err)
@@ -44,36 +53,59 @@ func Run(ctx context.Context, s *store.Store, poster WebhookPoster, interval, st
 		return false, nil
 	}
 
-	body, err := BuildBlocks(deals, s.Now())
-	if err != nil {
-		_ = s.DeleteDigest(ctx, digestID)
-		return false, fmt.Errorf("build blocks: %w", err)
-	}
-
-	if err := poster.Post(ctx, body); err != nil {
-		if ferr := s.MarkDigestFailed(ctx, digestID); ferr != nil {
-			return false, fmt.Errorf("post failed (%v) and mark failed: %w", err, ferr)
-		}
-		return false, fmt.Errorf("post digest: %w", err)
-	}
-
 	shown := deals
 	if len(shown) > MaxDealsPerDigest {
 		shown = shown[:MaxDealsPerDigest]
 	}
+
+	var body []byte
+	var condenseErr error
+	allSuppressed := false
+	if condenser != nil {
+		groups, cerr := condenseDeals(ctx, s, condenser, shown)
+		switch {
+		case cerr != nil:
+			condenseErr = cerr // post uncondensed; surfaced to the caller for logging
+		case countBullets(groups) == 0:
+			allSuppressed = true
+		default:
+			if body, cerr = buildCondensedBlocks(groups, shown, len(deals)-len(shown)); cerr != nil {
+				body, condenseErr = nil, cerr
+			}
+		}
+	}
+	if body == nil && !allSuppressed {
+		body, err = BuildBlocks(deals, s.Now())
+		if err != nil {
+			_ = s.DeleteDigest(ctx, digestID)
+			return false, fmt.Errorf("build blocks: %w", err)
+		}
+	}
+
+	if !allSuppressed {
+		if err := poster.Post(ctx, body); err != nil {
+			if ferr := s.MarkDigestFailed(ctx, digestID); ferr != nil {
+				return false, fmt.Errorf("post failed (%v) and mark failed: %w", err, ferr)
+			}
+			return false, fmt.Errorf("post digest: %w", err)
+		}
+	}
+
 	ids := make([]int64, len(shown))
 	for i, d := range shown {
 		ids[i] = d.ID
 	}
 	// The post already succeeded, so retry the bookkeeping write a few times
 	// before giving up — a transient DB blip here would otherwise risk a
-	// duplicate digest on the next run (see the doc comment).
+	// duplicate digest on the next run (see the doc comment). An all-suppressed
+	// cycle books the same way: the deals are consumed even though nothing was
+	// sent.
 	const markAttempts = 3
 	for attempt := 1; ; attempt++ {
 		if err := s.MarkDigestPosted(ctx, digestID, ids); err == nil {
-			return true, nil
+			return !allSuppressed, condenseErr
 		} else if attempt == markAttempts {
-			return true, fmt.Errorf("posted to slack but failed to mark digest posted after %d attempts: %w", markAttempts, err)
+			return !allSuppressed, fmt.Errorf("posted to slack but failed to mark digest posted after %d attempts: %w", markAttempts, err)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/apps/api/internal/digest/run_test.go
+++ b/apps/api/internal/digest/run_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -87,7 +88,7 @@ func TestRunHappyPath(t *testing.T) {
 	addDeals(t, s, id, 2)
 	fp := &fakePoster{}
 
-	posted, err := Run(ctx, s, fp, interval, stale, false)
+	posted, err := Run(ctx, s, fp, interval, stale, false, nil)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -108,7 +109,7 @@ func TestRunPostFailureKeepsDealsQueued(t *testing.T) {
 	addDeals(t, s, id, 2)
 	fp := &fakePoster{err: errors.New("slack down")}
 
-	posted, err := Run(ctx, s, fp, interval, stale, false)
+	posted, err := Run(ctx, s, fp, interval, stale, false, nil)
 	if err == nil {
 		t.Fatal("expected error on post failure")
 	}
@@ -120,7 +121,7 @@ func TestRunPostFailureKeepsDealsQueued(t *testing.T) {
 	}
 	// A failed digest must not suppress the next attempt.
 	fp2 := &fakePoster{}
-	posted, err = Run(ctx, s, fp2, interval, stale, false)
+	posted, err = Run(ctx, s, fp2, interval, stale, false, nil)
 	if err != nil || !posted {
 		t.Fatalf("retry after failure: posted=%v err=%v", posted, err)
 	}
@@ -130,7 +131,7 @@ func TestRunEmptyReleasesClaim(t *testing.T) {
 	s := newStore(t)
 	fp := &fakePoster{}
 
-	posted, err := Run(ctx, s, fp, interval, stale, false)
+	posted, err := Run(ctx, s, fp, interval, stale, false, nil)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -152,7 +153,7 @@ func TestRunOverflowMarksOnlyShown(t *testing.T) {
 	addDeals(t, s, id, MaxDealsPerDigest+1)
 	fp := &fakePoster{}
 
-	posted, err := Run(ctx, s, fp, interval, stale, false)
+	posted, err := Run(ctx, s, fp, interval, stale, false, nil)
 	if err != nil || !posted {
 		t.Fatalf("Run: posted=%v err=%v", posted, err)
 	}
@@ -168,7 +169,7 @@ func TestRunSuppressedThenForce(t *testing.T) {
 	addDeals(t, s, id, 2)
 	fp := &fakePoster{}
 
-	if posted, err := Run(ctx, s, fp, interval, stale, false); err != nil || !posted {
+	if posted, err := Run(ctx, s, fp, interval, stale, false, nil); err != nil || !posted {
 		t.Fatalf("first run: posted=%v err=%v", posted, err)
 	}
 
@@ -176,18 +177,163 @@ func TestRunSuppressedThenForce(t *testing.T) {
 	addDeal(t, s, id, "Latecomer")
 
 	// Non-force is suppressed (a digest was posted < interval ago).
-	if posted, _ := Run(ctx, s, fp, interval, stale, false); posted {
+	if posted, _ := Run(ctx, s, fp, interval, stale, false, nil); posted {
 		t.Fatal("expected suppression within interval")
 	}
 	if fp.count() != 1 {
 		t.Fatalf("poster called %d times, want 1", fp.count())
 	}
 	// Force posts the new deal despite the interval.
-	if posted, err := Run(ctx, s, fp, interval, stale, true); err != nil || !posted {
+	if posted, err := Run(ctx, s, fp, interval, stale, true, nil); err != nil || !posted {
 		t.Fatalf("force run: posted=%v err=%v", posted, err)
 	}
 	if fp.count() != 2 {
 		t.Errorf("poster called %d times after force, want 2", fp.count())
+	}
+}
+
+// fakeCondenser returns canned groups (or an error), and records what it saw.
+type fakeCondenser struct {
+	mu     sync.Mutex
+	groups []CondensedGroup
+	err    error
+	queued []store.Deal
+	recent []store.Deal
+	calls  int
+}
+
+func (f *fakeCondenser) Condense(_ context.Context, queued, recent []store.Deal) ([]CondensedGroup, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.queued = queued
+	f.recent = recent
+	return f.groups, f.err
+}
+
+func TestRunCondensedDigest(t *testing.T) {
+	// With a condenser, the digest posts per-source bullets: bold source name,
+	// "• <url|text>" lines linked via the cited deal's stored URL, and all
+	// queued deals — including ones condensed away — marked posted.
+	s := newStore(t)
+	id := seedEmail(t, s, "<cd@x>")
+	addDeals(t, s, id, 4)
+	queued, _ := s.UnpostedDeals(ctx, 0)
+	fp := &fakePoster{}
+	fc := &fakeCondenser{groups: []CondensedGroup{{
+		Source: "Humble",
+		Bullets: []Bullet{
+			{DealID: queued[0].ID, Text: "50% off all books"},
+			{DealID: queued[3].ID, Text: "Free webinar: The Rust Journey"},
+		},
+	}}}
+
+	posted, err := Run(ctx, s, fp, interval, stale, false, fc)
+	if err != nil || !posted {
+		t.Fatalf("Run: posted=%v err=%v", posted, err)
+	}
+	if fp.count() != 1 {
+		t.Fatalf("poster called %d times, want 1", fp.count())
+	}
+	got := string(fp.payloads[0])
+	for _, want := range []string{
+		"2 new deals", // header counts bullets, not consumed deals
+		"*Humble*",
+		"• ",
+		// The bullet links deal 0's stored URL (its "|" percent-encoded for
+		// Slack link syntax) with the condensed text as the label.
+		"https://h/humblebundle.com%7Cdeal0|50% off all books",
+		"Free webinar: The Rust Journey",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("payload missing %q:\n%s", want, got)
+		}
+	}
+	if left, _ := s.UnpostedDeals(ctx, 0); len(left) != 0 {
+		t.Errorf("%d deals still unposted — condensed-away deals must be consumed", len(left))
+	}
+}
+
+func TestRunCondenserSeesRecentDeals(t *testing.T) {
+	// The condenser gets recently-posted deals as already-announced context.
+	s := newStore(t)
+	id := seedEmail(t, s, "<cr@x>")
+	addDeals(t, s, id, 1)
+	fp := &fakePoster{}
+	if posted, err := Run(ctx, s, fp, interval, stale, false, nil); err != nil || !posted {
+		t.Fatalf("seed run: posted=%v err=%v", posted, err)
+	}
+
+	addDeal(t, s, id, "Latecomer")
+	fc := &fakeCondenser{} // no groups: everything suppressed
+	posted, err := Run(ctx, s, fp, interval, stale, true, fc)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if posted {
+		t.Fatal("expected posted=false when the condenser returns no bullets")
+	}
+	if fp.count() != 1 {
+		t.Fatalf("poster called %d times, want 1 (suppressed cycle must not post)", fp.count())
+	}
+	if len(fc.recent) != 1 || fc.recent[0].Title != "Deal0" {
+		t.Errorf("condenser recent = %+v, want the previously posted Deal0", fc.recent)
+	}
+	if len(fc.queued) != 1 || fc.queued[0].Title != "Latecomer" {
+		t.Errorf("condenser queued = %+v, want just Latecomer", fc.queued)
+	}
+	// The suppressed deal is consumed: nothing left to re-announce.
+	if left, _ := s.UnpostedDeals(ctx, 0); len(left) != 0 {
+		t.Errorf("%d deals still unposted after suppressed cycle", len(left))
+	}
+}
+
+func TestRunCondenserErrorFallsBack(t *testing.T) {
+	// A condenser failure must not lose the digest: the plain format posts and
+	// the error is surfaced alongside posted=true for logging.
+	s := newStore(t)
+	id := seedEmail(t, s, "<ce@x>")
+	addDeals(t, s, id, 2)
+	fp := &fakePoster{}
+	fc := &fakeCondenser{err: errors.New("model down")}
+
+	posted, err := Run(ctx, s, fp, interval, stale, false, fc)
+	if !posted {
+		t.Fatal("expected posted=true via fallback")
+	}
+	if err == nil || !strings.Contains(err.Error(), "model down") {
+		t.Errorf("err = %v, want the condense failure surfaced", err)
+	}
+	if fp.count() != 1 {
+		t.Fatalf("poster called %d times, want 1", fp.count())
+	}
+	if got := string(fp.payloads[0]); !strings.Contains(got, "2 new deals") || strings.Contains(got, "• ") {
+		t.Errorf("fallback payload should be the plain per-deal format:\n%s", got)
+	}
+}
+
+func TestRunCondenserUnknownIDDropped(t *testing.T) {
+	// Bullets citing ids outside the queued set are the model inventing —
+	// dropped; a group left empty disappears. Here that empties everything, so
+	// nothing posts.
+	s := newStore(t)
+	id := seedEmail(t, s, "<cu@x>")
+	addDeals(t, s, id, 1)
+	fp := &fakePoster{}
+	fc := &fakeCondenser{groups: []CondensedGroup{{
+		Source:  "Humble",
+		Bullets: []Bullet{{DealID: 99999, Text: "invented offer"}, {DealID: 0, Text: "   "}},
+	}}}
+
+	posted, err := Run(ctx, s, fp, interval, stale, false, fc)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if posted || fp.count() != 0 {
+		t.Fatalf("posted=%v count=%d, want no post when every bullet is invalid", posted, fp.count())
+	}
+	if left, _ := s.UnpostedDeals(ctx, 0); len(left) != 0 {
+		t.Errorf("%d deals still unposted", len(left))
 	}
 }
 
@@ -203,7 +349,7 @@ func TestRunConcurrentSingleWinner(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			posted, err := Run(ctx, s, fp, interval, stale, false)
+			posted, err := Run(ctx, s, fp, interval, stale, false, nil)
 			if err != nil {
 				t.Errorf("Run: %v", err)
 			}

--- a/apps/api/internal/digest/run_test.go
+++ b/apps/api/internal/digest/run_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -309,6 +310,29 @@ func TestRunCondenserErrorFallsBack(t *testing.T) {
 	}
 	if got := string(fp.payloads[0]); !strings.Contains(got, "2 new deals") || strings.Contains(got, "• ") {
 		t.Errorf("fallback payload should be the plain per-deal format:\n%s", got)
+	}
+}
+
+func TestSanitizeGroupsDropsRepeats(t *testing.T) {
+	queued := []store.Deal{{ID: 1}, {ID: 2}}
+	got := sanitizeGroups([]CondensedGroup{
+		{Source: "A", Bullets: []Bullet{
+			{DealID: 1, Text: "50% off all books"},
+			{DealID: 1, Text: "50% off all books"}, // exact repeat: dropped
+			{DealID: 1, Text: "liveProjects $10"},  // same id, new text: kept (facets share the umbrella link)
+			{DealID: 2, Text: "  Free webinar  "},  // kept, trimmed
+		}},
+		// Cross-group repeat of the trimmed (id, text) pair: dropped, emptying
+		// the group.
+		{Source: "B", Bullets: []Bullet{{DealID: 2, Text: "Free webinar"}}},
+	}, queued)
+	want := []CondensedGroup{{Source: "A", Bullets: []Bullet{
+		{DealID: 1, Text: "50% off all books"},
+		{DealID: 1, Text: "liveProjects $10"},
+		{DealID: 2, Text: "Free webinar"},
+	}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sanitizeGroups = %+v, want %+v", got, want)
 	}
 }
 

--- a/apps/api/internal/extract/gemini.go
+++ b/apps/api/internal/extract/gemini.go
@@ -12,7 +12,9 @@ import (
 
 	"google.golang.org/genai"
 
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/digest"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/mailparse"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
 )
 
 // maxPromptChars caps the email body sent to Gemini. Deals live at the top of
@@ -24,11 +26,21 @@ A deal is a discounted or time-limited offer whose subject is software or softwa
 Include an offer only when it is about software or software development. Exclude everything else, even when discounted: video games and game bundles, comics, art or asset bundles, tabletop/RPG material, and books or courses on non-technical topics.
 For a bundle that mixes software titles with unrelated ones, include it only if it is primarily about software.
 Return one entry per bundle or offer — never one entry per item inside a bundle.
-When one promotion spans several product categories or tiers — a sitewide or storewide sale covering books, subscriptions, and other products — return a single entry describing the whole promotion, not one entry per category or tier. Still return a separate entry for each individually featured product, such as a specific book on sale, even when the same promotion also covers it. Never return an entry whose offer merely restates a piece of another entry's broader promotion.
+When one promotion spans several product categories or tiers — a sitewide or storewide sale covering books, subscriptions, and other products — return a single entry describing the whole promotion, not one entry per category or tier. Do not return a separate entry for a product whose only offer is that broader promotion's discount applied to it (a featured book at the sale's own percentage); a product gets its own entry only when its offer is genuinely distinct, such as a free item, a deeper discount, or a price the promotion does not explain. Never return an entry whose offer merely restates a piece of another entry's broader promotion.
 Set url to the link printed next to that offer if one is present.
 The prompt's Date line is the day the email was sent. When a deadline omits the year, resolve it against that date so the deadline is on or after it: "ends November 27" in an email dated 2026-07-26 means 2026-11-27.
 Copy prices, promo codes, and deadlines only from the email's own text; never invent, infer, or embellish them. Leave a field null when the email does not state it.
 If the email has no software deals (receipts, shipping notices, account or security alerts, plain content newsletters, or only non-software offers), return an empty array.
+Respond only with the JSON array described by the schema.`
+
+const condenseSystemInstruction = `You condense a list of software deals into the essential offers for a Slack digest, grouped by vendor.
+The QUEUED list holds the deals to condense, one per line: id | source | title | price | ends | description. The ANNOUNCED list holds offers already posted recently.
+Merge queued entries that describe the same underlying offer into a single bullet — vendors restate one promotion under many wordings.
+Omit a product whose only offer is a broader promotion's discount applied to it (a book at 50% off during a 50%-off-everything sale); keep products with a genuinely distinct offer, such as a free item, a deeper discount, or a price the promotion does not explain.
+Omit any offer equivalent to one in the ANNOUNCED list.
+Each bullet cites the id of one QUEUED deal that best represents the offer, and states the offer as a short phrase with the price folded in, e.g. "50% off all books", "liveVideos / liveProjects $10 each", "Free webinar: The Rust Journey".
+Copy prices and facts only from the lists; never invent or embellish. Cite only ids from the QUEUED list.
+Group bullets by the deals' source. Return an empty array when nothing new remains to announce.
 Respond only with the JSON array described by the schema.`
 
 const enrichSystemInstruction = `You read the text of one deal's landing page and report two facts about the current offer: when it ends and what it costs.
@@ -43,12 +55,14 @@ Respond only with the JSON object described by the schema.`
 // headroom for a higher MaxAttempts (backoff clamps to the last entry).
 var defaultRetryDelays = []time.Duration{2 * time.Second, 8 * time.Second, 20 * time.Second}
 
-// Gemini is an Extractor (and PageEnricher) backed by the Gemini API.
+// Gemini is an Extractor (plus PageEnricher and digest.Condenser) backed by
+// the Gemini API.
 type Gemini struct {
-	client       *genai.Client
-	model        string
-	genConfig    *genai.GenerateContentConfig
-	enrichConfig *genai.GenerateContentConfig
+	client         *genai.Client
+	model          string
+	genConfig      *genai.GenerateContentConfig
+	enrichConfig   *genai.GenerateContentConfig
+	condenseConfig *genai.GenerateContentConfig
 
 	// MaxAttempts is the total number of attempts (including the first) on
 	// retriable errors. RetryDelays is the base backoff before each retry.
@@ -68,12 +82,13 @@ func NewGemini(ctx context.Context, apiKey, model, baseURL string) (*Gemini, err
 		return nil, fmt.Errorf("new gemini client: %w", err)
 	}
 	return &Gemini{
-		client:       client,
-		model:        model,
-		genConfig:    dealGenConfig(),
-		enrichConfig: enrichGenConfig(),
-		MaxAttempts:  3,
-		RetryDelays:  defaultRetryDelays,
+		client:         client,
+		model:          model,
+		genConfig:      dealGenConfig(),
+		enrichConfig:   enrichGenConfig(),
+		condenseConfig: condenseGenConfig(),
+		MaxAttempts:    3,
+		RetryDelays:    defaultRetryDelays,
 	}, nil
 }
 
@@ -95,6 +110,33 @@ func dealGenConfig() *genai.GenerateContentConfig {
 					"description": {Type: genai.TypeString, Nullable: genai.Ptr(true), Description: "one short sentence"},
 				},
 				Required: []string{"source", "title"},
+			},
+		},
+	}
+}
+
+// condenseGenConfig forces a JSON response conforming to the condensed-groups
+// schema (see digest.CondensedGroup).
+func condenseGenConfig() *genai.GenerateContentConfig {
+	return &genai.GenerateContentConfig{
+		SystemInstruction: genai.NewContentFromText(condenseSystemInstruction, genai.RoleUser),
+		ResponseMIMEType:  "application/json",
+		ResponseSchema: &genai.Schema{
+			Type: genai.TypeArray,
+			Items: &genai.Schema{
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"source": {Type: genai.TypeString, Description: "vendor name shared by this group's bullets"},
+					"bullets": {Type: genai.TypeArray, Items: &genai.Schema{
+						Type: genai.TypeObject,
+						Properties: map[string]*genai.Schema{
+							"deal_id": {Type: genai.TypeInteger, Description: "id of the QUEUED deal this bullet represents"},
+							"text":    {Type: genai.TypeString, Description: `short offer phrase with the price folded in, e.g. "50% off all books"`},
+						},
+						Required: []string{"deal_id", "text"},
+					}},
+				},
+				Required: []string{"source", "bullets"},
 			},
 		},
 	}
@@ -134,6 +176,69 @@ func (g *Gemini) EnrichFromPage(ctx context.Context, title, pageText string, sen
 		return Enrichment{}, err
 	}
 	return parseEnrichment(text)
+}
+
+// Condense implements digest.Condenser: one model call over the queued deals,
+// with the recently-announced ones as suppression context, returning per-source
+// essential bullets that cite queued deal ids. Retry behavior matches Extract;
+// the caller (digest.Run) validates the cited ids and falls back to the plain
+// digest format on any error.
+func (g *Gemini) Condense(ctx context.Context, queued, recent []store.Deal) ([]digest.CondensedGroup, error) {
+	text, err := g.generateText(ctx, buildCondensePrompt(queued, recent), g.condenseConfig)
+	if err != nil {
+		return nil, err
+	}
+	return parseCondensed(text)
+}
+
+// buildCondensePrompt lists both deal sets in the line format the condense
+// instruction documents. Newlines inside fields are flattened so one deal is
+// always one line.
+func buildCondensePrompt(queued, recent []store.Deal) string {
+	var b strings.Builder
+	b.WriteString("QUEUED:\n")
+	for _, d := range queued {
+		writeDealLine(&b, d)
+	}
+	b.WriteString("\nANNOUNCED:\n")
+	for _, d := range recent {
+		writeDealLine(&b, d)
+	}
+	return b.String()
+}
+
+func writeDealLine(b *strings.Builder, d store.Deal) {
+	oneLine := func(s string) string {
+		return strings.Join(strings.Fields(s), " ")
+	}
+	fmt.Fprintf(b, "%d | %s | %s | %s | %s | %s\n",
+		d.ID, oneLine(d.Source), oneLine(d.Title), oneLine(d.Price), d.EndsAt, oneLine(d.Description))
+}
+
+func parseCondensed(text string) ([]digest.CondensedGroup, error) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil, nil
+	}
+	var wire []struct {
+		Source  string `json:"source"`
+		Bullets []struct {
+			DealID int64  `json:"deal_id"`
+			Text   string `json:"text"`
+		} `json:"bullets"`
+	}
+	if err := json.Unmarshal([]byte(text), &wire); err != nil {
+		return nil, fmt.Errorf("parse condensed json: %w", err)
+	}
+	groups := make([]digest.CondensedGroup, 0, len(wire))
+	for _, w := range wire {
+		g := digest.CondensedGroup{Source: w.Source}
+		for _, b := range w.Bullets {
+			g.Bullets = append(g.Bullets, digest.Bullet{DealID: b.DealID, Text: b.Text})
+		}
+		groups = append(groups, g)
+	}
+	return groups, nil
 }
 
 // generateText calls the model with retries on retriable errors (HTTP 429 /

--- a/apps/api/internal/extract/gemini_test.go
+++ b/apps/api/internal/extract/gemini_test.go
@@ -9,12 +9,15 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/digest"
 	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/mailparse"
+	"github.com/codeselfstudy/codeselfstudy/apps/api/internal/store"
 )
 
 var ctx = context.Background()
@@ -355,23 +358,86 @@ func TestSystemInstructionScopesToSoftware(t *testing.T) {
 }
 
 // TestSystemInstructionCollapsesPromotions locks the overlap rule — one
-// promotion spanning categories yields one umbrella entry, with individually
-// featured products kept separate — so the prompt can't silently regress. The
-// model-based behaviour itself is verified by
-// TestExtractLiveCollapsesPromotions.
+// promotion spanning categories yields one umbrella entry, and a product
+// merely carrying that promotion's discount gets no entry of its own — so the
+// prompt can't silently regress. The model-based behaviour itself is verified
+// by TestExtractLiveCollapsesPromotions.
 func TestSystemInstructionCollapsesPromotions(t *testing.T) {
 	lower := strings.ToLower(systemInstruction)
-	for _, want := range []string{"promotion", "category or tier", "individually featured"} {
+	for _, want := range []string{"promotion", "category or tier", "genuinely distinct"} {
 		if !strings.Contains(lower, want) {
 			t.Errorf("systemInstruction missing %q", want)
 		}
 	}
 }
 
+// TestCondenseSystemInstruction locks the condense rules — merge rewordings,
+// drop sale-priced products, suppress already-announced offers, cite only
+// given ids — so the prompt can't silently regress. The model behaviour is
+// verified by TestCondenseLive.
+func TestCondenseSystemInstruction(t *testing.T) {
+	lower := strings.ToLower(condenseSystemInstruction)
+	for _, want := range []string{"queued", "announced", "merge", "cite only ids", "never invent"} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("condenseSystemInstruction missing %q", want)
+		}
+	}
+}
+
+func TestBuildCondensePrompt(t *testing.T) {
+	queued := []store.Deal{{ID: 7, Source: "Manning", Title: "Sale A", Price: "50% off", EndsAt: "2026-07-31", Description: "line one\nline two"}}
+	recent := []store.Deal{{ID: 3, Source: "Manning", Title: "Old Sale"}}
+	got := buildCondensePrompt(queued, recent)
+	for _, want := range []string{
+		"QUEUED:\n7 | Manning | Sale A | 50% off | 2026-07-31 | line one line two\n",
+		"ANNOUNCED:\n3 | Manning | Old Sale |  |  | \n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestCondenseParsesResponse(t *testing.T) {
+	g := newTestGemini(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(geminiEnvelope(`[{"source":"Manning","bullets":[{"deal_id":7,"text":"50% off all books"},{"deal_id":9,"text":"Free webinar: The Rust Journey"}]}]`))
+	})
+	groups, err := g.Condense(ctx, []store.Deal{{ID: 7}, {ID: 9}}, nil)
+	if err != nil {
+		t.Fatalf("Condense: %v", err)
+	}
+	want := []digest.CondensedGroup{{
+		Source: "Manning",
+		Bullets: []digest.Bullet{
+			{DealID: 7, Text: "50% off all books"},
+			{DealID: 9, Text: "Free webinar: The Rust Journey"},
+		},
+	}}
+	if !reflect.DeepEqual(groups, want) {
+		t.Errorf("Condense = %+v, want %+v", groups, want)
+	}
+}
+
+func TestCondenseMalformedJSONNotRetried(t *testing.T) {
+	var calls int32
+	g := newTestGemini(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Write(geminiEnvelope("not json"))
+	})
+	if _, err := g.Condense(ctx, []store.Deal{{ID: 1}}, nil); err == nil {
+		t.Fatal("expected parse error")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("made %d calls, want 1 (no retry on parse error)", got)
+	}
+}
+
 // TestExtractLiveCollapsesPromotions hits the real Gemini API; run with
 // GEMINI_LIVE_TEST=1 and a key. A Manning-shaped email — one sitewide sale
-// restated per category plus one individually featured book — must collapse to
-// exactly two deals: the umbrella promotion and the book.
+// restated per category, a book merely at the sale's own discount, and one
+// genuinely distinct free webinar — must collapse to exactly two deals: the
+// umbrella promotion and the webinar. The sale-priced book must NOT get its
+// own entry.
 func TestExtractLiveCollapsesPromotions(t *testing.T) {
 	if os.Getenv("GEMINI_LIVE_TEST") != "1" {
 		t.Skip("set GEMINI_LIVE_TEST=1 and GEMINI_API_KEY to run")
@@ -383,12 +449,11 @@ func TestExtractLiveCollapsesPromotions(t *testing.T) {
 
 	email := mailparse.Email{
 		From:    "Manning Publications <promo@manning.com>",
-		Subject: "Deal of the Day: Lean Software Engineering",
-		Text: `Deal of the Day: Lean Software Engineering — half off today. https://www.manning.com/books/lean-software-engineering
-Our summer sale is on: save half sitewide on all Manning books, get any liveProject or liveVideo for $10, or a year of Manning Online Pro for $199.99. Sale ends July 31. https://www.manning.com/sale
+		Subject: "Save half sitewide + a free Rust webinar",
+		Text: `Our summer sale is on: save half sitewide on all Manning books, get any liveProject or liveVideo for $10, or a year of Manning Online Pro for $199.99. Sale ends July 31. https://www.manning.com/sale
 All liveProjects and liveVideos $10! https://www.manning.com/liveprojects
-liveProjects and liveVideos bestsellers, $10 each. https://www.manning.com/livevideos
-Manning Online Pro annual subscription $199.99 (save $50). https://www.manning.com/pro`,
+Featured today at 50% off: Build a Reasoning Model (From Scratch), $23.99 for eBook. https://www.manning.com/books/build-a-reasoning-model-from-scratch
+Free live webinar: The Rust Journey — Exploring Safe Systems Programming. https://www.manning.com/webinars/rust-journey`,
 	}
 
 	deals, err := g.Extract(ctx, email)
@@ -397,15 +462,81 @@ Manning Online Pro annual subscription $199.99 (save $50). https://www.manning.c
 	}
 	t.Logf("got %d deals: %+v", len(deals), deals)
 	if len(deals) != 2 {
-		t.Errorf("expected exactly 2 deals (umbrella sale + featured book), got %d", len(deals))
+		t.Errorf("expected exactly 2 deals (umbrella sale + free webinar), got %d", len(deals))
 	}
-	books := 0
 	for _, d := range deals {
-		if strings.Contains(strings.ToLower(d.Title), "lean") {
-			books++
+		if strings.Contains(strings.ToLower(d.Title), "reasoning") {
+			t.Errorf("sale-priced book got its own entry: %+v", d)
 		}
 	}
-	if books != 1 {
-		t.Errorf("expected exactly one entry for the featured book, got %d", books)
+	webinars := 0
+	for _, d := range deals {
+		if strings.Contains(strings.ToLower(d.Title), "rust") {
+			webinars++
+		}
+	}
+	if webinars != 1 {
+		t.Errorf("expected exactly one entry for the free webinar, got %d", webinars)
+	}
+}
+
+// TestCondenseLive hits the real Gemini API; run with GEMINI_LIVE_TEST=1 and a
+// key. A screenshot-shaped queue — one sale under four wordings, one $10 promo
+// under three, sale-priced books, and one free webinar — must condense to a
+// handful of Manning bullets citing only queued ids, with no bullet for the
+// sale-priced books.
+func TestCondenseLive(t *testing.T) {
+	if os.Getenv("GEMINI_LIVE_TEST") != "1" {
+		t.Skip("set GEMINI_LIVE_TEST=1 and GEMINI_API_KEY to run")
+	}
+	g, err := NewGemini(ctx, os.Getenv("GEMINI_API_KEY"), "gemini-3.5-flash-lite", "")
+	if err != nil {
+		t.Fatalf("NewGemini: %v", err)
+	}
+
+	src := "Manning Publications"
+	queued := []store.Deal{
+		{ID: 1, Source: src, Title: "Manning Pro Annual Subscription", Price: "$199.99 (was $249.99)", EndsAt: "2026-07-31"},
+		{ID: 2, Source: src, Title: "All books (including MEAP)", Price: "50% off", EndsAt: "2026-07-31"},
+		{ID: 3, Source: src, Title: "All liveVideos and liveProjects", Price: "$10 each", EndsAt: "2026-07-31"},
+		{ID: 4, Source: src, Title: "Books and MEAP Sale", Price: "50% off", EndsAt: "2026-07-31"},
+		{ID: 5, Source: src, Title: "liveVideos and liveProjects", Price: "$10 each", EndsAt: "2026-07-31"},
+		{ID: 6, Source: src, Title: "Architecting for Autonomy", Price: "$27.99 (eBook, 50% off)", EndsAt: "2026-07-31"},
+		{ID: 7, Source: src, Title: "The Rust Journey – Exploring Safe Systems Programming", Price: "Free", EndsAt: "2026-07-31", Description: "Free live webinar exploring Rust and safe systems programming."},
+		{ID: 8, Source: src, Title: "Manning Storewide Book Sale", Price: "50% off", EndsAt: "2026-07-31"},
+		{ID: 9, Source: src, Title: "Manning liveVideos and liveProjects", Price: "$10 each", EndsAt: "2026-07-31"},
+		{ID: 10, Source: src, Title: "Summer Sale Sitewide Book Discount", Price: "50% off", EndsAt: "2026-07-31"},
+		{ID: 11, Source: src, Title: "Build a Reasoning Model (From Scratch)", Price: "$23.99 eBook (50% off)", EndsAt: "2026-07-31"},
+		{ID: 12, Source: src, Title: "AI Agents and Applications", Price: "$23.99 eBook (50% off)", EndsAt: "2026-07-31"},
+		{ID: 13, Source: src, Title: "Build an AI Agent (From Scratch)", Price: "50% off", EndsAt: "2026-07-31"},
+	}
+
+	groups, err := g.Condense(ctx, queued, nil)
+	if err != nil {
+		t.Fatalf("Condense: %v", err)
+	}
+	t.Logf("got %+v", groups)
+	known := map[int64]bool{}
+	for _, d := range queued {
+		known[d.ID] = true
+	}
+	bullets := 0
+	sawWebinar := false
+	for _, g := range groups {
+		for _, b := range g.Bullets {
+			bullets++
+			if !known[b.DealID] {
+				t.Errorf("bullet cites unknown id %d: %+v", b.DealID, b)
+			}
+			if strings.Contains(strings.ToLower(b.Text), "rust") {
+				sawWebinar = true
+			}
+		}
+	}
+	if bullets < 2 || bullets > 5 {
+		t.Errorf("got %d bullets, want the 13 deals condensed to roughly 3-4", bullets)
+	}
+	if !sawWebinar {
+		t.Errorf("expected a bullet for the free Rust webinar")
 	}
 }

--- a/apps/api/internal/ingest/ingest.go
+++ b/apps/api/internal/ingest/ingest.go
@@ -81,6 +81,11 @@ type Handlers struct {
 	// page's text, after the page's structured data came up empty. nil skips
 	// enrichment (no API key, tests).
 	Enricher extract.PageEnricher
+
+	// Condenser, when set, condenses each digest to per-source essentials and
+	// suppresses re-announcements (see digest.Condenser). nil posts the plain
+	// per-deal digest (no API key, tests).
+	Condenser digest.Condenser
 }
 
 // New builds the ingest Handlers over an already-open store, an extractor, and a
@@ -309,7 +314,7 @@ func (h *Handlers) Ingest(c echo.Context) error {
 
 	// The email is safely ingested; a digest failure must not fail the request
 	// (the deals are queued and a later ingest retries).
-	posted, derr := digest.Run(ctx, h.store, h.poster, h.cfg.DigestInterval, store.DefaultStaleWindow, force)
+	posted, derr := digest.Run(ctx, h.store, h.poster, h.cfg.DigestInterval, store.DefaultStaleWindow, force, h.Condenser)
 	if derr != nil {
 		c.Logger().Errorf("digest run: %v", derr)
 	}
@@ -356,11 +361,15 @@ func (h *Handlers) enrichFromPage(ctx context.Context, c echo.Context, d *extrac
 
 // AdminDigest forces a digest post (skips the interval check, still race-safe).
 func (h *Handlers) AdminDigest(c echo.Context) error {
-	posted, err := digest.Run(c.Request().Context(), h.store, h.poster, h.cfg.DigestInterval, store.DefaultStaleWindow, true)
+	posted, err := digest.Run(c.Request().Context(), h.store, h.poster, h.cfg.DigestInterval, store.DefaultStaleWindow, true, h.Condenser)
 	if err != nil {
 		// Do not echo err: it can contain the Slack webhook URL (a secret).
 		c.Logger().Errorf("admin digest: %v", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "digest failed")
+		// posted=true with an error means the digest went out degraded (e.g.
+		// the condenser fell back) — that is a success for the caller.
+		if !posted {
+			return echo.NewHTTPError(http.StatusInternalServerError, "digest failed")
+		}
 	}
 	return c.JSON(http.StatusOK, map[string]bool{"posted": posted})
 }

--- a/apps/api/internal/store/store.go
+++ b/apps/api/internal/store/store.go
@@ -281,6 +281,39 @@ func (s *Store) UnpostedDeals(ctx context.Context, limit int) ([]Deal, error) {
 	return deals, rows.Err()
 }
 
+// RecentlyPostedDeals returns deals included in a digest posted after since,
+// newest digest first, capped at limit (limit <= 0 means no cap). The digest
+// condenser feeds these to the model as "already announced" so an ongoing
+// promotion re-extracted from a later email is not re-posted.
+func (s *Store) RecentlyPostedDeals(ctx context.Context, since time.Time, limit int) ([]Deal, error) {
+	query := `SELECT d.id, d.email_id, d.dedupe_key, d.source, d.title, d.url, d.price, d.ends_at,
+	                 d.description, d.first_seen_at, d.last_seen_at, d.seen_count, d.posted_in_digest_id
+	          FROM deals d
+	          JOIN digests g ON g.id = d.posted_in_digest_id
+	          WHERE g.posted_at > ?
+	          ORDER BY g.posted_at DESC, d.id`
+	args := []any{formatTime(since.UTC())}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("recently posted deals: %w", err)
+	}
+	defer rows.Close()
+
+	var deals []Deal
+	for rows.Next() {
+		d, err := scanDeal(rows)
+		if err != nil {
+			return nil, err
+		}
+		deals = append(deals, d)
+	}
+	return deals, rows.Err()
+}
+
 // GetDealByDedupeKey returns the deal with the given dedupe_key, or
 // sql.ErrNoRows if none exists.
 func (s *Store) GetDealByDedupeKey(ctx context.Context, key string) (Deal, error) {

--- a/apps/api/internal/store/store_test.go
+++ b/apps/api/internal/store/store_test.go
@@ -224,6 +224,51 @@ func isPosted(t *testing.T, s *store.Store, key string) bool {
 	return d.PostedInDigestID != nil
 }
 
+func TestRecentlyPostedDeals(t *testing.T) {
+	s := newStore(t)
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	set := fixedClock(s, t0)
+	e := mustInsertEmail(t, s, "<rp@x>")
+
+	// One deal posted at T0, one posted a week later, one never posted.
+	seedPostedDeal(t, s, set, e.ID, "Old Bundle", t0)
+	seedPostedDeal(t, s, set, e.ID, "New Bundle", t0.Add(7*24*time.Hour))
+	set(t0.Add(7*24*time.Hour + time.Hour))
+	if err := s.UpsertDeal(ctx, store.Deal{
+		EmailID: e.ID, DedupeKey: store.DedupeKey("deals@humblebundle.com", "Queued Bundle"),
+		Source: "Humble", Title: "Queued Bundle",
+	}, t0); err != nil {
+		t.Fatalf("UpsertDeal: %v", err)
+	}
+
+	// A window opening after T0 sees only the newer posted deal — never the
+	// old one or the unposted one.
+	got, err := s.RecentlyPostedDeals(ctx, t0.Add(24*time.Hour), 0)
+	if err != nil {
+		t.Fatalf("RecentlyPostedDeals: %v", err)
+	}
+	if len(got) != 1 || got[0].Title != "New Bundle" {
+		t.Fatalf("RecentlyPostedDeals = %+v, want just New Bundle", got)
+	}
+
+	// A window before T0 sees both posted deals, newest digest first, and the
+	// limit caps the result.
+	got, err = s.RecentlyPostedDeals(ctx, t0.Add(-time.Hour), 0)
+	if err != nil {
+		t.Fatalf("RecentlyPostedDeals: %v", err)
+	}
+	if len(got) != 2 || got[0].Title != "New Bundle" || got[1].Title != "Old Bundle" {
+		t.Fatalf("RecentlyPostedDeals = %+v, want New then Old", got)
+	}
+	got, err = s.RecentlyPostedDeals(ctx, t0.Add(-time.Hour), 1)
+	if err != nil {
+		t.Fatalf("RecentlyPostedDeals limit: %v", err)
+	}
+	if len(got) != 1 || got[0].Title != "New Bundle" {
+		t.Fatalf("RecentlyPostedDeals limit = %+v, want just New Bundle", got)
+	}
+}
+
 func TestUpsertDealRepostWindow(t *testing.T) {
 	s := newStore(t)
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -201,10 +201,14 @@ func newIngestFromEnv(ctx context.Context, database *sql.DB) *ingest.Handlers {
 	// (best-effort; see internal/resolve).
 	h.Resolver = resolve.New()
 	// The Gemini extractor doubles as the page-text enricher for deadlines the
-	// page's structured data doesn't state; Disabled doesn't, so enrichment
-	// stays off without an API key.
+	// page's structured data doesn't state, and as the digest condenser that
+	// collapses each digest to per-source essentials; Disabled does neither, so
+	// both stay off without an API key.
 	if en, ok := extractor.(extract.PageEnricher); ok {
 		h.Enricher = en
+	}
+	if co, ok := extractor.(digest.Condenser); ok {
+		h.Condenser = co
 	}
 	return h
 }


### PR DESCRIPTION
Closes #403. Fixes the 13-deals-that-are-really-3 digest.

## Problem

Three duplication axes fill digests with restatements: Manning re-describes one ongoing sale under new wording in every daily email (the sender+title dedupe key only collides exact strings — Humble's stable bundle titles dedupe fine, Manning's phrasing never repeats); #399's within-email rule can't see across emails; and individual books merely carrying the sitewide discount each got an entry.

## Fix

**Digest-time condenser** — the digest is the one point where every duplicate (across emails and across days) is visible together:

- `digest.Condenser` interface + `Run(..., condenser)` (nil = today's behavior). When set, one model call sees the queued deals **plus the last week's posted deals** (`store.RecentlyPostedDeals`, new) and returns per-source groups of bullets, each citing a queued deal id. Equivalent rewordings merge into one bullet, sale-priced products drop, and offers equivalent to something already announced are suppressed entirely.
- **Links are never model-generated**: a bullet's URL comes from the stored deal row its `deal_id` cites; bullets citing ids outside the queued set are dropped (`sanitizeGroups`).
- **Strictly best-effort**: condenser error/timeout (20s cap) → the plain per-deal format posts, and the error is surfaced alongside `posted=true` for the caller to log (AdminDigest now 500s only when nothing posted).
- **Condensed-away deals are still marked posted** — that is what stops tomorrow's re-announcement. A cycle whose offers were all already announced posts nothing to Slack but consumes its deals (the digest row records a postless cycle).
- Render: bold source name, minimal linked bullets ("50% off all books", "liveVideos / liveProjects $10 each", "Free webinar: The Rust Journey…"); header counts bullets.
- `extract.Gemini` implements the interface (`Condense`, new instruction + schema, same retry plumbing); wired in `main.go` via the same type-assertion pattern as the enricher, so it's on exactly when a Gemini key is.

**Extraction-side reversal** (part of #398's rule): a product whose only offer is the umbrella promotion's discount applied to it no longer gets its own entry; genuinely distinct offers (free items, deeper discounts, unique prices) still do.

## Verification

- `go vet ./... && go test -race ./...` green.
- digest: condensed render (source header, linked bullets, bullet-count header, consumed deals), recent-deals context fed to the condenser, error→fallback with the plain format, unknown-id bullets dropped, all-suppressed cycle posts nothing but consumes deals, nil condenser byte-identical behavior.
- store: `RecentlyPostedDeals` window + ordering + limit.
- extract: prompt-lock tests for both instructions; `TestCondenseParsesResponse` and malformed-JSON no-retry; live opt-in tests (`GEMINI_LIVE_TEST=1` + key, maintainer-run):

  ```
  cd apps/api && GEMINI_LIVE_TEST=1 go test ./internal/extract -run 'TestExtractLiveCollapsesPromotions|TestCondenseLive' -v
  ```

  `TestCondenseLive` feeds the exact 13-deal queue from the reported screenshot and requires 2–5 bullets, the free Rust webinar kept, and every cited id valid.

No migration (the new query uses existing columns). Takes effect after `just deploy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-powered digest condensation that groups queued deals into concise, source-based bullet lists.
  * Suppresses deals already included in recent digests to reduce repetition.
  * Preserves deal-detail links and indicates when additional deals are still queued.

* **Bug Fixes**
  * Falls back to the standard deal-by-deal digest when condensation fails, while surfacing the error.
  * Removes empty, unknown, or duplicate bullet items to prevent malformed summaries.
  * Avoids posting empty digests while still updating digest delivery tracking; admin digest requests tolerate degraded delivery without failing the response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->